### PR TITLE
Reuse datagram and more

### DIFF
--- a/src/apps/lwaftr/fragment.lua
+++ b/src/apps/lwaftr/fragment.lua
@@ -19,6 +19,8 @@ local ipv6_payload_len = constants.ethernet_header_size + constants.ipv6_payload
 local frag_id_start = constants.ethernet_header_size + constants.ipv6_fixed_header_size + constants.ipv6_frag_id
 local ipv6_frag_offset_offset = constants.ethernet_header_size + constants.ipv6_fixed_header_size + constants.ipv6_frag_offset
 
+local dgram = datagram:new()
+
 local function compare_fragment_offsets(pkt1, pkt2)
    return pkt1.data[ipv6_frag_offset_offset] < pkt2.data[ipv6_frag_offset_offset]
 end
@@ -77,12 +79,11 @@ local function _reassemble_ipv6_validated(fragments, fragment_offsets, fragment_
    local ipv6_header = ipv6:new({next_header = ipv6_next_header, hop_limit = constants.default_ttl, src = ipv6_src, dst = ipv6_dst})
    local eth_header = ethernet:new({src = eth_src, dst = eth_dst, type = constants.ethertype_ipv6})
    local ipv6_header = ipv6:new({next_header = ipv6_next_header, hop_limit = constants.default_ttl, src = ipv6_src, dst = ipv6_dst})
-   local dgram = datagram:new(repkt)
    local frag_start = constants.ethernet_header_size + constants.ipv6_fixed_header_size
 
+   local dgram = dgram:reuse(repkt)
    dgram:push(ipv6_header)
    dgram:push(eth_header)
-   dgram:free()
    ipv6_header:free()
    eth_header:free()
    local frag_indata_start = constants.ethernet_header_size + constants.ipv6_fixed_header_size + constants.ipv6_frag_header_size


### PR DESCRIPTION
This branch contains 3 commits. All commits depend on the previous one:
1) Make the 'scratch_ipv4' variable an attribute of the lwAftr class. It also changes the constructor to create its own object and copy the configuration parameters into them, instead of reusing the 'conf' parameter.
2) Create one single 'datagram' object as an attribute of lwAftr and reuse it when necessary. In 'icmp.lua' and 'fragment.lua' as these modules are not classes, there's a local datagram variable for each module.
3) Create classes 'add_ethernet_header' and 'add_ipv6_header'. Basically it generalizes the former 'add_inet_ethernet' method so it can be reused in other parts of the code. The 'add_ipv6_header' is called only once, but I added it for symmetry.

This is the result of the benchmark tests after the changes:

```
Benchmarking: from-internet IPv4 packet found in the binding table.
Rate(Mpps): 3.735
Benchmarking: from-internet IPv4 packet found in the binding table, needs IPv6 fragmentation.
Rate(Mpps): 0.839
Benchmarking: from-internet IPv4 packet found in the binding table, needs IPv6 fragmentation, DF set, ICMP-3,4.
Rate(Mpps): 0.380
Benchmarking: from-b4 to-internet IPv6 packet found in the binding table.
Rate(Mpps): 2.010
Benchmarking: from-b4 to-internet IPv6 packet NOT found in the binding table (ICMP-on-fail)
Rate(Mpps): 1.180
Benchmarking: from-to-b4 IPv6 packet, no hairpinning
Rate(Mpps): 2.308
Benchmarking: from-to-b4 IPv6 packet, with hairpinning
Rate(Mpps): 0.169
Benchmarking: from-b4 IPv6 packet, with hairpinning, to B4 with custom lwAFTR address
Rate(Mpps): 0.931
Benchmarking: from-b4 IPv6 packet, with hairpinning, from B4 with custom lwAFTR address
Rate(Mpps): 1.306
Benchmarking: from-b4 IPv6 packet, with hairpinning, different non-default lwAFTR addresses
Rate(Mpps): 1.092
```
The first benchmark, which was already good, kept improving. Two other tests went above 2 Mpps, other benchmarks improved slightly.