### PR TITLE
Bit module improvements

### DIFF
--- a/src/apps/lwaftr/icmp.lua
+++ b/src/apps/lwaftr/icmp.lua
@@ -8,8 +8,10 @@ local datagram = require("lib.protocol.datagram")
 local ethernet = require("lib.protocol.ethernet")
 local ipv4 = require("lib.protocol.ipv4")
 local ipv6 = require("lib.protocol.ipv6")
-
+local bit = require("bit")
 local ffi = require("ffi")
+
+local band, bnot = bit.band, bit.bnot
 local C = ffi.C
 
 -- Write ICMP data to the end of a packet
@@ -85,7 +87,7 @@ function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, config)
    ipv6_header:payload_length(ipv6_payload_len)
    local ph = ipv6_header:pseudo_header(ipv6_payload_len, constants.proto_icmpv6)
    local ph_csum = checksum.ipsum(ffi.cast("uint8_t *", ph), ffi.sizeof(ph), 0)
-   local ph_csum = bit.band(bit.bnot(ph_csum), 0xffff)
+   local ph_csum = band(bnot(ph_csum), 0xffff)
    local ethernet_header = ethernet:new({src = from_eth,
                                          dst = to_eth,
                                          type = constants.ethertype_ipv6})

--- a/src/apps/lwaftr/icmp.lua
+++ b/src/apps/lwaftr/icmp.lua
@@ -85,7 +85,7 @@ function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, config)
    ipv6_header:payload_length(ipv6_payload_len)
    local ph = ipv6_header:pseudo_header(ipv6_payload_len, constants.proto_icmpv6)
    local ph_csum = checksum.ipsum(ffi.cast("uint8_t *", ph), ffi.sizeof(ph), 0)
-   local ph_csum = bit.band(0xffff, bit.bnot(ph_csum))
+   local ph_csum = bit.band(bit.bnot(ph_csum), 0xffff)
    local ethernet_header = ethernet:new({src = from_eth,
                                          dst = to_eth,
                                          type = constants.ethertype_ipv6})

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -111,9 +111,9 @@ local function fixup_tcp_checksum(pkt, csum_offset, fixup_val)
    -- TODO/FIXME: *test* this code
    -- Manually unrolled loop; max 2 iterations, extra iterations
    -- don't hurt, bitops are fast and ifs are slow.
-   local overflow = bit.rshift(bit.band(0xffff0000, csum), 16)
+   local overflow = bit.rshift(csum, 16)
    csum = bit.band(csum, 0xffff) + overflow
-   local overflow = bit.rshift(bit.band(0xffff0000, csum), 16)
+   local overflow = bit.rshift(csum, 16)
    csum = bit.band(csum, 0xffff) + overflow
    csum = bit.bnot(csum)
 

--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -28,8 +28,12 @@ end
 
 function format_ipv4(uint32)
    return string.format("%i.%i.%i.%i",
-      bit.rshift(bit.band(uint32, 0xff000000), 24),
-      bit.rshift(bit.band(uint32, 0xff0000), 16),
-      bit.rshift(bit.band(uint32, 0xff00), 8),
+      bit.rshift(uint32, 24),
+      bit.rshift(uint32, 16),
+      bit.rshift(uint32, 8),
       bit.band(uint32, 0xff))
+end
+
+function selftest ()
+   assert(format_ipv4(65535) == "0.0.255.255", "Bad conversion in format_ipv4")
 end


### PR DESCRIPTION
Changes related with bit operations:

* Casting packet.data to uint8_t* is not necessary as it's already uint8_t.
* LuaJIT's BitOp module only uses the least significant 32-bit of arguments, so it's not necessary to band to fetch the lowest 32 bits.
* bit.band was used either placing a constant as first argument or sometimes as second argument. I think it improves readability to follow a pattern. I made all comparisons as bit.band(var, constant).
* Cached bit module functions as recommended by LuaJIT's docs.

Benchmark results after changes:

```
Benchmarking: from-internet IPv4 packet found in the binding table.
Rate(Mpps): 3.730
Benchmarking: from-internet IPv4 packet found in the binding table, needs IPv6 fragmentation.
Rate(Mpps): 1.685
Benchmarking: from-internet IPv4 packet found in the binding table, needs IPv6 fragmentation, DF set, ICMP-3,4.
Rate(Mpps): 0.382
Benchmarking: from-b4 to-internet IPv6 packet found in the binding table.
Rate(Mpps): 2.033
Benchmarking: from-b4 to-internet IPv6 packet NOT found in the binding table (ICMP-on-fail)
Rate(Mpps): 1.182
Benchmarking: from-to-b4 IPv6 packet, no hairpinning
Rate(Mpps): 2.273
Benchmarking: from-to-b4 IPv6 packet, with hairpinning
Rate(Mpps): 1.139
Benchmarking: from-b4 IPv6 packet, with hairpinning, to B4 with custom lwAFTR address
Rate(Mpps): 1.125
Benchmarking: from-b4 IPv6 packet, with hairpinning, from B4 with custom lwAFTR address
Rate(Mpps): 0.174
Benchmarking: from-b4 IPv6 packet, with hairpinning, different non-default lwAFTR addresses
Rate(Mpps): 1.092
```