### PR TITLE
Script to add 802.1q VLAN tagging to pcap files

### DIFF
--- a/tests/apps/lwaftr/data/Makefile
+++ b/tests/apps/lwaftr/data/Makefile
@@ -1,0 +1,12 @@
+VLAN_ID ?= 42
+
+in_pcaps := $(filter-out empty.pcap,$(filter-out %-vlan.pcap,$(wildcard *.pcap)))
+out_pcaps := $(patsubst %.pcap,%-vlan.pcap,$(in_pcaps))
+
+%-vlan.pcap: %.pcap
+	python2 add-dot1q.py $< $@ $(VLAN_ID)
+
+all: $(out_pcaps)
+
+clean:
+	$(RM) $(out_pcaps)

--- a/tests/apps/lwaftr/data/add-dot1q.py
+++ b/tests/apps/lwaftr/data/add-dot1q.py
@@ -1,0 +1,36 @@
+#! /usr/bin/env python2
+
+import sys
+from scapy.all import rdpcap, wrpcap, NoPayload, Ether, Dot1Q
+
+if len(sys.argv) not in (3, 4):
+    raise SystemExit("Usage: " + sys.argv[0]
+            + " input.pcap output.pcap [vlan-id]")
+
+VLAN_ID = 42
+if len(sys.argv) == 4:
+    try:
+        VLAN_ID = int(sys.argv[3])
+    except:
+        raise SystemExit("'" + sys.argv[3]
+            + "' is not a valid VLAN identifier")
+
+packets = []
+for packet in rdpcap(sys.argv[1]):
+    layer = packet.firstlayer()
+    while not isinstance(layer, NoPayload):
+        if 'chksum' in layer.default_fields:
+            del layer.chksum
+        if type(layer) is Ether:
+            # adjust ether type
+            layer.type = 0x8100
+            # add 802.1q layer between Ether and IP
+            dot1q = Dot1Q(vlan=VLAN_ID)
+            dot1q.add_payload(layer.payload)
+            layer.remove_payload()
+            layer.add_payload(dot1q)
+            layer = dot1q
+        layer = layer.payload
+    packets.append(packet)
+
+wrpcap(sys.argv[2], packets)


### PR DESCRIPTION
This script uses the Scapy Python module to read packets from a pcap input
file, add 802.1q fields to their Ethernet frames, and write the modified
packets to another pcap file. The VLAN identifier is hardcoded to be vid=42.

As a bonus, a Makefile which can be used to add 802.1q to the pcap files
under "tests/apps/lwaftr/data/" is included.