### PR TITLE
Fix benchmark and benchmark tests

### DIFF
--- a/tests/apps/lwaftr/end-to-end/benchmark-end-to-end.sh
+++ b/tests/apps/lwaftr/end-to-end/benchmark-end-to-end.sh
@@ -3,6 +3,7 @@
 SNABB_BASE=../../../..
 TEST_BASE=${SNABB_BASE}/tests/apps/lwaftr/data
 TEST_OUT=/tmp
+EMPTY=${TEST_BASE}/empty.pcap
 
 if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root" 1>&2
@@ -14,11 +15,12 @@ function quit_with_msg {
 }
 
 function usage {
-    quit_with_msg "Usage: benchmark-end-to-end <pcidev>"
+    quit_with_msg "Usage: benchmark-end-to-end <pcidev_v4> <pcidev_v6>"
 }
 
-pcidev=$1
-if [ -z "$pcidev" ]; then
+pcidev_v4=$1
+pcidev_v6=$2
+if [ -z "$pcidev_v4" ] || [ -z "$pcidev_v6" ]; then
     usage
 fi
 
@@ -26,15 +28,15 @@ function run_benchmark {
     local script=${SNABB_BASE}/src/apps/lwaftr/benchmark.lua
     local binding_table=${TEST_BASE}/binding.table
     local conf=$1
-    local pcap_file=$2
+    local pcap_file_v4=$2
+    local pcap_file_v6=$3
 
-    echo "${SNABB_BASE}/src/snabb snsh $script $binding_table $conf $pcap_file $pcidev"
-    ${SNABB_BASE}/src/snabb snsh $script $binding_table $conf $pcap_file $pcidev
+    ${SNABB_BASE}/src/snabb snsh $script $binding_table $conf $pcap_file_v4 $pcap_file_v6 $pcidev_v4 $pcidev_v6
 }
 
 echo "Benchmarking: from-internet IPv4 packet found in the binding table."
 run_benchmark ${TEST_BASE}/icmp_on_fail.conf \
-    ${TEST_BASE}/tcp-frominet-bound.pcap
+    ${TEST_BASE}/tcp-frominet-bound.pcap ${EMPTY}
 
 # Fail
 # echo "Testing: from-internet IPv4 packet found in the binding table, original TTL=1."
@@ -43,11 +45,11 @@ run_benchmark ${TEST_BASE}/icmp_on_fail.conf \
 
 echo "Benchmarking: from-internet IPv4 packet found in the binding table, needs IPv6 fragmentation."
 run_benchmark ${TEST_BASE}/small_ipv6_mtu_no_icmp.conf \
-   ${TEST_BASE}/tcp-frominet-bound1494.pcap
+   ${TEST_BASE}/tcp-frominet-bound1494.pcap ${EMPTY}
 
 echo "Benchmarking: from-internet IPv4 packet found in the binding table, needs IPv6 fragmentation, DF set, ICMP-3,4."
 run_benchmark ${TEST_BASE}/small_ipv6_mtu_no_icmp.conf \
-   ${TEST_BASE}/tcp-frominet-bound1494-DF.pcap
+   ${TEST_BASE}/tcp-frominet-bound1494-DF.pcap ${EMPTY}
 
 # TODO: Returns 0 Mbps
 # echo "Benchmarking: from-internet IPv4 packet NOT found in the binding table, no ICMP."
@@ -66,7 +68,7 @@ run_benchmark ${TEST_BASE}/small_ipv6_mtu_no_icmp.conf \
 
 echo "Benchmarking: from-b4 to-internet IPv6 packet found in the binding table."
 run_benchmark ${TEST_BASE}/no_icmp.conf \
-${TEST_BASE}/tcp-fromb4-ipv6.pcap
+    ${EMPTY} ${TEST_BASE}/tcp-fromb4-ipv6.pcap
 
 # TODO: Returns 0 Mbps
 # echo "Benchmarking: from-b4 to-internet IPv6 packet NOT found in the binding table, no ICMP"
@@ -76,26 +78,26 @@ ${TEST_BASE}/tcp-fromb4-ipv6.pcap
 # TODO: Returns 0 Mbps
 echo "Benchmarking: from-b4 to-internet IPv6 packet NOT found in the binding table (ICMP-on-fail)"
 run_benchmark ${TEST_BASE}/icmp_on_fail.conf \
-${TEST_BASE}/tcp-fromb4-ipv6-unbound.pcap
+    ${EMPTY} ${TEST_BASE}/tcp-fromb4-ipv6-unbound.pcap
 
 echo "Benchmarking: from-to-b4 IPv6 packet, no hairpinning"
 run_benchmark ${TEST_BASE}/no_hairpin.conf \
-   ${TEST_BASE}/tcp-fromb4-tob4-ipv6.pcap
+   ${EMPTY} ${TEST_BASE}/tcp-fromb4-tob4-ipv6.pcap
 
 echo "Benchmarking: from-to-b4 IPv6 packet, with hairpinning"
 run_benchmark ${TEST_BASE}/no_icmp.conf \
-   ${TEST_BASE}/tcp-fromb4-tob4-ipv6.pcap
+   ${EMPTY} ${TEST_BASE}/tcp-fromb4-tob4-ipv6.pcap
 
 echo "Benchmarking: from-b4 IPv6 packet, with hairpinning, to B4 with custom lwAFTR address"
 run_benchmark ${TEST_BASE}/no_icmp.conf \
-   ${TEST_BASE}/tcp-fromb4-tob4-customBRIP-ipv6.pcap
+   ${EMPTY} ${TEST_BASE}/tcp-fromb4-tob4-customBRIP-ipv6.pcap
 
 echo "Benchmarking: from-b4 IPv6 packet, with hairpinning, from B4 with custom lwAFTR address"
 run_benchmark ${TEST_BASE}/no_icmp.conf \
-   ${TEST_BASE}/tcp-fromb4-customBRIP-tob4-ipv6.pcap
+   ${EMPTY} ${TEST_BASE}/tcp-fromb4-customBRIP-tob4-ipv6.pcap
 
 echo "Benchmarking: from-b4 IPv6 packet, with hairpinning, different non-default lwAFTR addresses"
 run_benchmark ${TEST_BASE}/no_icmp.conf \
-   ${TEST_BASE}/tcp-fromb4-customBRIP1-tob4-customBRIP2-ipv6.pcap
+   ${EMPTY} ${TEST_BASE}/tcp-fromb4-customBRIP1-tob4-customBRIP2-ipv6.pcap
 
 echo "All benchmarking tests run."


### PR DESCRIPTION
* benchmark.lua: change usage message, vmdq is not necessary, refactor report_bench.
* benchmark-end-to-end.sh: change usage message, run_benchmark needs more parameters, adjust tests.