### PR TITLE
Add 'snabb-lwaftr' executable and packetblaster generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-bin
 obj
 *~
 *.so

--- a/bin/snabb-lwaftr
+++ b/bin/snabb-lwaftr
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+usage() {
+   echo -e "usage: snabb-lwaftr --help"
+   echo -e "       snabb-lwaftr --bt <binding-table> --conf <conf-file> --v4-pci <pci-addr> --v6-pci <pci-addr>"
+   echo -e " "
+   echo -e "       --bt <binding-table>\tSets binding table"
+   echo -e "       --conf <conf-file>\tSets configuration policy table"
+   echo -e "       --v4-pci <pci-addr>\tPCI device number for the INET-side NIC"
+   echo -e "       --v6-pci <pci-addr>\tPCI device number for the B4-side NIC"
+}
+
+error() {
+   local msg=$1
+
+   usage
+   echo "Error: $msg" >&2
+   exit 1
+}
+
+# No arguments, print out usage
+if [ $# -eq "0" ]; then
+   usage
+   exit 1
+fi
+
+# Include helper functions
+dir="$(dirname "$0")"
+source "$dir/snabb-lwaftr.inc.sh"
+
+# Parse arguments
+while [[ $# > 0 ]]; do
+   key="$1"
+   case $key in
+      --bt)
+         bt="$2"
+         shift
+      ;;
+      --conf)
+         conf="$2"
+         shift
+      ;;
+      --v4-pci)
+         v4_pci="$2"
+         shift
+      ;;
+      --v6-pci)
+         v6_pci="$2"
+         shift
+      ;;
+      --help)
+         usage
+         exit 1
+      ;;
+   esac
+   shift
+done
+
+if [ $EUID -ne 0 ]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+# Helper variables for default parameters
+snabb_src=$(whereis_snabb_src)
+snabb_dir=`dirname $snabb_src`
+snabb_test=$snabb_dir/tests
+snabb_test_data=$snabb_test/apps/lwaftr/data
+
+# Default parameters
+if [ -z "$bt" ]; then
+   bt=$snabb_test_data/binding.table
+fi
+if [ -z "$conf" ]; then
+   conf=$snabb_test_data/icmp_on_fail.conf
+fi
+if [ -z "$v4_pci" ]; then
+   error "v4-pci not set"
+fi
+if [ -z "$v6_pci" ]; then
+   error "v6-pci not set"
+fi
+
+# NIC addresses must start with '0000:'
+if [[ ! $v4_pci =~ ^0000:* ]]; then
+   v4_pci=0000:$v4_pci
+fi
+if [[ ! $v6_pci =~ ^0000:* ]]; then
+   v6_pci=0000:$v6_pci
+fi
+
+# Check parameters are correct
+if [ ! -f "$bt" ]; then
+   error "Couldn't find binding table at '$bt'"
+fi
+if [ ! -f "$conf" ]; then
+   error "Couldn't find configuration file at '$conf'"
+fi
+if ! nic_exists "$v4_pci"; then
+   error "NIC address '$v4_pci' doesn't exist"
+fi
+if ! nic_exists "$v6_pci"; then
+   error "NIC address '$v6_pci' doesn't exist"
+fi
+
+# Run lwaftr/nic_ui
+sudo $snabb_src/snabb snsh $snabb_src/apps/lwaftr/nic_ui.lua \
+   -v $bt $conf $v4_pci $v6_pci

--- a/bin/snabb-lwaftr-blaster
+++ b/bin/snabb-lwaftr-blaster
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Program name
+snabb_lwaftr_blaster=$0
+
+usage() {
+   echo -e "usage: snabb-lwaftr-blaster --help"
+   echo -e "       snabb-lwaftr-blaster --v4-pcap <ipv4.pcap> --v4-pci <pci-addr> --v6-pcap <ipv6.pcap> --v6-pci <pci-addr>"
+   echo -e " "
+   echo -e "       --v4-pcap <ipv4.pcap>\tPcap file containing IPv4 packets"
+   echo -e "       --v4-pci <pci-addr>\tPCI device number for the INET-side NIC"
+   echo -e "       --v6-pcap <ipv6.pcap>\tPcap file containing IPv6 packets"
+   echo -e "       --v6-pci <pci-addr>\tPCI device number for the B4-side NIC"
+}
+
+error() {
+   local msg=$1
+
+   usage
+   echo "Error: $msg" >&2
+   exit 1
+}
+
+# No arguments, print out usage
+if [ $# -eq 0 ]; then
+   usage
+   exit 1
+fi
+
+# On SIGINT, kill background jobs (free NICs)
+trap 'kill $(jobs -p) 2>/dev/null' INT
+
+dir="$(dirname "$0")"
+source "$dir/snabb-lwaftr.inc.sh"
+
+# Parse arguments
+while [[ $# > 1 ]]; do
+   key="$1"
+   case $key in
+      --v4-pcap)
+         v4_pcap="$2"
+         shift
+      ;;
+      --v4-pci)
+         v4_pci="$2"
+         shift
+      ;;
+      --v6-pcap)
+         v6_pcap="$2"
+         shift
+      ;;
+      --v6-pci)
+         v6_pci="$2"
+         shift
+      ;;
+      --kill)
+         do_killnic=1
+         break;
+      ;;
+      --help)
+         usage
+         exit 1
+      ;;
+   esac
+   shift
+done
+
+if [ $EUID -ne 0 ]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+if [ -n "$do_killnic" ]; then
+   shift
+   while [[ $# > 0 ]]; do
+      killnic $1
+      shift
+   done
+   exit 0
+fi
+
+# Helper variables for default parameters
+snabb_src=$(whereis_snabb_src)
+snabb_dir=`dirname $snabb_src`
+snabb_test=$snabb_dir/tests
+snabb_test_data=$snabb_test/apps/lwaftr/benchdata
+
+# Default parameters
+if [ -z "$v4_pcap" ]; then
+   v4_pcap=$snabb_test_data/ipv4-550.pcap
+fi
+if [ -z "$v6_pcap" ]; then
+   v6_pcap=$snabb_test_data/ipv6-550.pcap
+fi
+if [ -z "$v4_pci" ]; then
+   error "v4-pci not set"
+fi
+if [ -z "$v6_pci" ]; then
+   error "v6-pci not set"
+fi
+
+# NIC addresses must start with '0000:'
+if [[ ! $v4_pci =~ ^0000:* ]]; then
+   v4_pci=0000:$v4_pci
+fi
+if [[ ! $v6_pci =~ ^0000:* ]]; then
+   v6_pci=0000:$v6_pci
+fi
+
+# Check parameters are correct
+if [ ! -f "$v4_pcap" ]; then
+   error "Couldn't find file at '$v4_pcap'"
+fi
+if [ ! -f "$v6_pcap" ]; then
+   error "Couldn't find file at '$v6_pcap'"
+fi
+if ! nic_exists "$v4_pci"; then
+   error "NIC address '$v4_pci' doesn't exist"
+fi
+if ! nic_exists "$v6_pci"; then
+   error "NIC address '$v6_pci' doesn't exist"
+fi
+
+$snabb_src/snabb packetblaster replay $v4_pcap $v4_pci & pid1=$!
+$snabb_src/snabb packetblaster replay $v6_pcap $v6_pci & pid2=$!
+wait $pid1 && wait $pid2
+if [ $? -ne 0 ]; then
+   kill $(jobs -p) 2>/dev/null
+   exit 1
+fi

--- a/bin/snabb-lwaftr.inc.sh
+++ b/bin/snabb-lwaftr.inc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+nic_exists() {
+   local nic=$1
+
+   local devices=/sys/bus/pci/devices
+   if [ -d "$devices/$nic" ] || [ -d "$devices/0000:$nic" ]; then
+      return 0
+   fi
+   return 1
+}
+
+whereis_snabb_src() {
+  # Locate snabb executable and find out source folder
+  local snabb_exe=`which snabb`
+  if [ -z "$snabb_exe" ]; then
+     error "Couldn't find snabb executable"
+  fi
+  local snabb_src=`dirname $snabb_exe`
+  echo $snabb_src
+}


### PR DESCRIPTION
* `bin/snabb-lwaftr`: LwAftr executable. It can be executed from any location as long as 'snabb' executable is within PATH.
* `bin/snabb-lwaftr-blaster`: Reads IPv4 and IPv6 pcap files and flushes packetraffic traffic to NICs.
* `bin/snabb-lwaftr.inc.sh`: Helper functions.