### PR TITLE
Reload binding table on SIGHUP

### DIFF
--- a/src/apps/lwaftr/binding_table.lua
+++ b/src/apps/lwaftr/binding_table.lua
@@ -33,13 +33,18 @@ local function pton_binding_table(bt)
    return pbt
 end
 
+function load_binding_table(bt_file)
+   if not bt_file then
+      error("bt_file must be specified or the BT pre-initialized")
+   end
+   local binding_table = read_binding_table(bt_file)
+   machine_friendly_binding_table = pton_binding_table(binding_table)
+   return machine_friendly_binding_table
+end
+
 function get_binding_table(bt_file)
    if not machine_friendly_binding_table then
-      if not bt_file then
-         error("bt_file must be specified or the BT pre-initialized")
-      end
-      local binding_table = read_binding_table(bt_file)
-      machine_friendly_binding_table = pton_binding_table(binding_table)
+      load_binding_table(bt_file)
    end
    return machine_friendly_binding_table
 end

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -78,6 +78,10 @@ end
 
 LwAftr = {}
 
+local function reload_binding_table(lwstate, path)
+   lwstate.binding_table_by_ipv4 = compute_binding_table_by_ipv4(lwstate.binding_table)
+end
+
 function LwAftr:new(conf)
    -- It's a bit of a hack to deal with tagging here, but the front-ends are
    -- rapidly evolving, and this will happen regardless of which one is used.

--- a/src/program/snabb_lwaftr/run/run.lua
+++ b/src/program/snabb_lwaftr/run/run.lua
@@ -1,6 +1,6 @@
 module(..., package.seeall)
 
-local syscall    = require("syscall")
+local S          = require("syscall")
 local config     = require("core.config")
 local lib        = require("core.lib")
 local csv_stats  = require("lib.csv_stats")
@@ -23,12 +23,12 @@ local function fatal(msg)
 end
 
 local function file_exists(path)
-   local stat = syscall.stat(path)
+   local stat = S.stat(path)
    return stat and stat.isreg
 end
 
 local function dir_exists(path)
-   local stat = syscall.stat(path)
+   local stat = S.stat(path)
    return stat and stat.isdir
 end
 

--- a/src/program/snabb_lwaftr/run/run.lua
+++ b/src/program/snabb_lwaftr/run/run.lua
@@ -95,6 +95,7 @@ function run(args)
    local opts, bt_file, conf_file, v4_pci, v6_pci = parse_args(args)
    bt.get_binding_table(bt_file)
    local aftrconf = conf.get_aftrconf(conf_file)
+   aftrconf.bt_file = bt_file
 
    local c = config.new()
    config.app(c, 'inetNic', Intel82599, {


### PR DESCRIPTION
Implemented reload of binding table on SIGHUP. How to test:

1) Run lwaftr:

```bash
sudo ./snabb-lwaftr run \
    --bt program/snabb_lwaftr/tests/data/binding.table \
    --conf program/snabb_lwaftr/tests/data/icmp_on_fail.conf \
    --v4-pci 0000:04:00.0 \
    --v6-pci 0000:05:00.0
```

2) Send signal SIGHUP to running snabb-lwaftr process:

```bash
sudo kill -SIGHUP `pidof snabb-lwaftr`
```

Result:

```
[snabb-lwaftr: SIGHUP caught - reload binding table]
```

The binding table gets reloaded.