### PR TITLE
Script to run a benchmark multiple times and gather stats

### DIFF
--- a/tests/benchrun.lua
+++ b/tests/benchrun.lua
@@ -1,0 +1,73 @@
+#! /usr/bin/env lua
+
+local function printfln(fmt, ...)
+	print(fmt:format(...))
+end
+
+local function average(values)
+	local sum = 0.0
+	for _, value in ipairs(values) do
+		sum = sum + value
+	end
+	return sum / #values
+end
+
+local function stderror(values)
+	local avg = average(values)
+	local diffsum = 0.0
+	for _, value in ipairs(values) do
+		local diff = (value - avg)
+		diffsum = diffsum + (diff * diff)
+	end
+	local stddev = math.sqrt(diffsum / #values)
+	return stddev / math.sqrt(#values)
+end
+
+
+if #arg ~= 2 then
+	io.stderr:write("Usage: benchrun.lua N command\n")
+	os.exit(1)
+end
+local rounds = tonumber(arg[1])
+local command = arg[2]
+
+local sample_sets = {}
+for i = 1, rounds do
+	local proc = io.popen(command, "r")
+	local sample_set = 1
+	for line in proc:lines() do
+		-- Rate: N.M MPPS
+		local value, nsubs = string.gsub(line, "^Rate:%s+([%d%.]+)%s+MPPS$", "%1")
+		if nsubs > 0 then
+			if sample_sets[sample_set] == nil then
+				sample_sets[sample_set] = {}
+			end
+			table.insert(sample_sets[sample_set], tonumber(value))
+			sample_set = sample_set + 1
+		end
+	end
+end
+
+for setnum, samples in ipairs(sample_sets) do
+	printfln("set %d", setnum)
+	printfln("  min: %g", math.min(unpack(samples)))
+	printfln("  max: %g", math.max(unpack(samples)))
+	printfln("  avg: %g", average(samples))
+	printfln("  err: %g", stderror(samples))
+end
+
+if #sample_sets > 1 then
+	local sum_samples = {}
+	for i = 1, #sample_sets[1] do
+		local v = 0.0
+		for _, samples in ipairs(sample_sets) do
+			v = v + samples[1]
+		end
+		table.insert(sum_samples, v)
+	end
+	printfln("sum", setnum)
+	printfln("  min: %g", math.min(unpack(sum_samples)))
+	printfln("  max: %g", math.max(unpack(sum_samples)))
+	printfln("  avg: %g", average(sum_samples))
+	printfln("  err: %g", stderror(sum_samples))
+end


### PR DESCRIPTION
The `benchrun.lua` script accepts the number of times to execute a command, and the command itself. The command should output lines in the format:

```
Rate: X MPPS
```

where `X` is a positive number (either integer or floating point). The following calculations are made:

* Minimum rate.
* Maximum rate.
* Average rate.
* Standard error of rate.

If the command outputs more than one `Rate: X MPPS` line, the statistics are done separately for each of the observed values (average of the first values, average of the second, and so on), plus an additional report with the same statistics calculated over the sums of all the observed values per each run of the command.

Example usage:

```sh
sudo ../tests/benchrun.lua 10 'snabb snsh
    apps/lwaftr/benchmark.lua ../tests/apps/lwaftr/data/binding.table \
    ../tests/apps/lwaftr/data/icmp_on_fail.conf \
    ../tests/apps/lwaftr/data/tcp-frominet-bound-550.pcap \
    ../tests/apps/lwaftr/data/empty.pcap \
    0000:04:00.0 0000:04:00.1'
```

Notice how the command is a single argument to the script.