### PR TITLE
Refactor header handling, make outgoing ICMP work

### DIFF
--- a/src/apps/lwaftr/lwheader.lua
+++ b/src/apps/lwaftr/lwheader.lua
@@ -1,0 +1,44 @@
+module(..., package.seeall)
+
+local constants = require("apps.lwaftr.constants")
+local ethernet = require("lib.protocol.ethernet")
+local ffi = require("ffi")
+local ipv6 = require("lib.protocol.ipv6")
+local lib = require("core.lib")
+local lwutil = require("apps.lwaftr.lwutil")
+
+local C = ffi.C
+local cast = ffi.cast
+local bitfield = lib.bitfield
+local wr16, wr32 = lwutil.wr16, lwutil.wr32
+
+-- Transitional header handling library.
+-- Over the longer term, something more lib.protocol-like has some nice advantages.
+
+-- All addresses should be in network byte order, as should eth_type and vlan_tag.
+-- payload lengths should be in host byte order.
+-- next_hdr_type and dscp_and_ecn are <= 1 byte, so byte order is irrelevant.
+
+function write_eth_header(dst_ptr, ether_src, ether_dst, eth_type, vlan_tag)
+   local eth_hdr = cast(ethernet._header_ptr_type, dst_ptr)
+   eth_hdr.ether_shost = ether_src
+   eth_hdr.ether_dhost = ether_dst
+   if vlan_tag then -- TODO: don't have bare constant offsets here
+      wr32(dst_ptr + 12, vlan_tag)
+      wr16(dst_ptr + 16, eth_type)
+   else
+      eth_hdr.ether_type = eth_type
+   end
+end
+
+function write_ipv6_header(dst_ptr, ipv6_src, ipv6_dst, dscp_and_ecn, next_hdr_type, payload_length)
+   local ipv6_hdr = cast(ipv6._header_ptr_type, dst_ptr)
+   C.memset(ipv6_hdr, 0, ffi.sizeof(ipv6_hdr))
+   bitfield(32, ipv6_hdr, 'v_tc_fl', 0, 4, 6)            -- IPv6 Version
+   bitfield(32, ipv6_hdr, 'v_tc_fl', 4, 8, dscp_and_ecn) -- Traffic class
+   ipv6_hdr.payload_length = C.htons(payload_length)
+   ipv6_hdr.next_header = next_hdr_type
+   ipv6_hdr.hop_limit = constants.default_ttl
+   ipv6_hdr.src_ip = ipv6_src
+   ipv6_hdr.dst_ip = ipv6_dst
+end

--- a/src/program/snabb_lwaftr/tests/end-to-end/end-to-end-vlan.sh
+++ b/src/program/snabb_lwaftr/tests/end-to-end/end-to-end-vlan.sh
@@ -52,11 +52,10 @@ snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
    ${TEST_DATA}/tcp-frominet-trafficclass.pcap ${EMPTY} \
    ${EMPTY} ${TEST_DATA}/tcp-afteraftr-ipv6-trafficclass.pcap
 
-# Fail
-# echo "Testing: from-internet IPv4 packet found in the binding table, original TTL=1."
-# snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
-#    ${TEST_DATA}/tcp-frominet-bound-ttl1.pcap ${EMPTY}\
-#    ${TEST_DATA}/icmpv4-time-expired.pcap ${EMPTY}
+echo "Testing: from-internet IPv4 packet found in the binding table, original TTL=1."
+snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
+   ${TEST_DATA}/tcp-frominet-bound-ttl1.pcap ${EMPTY}\
+   ${TEST_DATA}/icmpv4-time-expired.pcap ${EMPTY}
 
 echo "Testing: from-B4 IPv4 fragmentation (2)"
 snabb_run_and_cmp ${TEST_CONF}/small_ipv4_mtu_icmp_vlan.conf \
@@ -96,11 +95,10 @@ snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
    ${TEST_DATA}/tcp-frominet-unbound.pcap ${EMPTY} \
    ${EMPTY} ${EMPTY}
 
-# Fail
-# echo "Testing: from-internet IPv4 packet NOT found in the binding table (ICMP-on-fail)."
-# snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
-#    ${TEST_DATA}/tcp-frominet-unbound.pcap ${EMPTY} \
-#    ${TEST_DATA}/icmpv4-dst-host-unreachable.pcap ${EMPTY}
+echo "Testing: from-internet IPv4 packet NOT found in the binding table (ICMP-on-fail)."
+snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
+   ${TEST_DATA}/tcp-frominet-unbound.pcap ${EMPTY} \
+   ${TEST_DATA}/icmpv4-dst-host-unreachable.pcap ${EMPTY}
 
 echo "Testing: from-to-b4 IPv6 packet NOT found in the binding table, no ICMP."
 snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
@@ -117,11 +115,10 @@ snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
    ${EMPTY} ${TEST_DATA}/tcp-fromb4-ipv6-unbound.pcap \
    ${EMPTY} ${EMPTY}
 
-# Fail
-# echo "Testing: from-b4 to-internet IPv6 packet NOT found in the binding table (ICMP-on-fail)"
-# snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/tcp-fromb4-ipv6-unbound.pcap \
-#    ${EMPTY} ${TEST_DATA}/icmpv6-nogress.pcap
+echo "Testing: from-b4 to-internet IPv6 packet NOT found in the binding table (ICMP-on-fail)"
+snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/tcp-fromb4-ipv6-unbound.pcap \
+   ${EMPTY} ${TEST_DATA}/icmpv6-nogress.pcap
 
 echo "Testing: from-to-b4 IPv6 packet, no hairpinning"
 # The idea is that with hairpinning off, the packet goes out the inet interface

--- a/src/program/snabb_lwaftr/tests/end-to-end/end-to-end.sh
+++ b/src/program/snabb_lwaftr/tests/end-to-end/end-to-end.sh
@@ -57,7 +57,7 @@ snabb_run_and_cmp ${TEST_BASE}/icmp_on_fail.conf \
 
 echo "Testing: from-internet IPv4 packet found in the binding table, original TTL=1."
 snabb_run_and_cmp ${TEST_BASE}/icmp_on_fail.conf \
-   ${TEST_BASE}/tcp-frominet-bound-ttl1.pcap ${EMPTY}\
+   ${TEST_BASE}/tcp-frominet-bound-ttl1.pcap ${EMPTY} \
    ${TEST_BASE}/icmpv4-time-expired.pcap ${EMPTY}
 
 echo "Testing: from-B4 IPv4 fragmentation (2)"


### PR DESCRIPTION
All outgoing ICMP vlan tests pass with this change.
