### PR TITLE
Ignore generated documentation files

### DIFF
--- a/src/program/snabb_lwaftr/.gitignore
+++ b/src/program/snabb_lwaftr/.gitignore
@@ -1,0 +1,4 @@
+doc/snabb-lwaftr.epub
+doc/snabb-lwaftr.html
+doc/snabb-lwaftr.md
+doc/snabb-lwaftr.pdf


### PR DESCRIPTION
Added `.gitignore` file so documents produced by `snabb-lwaftr-doc` are ignored.