### PR TITLE
Iterate binding table using standard 'for' loop

### DIFF
--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -40,7 +40,8 @@ function LwAftr:binding_lookup_ipv4(ipv4_ip, port)
       print(ipv4_ip, 'port: ', port)
       lwutil.pp(self.binding_table)
    end
-   for _, bind in ipairs(self.binding_table) do
+   for i=1,#self.binding_table do
+      local bind = self.binding_table[i]
       if debug then print("CHECK", string.format("%x, %x", bind[2], ipv4_ip)) end
       if bind[2] == ipv4_ip then
          if port >= bind[3] and port <= bind[4] then


### PR DESCRIPTION
After the use of recycle the only interpreted code reported by LuaJIT's profiler is on lwaftr.lua:

* -jp=vF (per VM states and files).

```
35%  Interpreted
  -- 48%  lwaftr.lua:method
  -- 24%  lwaftr.lua:binding_lookup_ipv4_from_pkt
  -- 22%  lwaftr.lua:_encapsulate_ipv4
```

* -jp=Fl (per file and line)

```
32%  lwaftr.lua:binding_lookup_ipv4_from_pkt
  -- 36%  lwaftr.lua:63
  -- 33%  lwaftr.lua:67
  -- 15%  lwaftr.lua:68
  --  8%  lwaftr.lua:65
  --  4%  lwaftr.lua:43
31%  lwaftr.lua:method
  -- 49%  lwaftr.lua:362
  -- 22%  lwaftr.lua:366
  -- 11%  lwaftr.lua:367
  --  6%  lwaftr.lua:358
  --  4%  lwaftr.lua:379
  --  3%  lwaftr.lua:363
  --  3%  lwaftr.lua:374
19%  lwaftr.lua:_encapsulate_ipv4
  -- 28%  lwaftr.lua:262
  -- 26%  lwaftr.lua:263
  --  7%  lwaftr.lua:278
  --  6%  lwaftr.lua:242
  --  5%  lwaftr.lua:190
  --  5%  lwaftr.lua:276
  --  4%  lwaftr.lua:265
  --  3%  lwaftr.lua:290
```

Entry ```-- 4%  lwaftr.lua:43``` corresponds to a loop in ```binding_lookup_ipv4_from_pkt```. Iterating the binding table with a standard for loop instead of ```ipairs``` makes LuaJIT happy and after the patch all interpreted code is gone.

```
99%  Compiled
  -- 12%  class.lua:free
  -- 12%  packet.lua:clone
  -- 10%  packet.lua:prepend
  --  7%  class.lua:new
  --  6%  packet.lua:shiftleft
  --  5%  datagram.lua:push
  --  5%  link.lua:receive
  --  4%  basic_apps.lua:method
  --  3%  lwaftr.lua:binding_lookup_ipv4_from_pkt
```

Performance improves significantly:

```
Processed 10.9 million packets in 5.00 seconds (7016299500 bytes; 11.23 Gbps)
Made 42,725 breaths: 255.00 packets per breath; 117.03 us per breath
Rate(Mpps): 2.179
```

I run the ```end-to-end.sh``` tests. All tests passed.