### PR TITLE
Remove unused variables

### DIFF
--- a/src/apps/lwaftr/fragmentv6.lua
+++ b/src/apps/lwaftr/fragmentv6.lua
@@ -2,7 +2,6 @@ module(..., package.seeall)
 
 local datagram = require("lib.protocol.datagram")
 local ethernet = require("lib.protocol.ethernet")
-local ipv4 = require("lib.protocol.ipv4")
 local ipv6 = require("lib.protocol.ipv6")
 
 local constants = require("apps.lwaftr.constants")
@@ -87,7 +86,6 @@ local function _reassemble_ipv6_validated(fragments, fragment_offsets, fragment_
    local ipv6_header = ipv6:new({next_header = ipv6_next_header, hop_limit = constants.default_ttl, src = ipv6_src, dst = ipv6_dst})
    local eth_header = ethernet:new({src = eth_src, dst = eth_dst, type = constants.ethertype_ipv6})
    local ipv6_header = ipv6:new({next_header = ipv6_next_header, hop_limit = constants.default_ttl, src = ipv6_src, dst = ipv6_dst})
-   local frag_start = constants.ethernet_header_size + constants.ipv6_fixed_header_size
 
    local dgram = dgram:reuse(repkt)
    dgram:push(ipv6_header)

--- a/src/apps/lwaftr/icmp.lua
+++ b/src/apps/lwaftr/icmp.lua
@@ -11,7 +11,6 @@ local ipv6 = require("lib.protocol.ipv6")
 
 local bit = require("bit")
 local ffi = require("ffi")
-local math = require("math")
 
 local band, bnot = bit.band, bit.bnot
 local C = ffi.C

--- a/src/apps/lwaftr/nic_ui.lua
+++ b/src/apps/lwaftr/nic_ui.lua
@@ -1,18 +1,14 @@
-local C = require("ffi").C
-
 local config = require("core.config")
 local lib = require("core.lib")
 
 local Intel82599 = require("apps.intel.intel_app").Intel82599
 local basic_apps = require("apps.basic.basic_apps")
-local pcap = require("apps.pcap.pcap")
 
 local bt = require("apps.lwaftr.binding_table")
 local lwaftr = require("apps.lwaftr.lwaftr")
 local conf = require("apps.lwaftr.conf")
 
 local ethernet = require("lib.protocol.ethernet")
-local ipv6 = require("lib.protocol.ipv6")
 
 local usage="thisapp binding_table_file conf_file inet_nic_pci b4side_nic_pci"
 

--- a/src/apps/lwaftr/pcapui.lua
+++ b/src/apps/lwaftr/pcapui.lua
@@ -3,7 +3,6 @@ local config = require("core.config")
 local pcap = require("apps.pcap.pcap")
 local lwaftr = require("apps.lwaftr.lwaftr")
 local bt = require("apps.lwaftr.binding_table")
-local ipv6 = require("lib.protocol.ipv6")
 
 local conf = require("apps.lwaftr.conf")
 


### PR DESCRIPTION
Removed unused variables in several files. Tests passes after this change. In most of files the removed variables were unused included headers.