### PR TITLE
CI: Run also unit tests via "make test"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: generic
 sudo: required
 dist: trusty
-script: make && ( cd src/program/snabb_lwaftr/tests/end-to-end; sudo ./end-to-end.sh )
+script:
+    - make
+    - sudo make -C src test
+    - cd src/program/snabb_lwaftr/tests/end-to-end && sudo ./end-to-end.sh


### PR DESCRIPTION
This modifies the Travis-CI configuration so the unit tests are also run
before the end-to-end tests.