### PR TITLE
Require 'lwaftr.lua' header after parsing arguments

### DIFF
--- a/src/program/snabb_lwaftr/run/run.lua
+++ b/src/program/snabb_lwaftr/run/run.lua
@@ -9,7 +9,7 @@ local Intel82599 = require("apps.intel.intel_app").Intel82599
 local basic_apps = require("apps.basic.basic_apps")
 local bt         = require("apps.lwaftr.binding_table")
 local conf       = require("apps.lwaftr.conf")
-local lwaftr     = require("apps.lwaftr.lwaftr")
+local lwaftr
 
 local function show_usage(exit_code)
    print(require("program.snabb_lwaftr.run.README_inc"))
@@ -94,6 +94,8 @@ end
 function run(args)
    -- It's essential to initialize the binding table before the aftrconf
    local opts, bt_file, conf_file, v4_pci, v6_pci = parse_args(args)
+   -- FIXME: If header is included on the top, cannot run --help without being sudo
+   local lwaftr = require("apps.lwaftr.lwaftr")
    bt.get_binding_table(bt_file)
    local aftrconf = conf.get_aftrconf(conf_file)
 


### PR DESCRIPTION
If the header is included before, it's not possible to run `snabb-lwaftr
run --help` without sudo permissions.

Remove execution permisssions to `run.lua`.