### PR TITLE
CI: Run also unit tests via "make test"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ sudo: required
 dist: trusty
 # install: sudo apt-get install linux-libc-dev
 
-script: make && ( cd tests/apps/lwaftr/end-to-end; sudo ./end-to-end.sh )
+script:
+    - make
+    - sudo make -C src test
+    - cd tests/apps/lwaftr/end-to-end && sudo ./end-to-end.sh


### PR DESCRIPTION
This modifies the Travis-CI configuration so the unit tests are also run
before the end-to-end tests.