### PR TITLE
Use lib.protocol recycle mechanism

### DIFF
--- a/src/apps/lwaftr/icmp.lua
+++ b/src/apps/lwaftr/icmp.lua
@@ -63,6 +63,9 @@ function new_icmpv4_packet(from_eth, to_eth, from_ip, to_ip, config)
                                          type = constants.ethertype_ipv4})
    dgram:push(ipv4_header)
    dgram:push(ethernet_header)
+   ethernet_header:free()
+   ipv4_header:free()
+   dgram:free()
    write_icmp(new_pkt, config)
 
    local ip_checksum_p = new_pkt.data + constants.ethernet_header_size + constants.ipv4_checksum
@@ -88,6 +91,9 @@ function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, config)
                                          type = constants.ethertype_ipv6})
    dgram:push(ipv6_header)
    dgram:push(ethernet_header)
+   ethernet_header:free()
+   ipv6_header:free()
+   dgram:free()
    write_icmp(new_pkt, config, ph_csum)
    return new_pkt
 end

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -158,6 +158,8 @@ function LwAftr:_add_inet_ethernet(pkt)
                                          dst = self.inet_mac,
                                          type = constants.ethertype_ipv4})
    dgram:push(ethernet_header)
+   ethernet_header:free()
+   dgram:free()
    return pkt
 end
 
@@ -185,11 +187,14 @@ function LwAftr:ipv6_encapsulate(pkt, next_hdr_type, ipv6_src, ipv6_dst,
                                  dst = ether_dst,
                                  type = constants.ethertype_ipv6})
    dgram:push(ipv6_hdr)
+   ipv6_hdr:free()
    -- The API makes setting the payload length awkward; set it manually
    -- Todo: less awkward way to write 16 bits of a number into cdata
    pkt.data[4] = bit.rshift(bit.band(payload_len, 0xff00), 8)
    pkt.data[5] = bit.band(payload_len, 0xff)
    dgram:push(eth_hdr)
+   eth_hdr:free()
+   dgram:free()
    if pkt.length <= self.ipv6_mtu then
       if debug then
          print("encapsulated packet:")
@@ -292,6 +297,7 @@ function LwAftr:decapsulate(pkt)
    local dgram = datagram:new(pkt) -- TODO: recycle this
    -- FIXME: don't hardcode the values like this
    dgram:pop_raw(constants.ethernet_header_size + constants.ipv6_header_size)
+   dgram:free()
    return pkt
 end
 
@@ -327,6 +333,8 @@ function LwAftr:from_b4(pkt)
                                                dst = self.aftr_mac_b4_side,
                                                type = constants.ethertype_ipv4})
          dgram:push(ethernet_header)
+         ethernet_header:free()
+         dgram:free()
          return self:_encapsulate_ipv4(pkt)
       else
          return self:_add_inet_ethernet(pkt)


### PR DESCRIPTION
Makes objects from lib.protocol to use their "recycle" mechanism. After using an object, call object:free() to add the object to a list of unused objects in the corresponding class. This avoids calling the code protected under the "recycle" flag in the lib.protocol classes.

More info: http://comments.gmane.org/gmane.network.snabb.devel/1009

Performance improves slightly:

```
Processed 1.0 million packets in 5.00 seconds (658850640 bytes; 1.05 Gbps)
Made 4,012 breaths: 255.00 packets per breath; 1246.29 us per breath
Rate(Mpps): 0.205
```