### PR TITLE
add-dot1q.py: Do not force checksum calculation on packets

### DIFF
--- a/src/program/snabb_lwaftr/tests/data/add-dot1q.py
+++ b/src/program/snabb_lwaftr/tests/data/add-dot1q.py
@@ -19,8 +19,6 @@ packets = []
 for packet in rdpcap(sys.argv[1]):
     layer = packet.firstlayer()
     while not isinstance(layer, NoPayload):
-        if 'chksum' in layer.default_fields:
-            del layer.chksum
         if type(layer) is Ether:
             # adjust ether type
             layer.type = 0x8100


### PR DESCRIPTION
The two lines removed by this commit are not really needed, because adding a 802.1Q VLAN tag in the Ethernet header does not change IP packet contents at all. Apart from unneeded, removing those lines makes the script generate proper output when the input contains fragmented packets.