### PR TITLE
Include lwaftr file on top 

### DIFF
--- a/src/program/snabb_lwaftr/bench/bench.lua
+++ b/src/program/snabb_lwaftr/bench/bench.lua
@@ -7,7 +7,7 @@ local conf = require("apps.lwaftr.conf")
 local config = require("core.config")
 local lib = require("core.lib")
 local pcap = require("apps.pcap.pcap")
-local lwaftr
+local lwaftr = require("apps.lwaftr.lwaftr")
 
 function show_usage(code)
    print(require("program.snabb_lwaftr.check.README_inc"))
@@ -24,7 +24,6 @@ end
 
 function run(args)
    local bt_file, conf_file, inv4_pcap, inv6_pcap = parse_args(args)
-   lwaftr = require("apps.lwaftr.lwaftr")
 
    -- It's essential to initialize the binding table before the aftrconf
    bt.get_binding_table(bt_file)

--- a/src/program/snabb_lwaftr/run/run.lua
+++ b/src/program/snabb_lwaftr/run/run.lua
@@ -9,7 +9,7 @@ local Intel82599 = require("apps.intel.intel_app").Intel82599
 local basic_apps = require("apps.basic.basic_apps")
 local bt         = require("apps.lwaftr.binding_table")
 local conf       = require("apps.lwaftr.conf")
-local lwaftr
+local lwaftr     = require("apps.lwaftr.lwaftr")
 
 local function show_usage(exit_code)
    print(require("program.snabb_lwaftr.run.README_inc"))
@@ -93,8 +93,6 @@ end
 function run(args)
    -- It's essential to initialize the binding table before the aftrconf
    local opts, bt_file, conf_file, v4_pci, v6_pci = parse_args(args)
-   -- FIXME: If header is included on the top, cannot run --help without being sudo
-   local lwaftr = require("apps.lwaftr.lwaftr")
    bt.get_binding_table(bt_file)
    local aftrconf = conf.get_aftrconf(conf_file)
 


### PR DESCRIPTION
Files `fragmentv6.lua` and `icmp.lua` initialize variable `dgram` when the file is included. This operation requires access to DMA which only root is allowed to do so. I created a wrap function that checks whether `dgram` is initialized, in case not initializes it and returns `dgram:reuse()`. After that, I moved back the inclusion of `lwaftr.lua` to the top in the required files.
