### PR TITLE
Small fixes to IPv4 reassembly code

### DIFF
--- a/src/apps/lwaftr/fragmentv4.lua
+++ b/src/apps/lwaftr/fragmentv4.lua
@@ -11,7 +11,7 @@ local rd16, wr16, wr32, get_ihl_from_offset = lwutil.rd16, lwutil.wr16, lwutil.w
 local cast = ffi.cast
 local C = ffi.C
 local band, bor = bit.band, bit.bor
-local ceil, pairs = math.ceil, pairs
+local ceil = math.ceil
 
 -- Constants to manipulate the flags next to the frag-offset field directly
 -- as a 16-bit integer, without needing to shift the 3 flag bits.


### PR DESCRIPTION
This patch contains a series of small cleanups to the IPv4 reassembly code and its unit tests, as suggested in PR #116:

* Removes an unneeded localization of `pairs()`.
* Changes uses of the `vlan_tag` identifier to `vlan_id`, because only identifiers are passed around in the code, and `vlan_tag` suggests that the variables may contain the VLAN TPID.
* The VLAN identifier field and the protocol type are checked field by field, instead of doing a byte-by-byte comparison. This better reflects the intention of the code in `check_packet_fragment()`.
* Uses values from the `apps.lwaftr.constants` instead of magic numbers.

Related bug: #78