### PR TITLE
Refactoring: vlans without overwriting constants

### DIFF
--- a/src/apps/lwaftr/icmp.lua
+++ b/src/apps/lwaftr/icmp.lua
@@ -18,8 +18,8 @@ local wr16, wr32 = lwutil.wr16, lwutil.wr32
 
 local dgram
 
-local function calculate_payload_size(dst_pkt, initial_pkt, max_size, config)
-   local original_bytes_to_skip = constants.ethernet_header_size
+local function calculate_payload_size(dst_pkt, initial_pkt, l2_size, max_size, config)
+   local original_bytes_to_skip = l2_size
    if config.extra_payload_offset then
       original_bytes_to_skip = original_bytes_to_skip + config.extra_payload_offset
    end
@@ -37,9 +37,9 @@ end
 -- Config must contain code and type
 -- Config may contain a 'next_hop_mtu' setting.
 
-local function write_icmp(dst_pkt, initial_pkt, max_size, base_checksum, config)
+local function write_icmp(dst_pkt, initial_pkt, l2_size, max_size, base_checksum, config)
    local payload_size, original_bytes_to_skip, non_payload_bytes =
-      calculate_payload_size(dst_pkt, initial_pkt, max_size, config)
+      calculate_payload_size(dst_pkt, initial_pkt, l2_size, max_size, config)
    local off = dst_pkt.length
    dst_pkt.data[off] = config.type
    dst_pkt.data[off + 1] = config.code
@@ -65,7 +65,7 @@ local function to_datagram(pkt)
 end
 
 -- initial_pkt is the one to embed (a subset of) in the ICMP payload
-function new_icmpv4_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, config)
+function new_icmpv4_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, l2_size, config)
    local new_pkt = packet.allocate()
    local dgram = to_datagram(new_pkt)
    local ipv4_header = ipv4:new({ttl = constants.default_ttl,
@@ -82,21 +82,21 @@ function new_icmpv4_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, config
 
    -- Generate RFC 1812 ICMPv4 packets, which carry as much payload as they can,
    -- rather than RFC 792 packets, which only carry the original IPv4 header + 8 octets
-   write_icmp(new_pkt, initial_pkt, constants.max_icmpv4_packet_size, 0, config)
+   write_icmp(new_pkt, initial_pkt, l2_size, constants.max_icmpv4_packet_size, 0, config)
 
    -- Fix up the IPv4 total length and checksum
-   local new_ipv4_len = new_pkt.length - constants.ethernet_header_size
-   local ip_tl_p = new_pkt.data + constants.ethernet_header_size + constants.o_ipv4_total_length
+   local new_ipv4_len = new_pkt.length - l2_size
+   local ip_tl_p = new_pkt.data + l2_size + constants.o_ipv4_total_length
    wr16(ip_tl_p, C.ntohs(new_ipv4_len))
-   local ip_checksum_p = new_pkt.data + constants.ethernet_header_size + constants.o_ipv4_checksum
+   local ip_checksum_p = new_pkt.data + l2_size + constants.o_ipv4_checksum
    wr16(ip_checksum_p,  0) -- zero out the checksum before recomputing
-   local csum = checksum.ipsum(new_pkt.data + constants.ethernet_header_size, new_ipv4_len, 0)
+   local csum = checksum.ipsum(new_pkt.data + l2_size, new_ipv4_len, 0)
    wr16(ip_checksum_p, C.htons(csum))
 
    return new_pkt
 end
 
-function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, config)
+function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, l2_size, config)
    local new_pkt = packet.allocate()
    local dgram = to_datagram(new_pkt)
    local ipv6_header = ipv6:new({hop_limit = constants.default_ttl,
@@ -111,14 +111,14 @@ function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, config
    ipv6_header:free()
 
    local max_size = constants.max_icmpv6_packet_size
-   local ph_len = calculate_payload_size(new_pkt, initial_pkt, max_size, config) + constants.icmp_base_size
+   local ph_len = calculate_payload_size(new_pkt, initial_pkt, l2_size, max_size, config) + constants.icmp_base_size
    local ph = ipv6_header:pseudo_header(ph_len, constants.proto_icmpv6)
    local ph_csum = checksum.ipsum(ffi.cast("uint8_t*", ph), ffi.sizeof(ph), 0)
    local ph_csum = band(bnot(ph_csum), 0xffff)
-   write_icmp(new_pkt, initial_pkt, max_size, ph_csum, config)
+   write_icmp(new_pkt, initial_pkt, l2_size, max_size, ph_csum, config)
 
-   local new_ipv6_len = new_pkt.length - (constants.ipv6_fixed_header_size + constants.ethernet_header_size)
-   local ip_pl_p = new_pkt.data + constants.ethernet_header_size + constants.o_ipv6_payload_len
+   local new_ipv6_len = new_pkt.length - (constants.ipv6_fixed_header_size + l2_size)
+   local ip_pl_p = new_pkt.data + l2_size + constants.o_ipv6_payload_len
    wr16(ip_pl_p, C.ntohs(new_ipv6_len))
 
    return new_pkt

--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -9,14 +9,6 @@ local cast = ffi.cast
 local uint16_ptr_t = ffi.typeof("uint16_t*")
 local uint32_ptr_t = ffi.typeof("uint32_t*")
 
-local ehs = require("apps.lwaftr.constants").ethernet_header_size
-
-function get_ihl(pkt)
-   -- It's the lower nibble of byte 0 of an IPv4 header
-   local ver_and_ihl = pkt.data[ehs]
-   return band(ver_and_ihl, 0xf) * 4
-end
-
 function get_ihl_from_offset(pkt, offset)
    local ver_and_ihl = pkt.data[offset]
    return band(ver_and_ihl, 0xf) * 4


### PR DESCRIPTION
This refactoring eliminates most dependency on the ethernet_header_size
constant. It also changes the way IPv6 reassembly is done, eliminating
an implicit dependency on a non-vlan configuration.
