### PR TITLE
Avoid memory copy when encapsulating

### DIFF
--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -71,6 +71,13 @@ function shiftleft (p, bytes)
    p.length = p.length - bytes
 end
 
+-- Move packet data to the right. This leaves length bytes of data
+-- at the beginning of the packet.
+function shiftright (p, bytes)
+   C.memmove(p.data + bytes, p.data, p.length)
+   p.length = p.length + bytes
+end
+
 -- Conveniently create a packet by copying some existing data.
 function from_pointer (ptr, len) return append(allocate(), ptr, len) end
 function from_string (d)         return from_pointer(d, #d) end


### PR DESCRIPTION
When encapsulating a IPv4 packet into IPv6, instead of removing the
ethernet header of the IPv4 packet and after that append IPv6 and
Ethernet headers, just prepend the necessary bits to the packet and
modify the correspondent header bytes directly.