### PR TITLE
Small cleanups to the IPv4 reassembly code

### DIFF
--- a/src/apps/lwaftr/fragmentv4.lua
+++ b/src/apps/lwaftr/fragmentv4.lua
@@ -11,7 +11,7 @@ local rd16, wr16, wr32, get_ihl_from_offset = lwutil.rd16, lwutil.wr16, lwutil.w
 local cast = ffi.cast
 local C = ffi.C
 local band, bor = bit.band, bit.bor
-local ceil, pairs = math.ceil, pairs
+local ceil = math.ceil
 
 -- Constants to manipulate the flags next to the frag-offset field directly
 -- as a 16-bit integer, without needing to shift the 3 flag bits.

--- a/src/apps/lwaftr/fragmentv4_test.lua
+++ b/src/apps/lwaftr/fragmentv4_test.lua
@@ -6,22 +6,21 @@ local fragmentv4 = require("apps.lwaftr.fragmentv4")
 local constants = require("apps.lwaftr.constants")
 local eth_proto = require("lib.protocol.ethernet")
 local ip4_proto = require("lib.protocol.ipv4")
-local get_ihl_from_offset = require("apps.lwaftr.lwutil").get_ihl_from_offset
-local wr16 = require("apps.lwaftr.lwutil").wr16
+local lwutil = require("apps.lwaftr.lwutil")
 local packet = require("core.packet")
 local band = require("bit").band
 local ffi = require("ffi")
+
+local rd16, wr16, get_ihl_from_offset = lwutil.rd16, lwutil.wr16, lwutil.get_ihl_from_offset
 
 --
 -- Returns a new packet, which contains an Ethernet frame, with an IPv4 header,
 -- followed by a payload of "payload_size" random bytes.
 --
-local function make_ipv4_packet(payload_size, vlan_tag)
+local function make_ipv4_packet(payload_size, vlan_id)
    local eth_size = eth_proto:sizeof()
-   if vlan_tag and vlan_tag > 0 then
+   if vlan_id then
       eth_size = eth_size + 4  -- VLAN tag takes 4 extra bytes
-   else
-      vlan_tag = nil
    end
    local pkt = packet.allocate()
    pkt.length = eth_size + ip4_proto:sizeof() + payload_size
@@ -35,12 +34,12 @@ local function make_ipv4_packet(payload_size, vlan_tag)
    eth_header:src(eth_proto:pton("5c:51:4f:8f:aa:ee"))
    eth_header:dst(eth_proto:pton("5c:51:4f:8f:aa:ef"))
 
-   if vlan_tag then
-      eth_header:type(0x8100) -- VLAN TPID
-      wr16(pkt.data + eth_proto:sizeof(), vlan_tag)
-      wr16(pkt.data + eth_proto:sizeof() + 2, 0x0800) -- IPv4
+   if vlan_id then
+      eth_header:type(constants.dotq_tpid)
+      wr16(pkt.data + eth_proto:sizeof(), vlan_id)
+      wr16(pkt.data + eth_proto:sizeof() + 2, constants.ethertype_ipv4)
    else
-      eth_header:type(0x0800) -- IPv4
+      eth_header:type(constants.ethertype_ipv4)
    end
 
    -- IPv4 header
@@ -69,7 +68,7 @@ end
 local function eth_header_size(pkt)
    local eth_size = eth_proto:sizeof()
    local eth_header = eth_proto:new_from_mem(pkt.data, pkt.length)
-   if eth_header:type() == 0x8100 then
+   if eth_header:type() == constants.dotq_tpid then
       return eth_size + 4  -- Packet has VLAN tagging
    else
       return eth_size
@@ -119,14 +118,12 @@ local function check_packet_fragment(orig_pkt, frag_pkt, is_last_fragment)
    assert(orig_hdr:dst_eq(frag_hdr:dst()))
    assert(orig_hdr:type() == frag_hdr:type())
 
+   -- Check for VLAN tagging and check the additional fields
    local eth_size = eth_proto:sizeof()
-   if orig_hdr:type() == 0x8100 then
+   if orig_hdr:type() == constants.dotq_tpid then
+      assert(rd16(orig_pkt.data + eth_size) == rd16(frag_pkt.data + eth_size)) -- VLAN id
+      assert(rd16(orig_pkt.data + eth_size + 2) == rd16(frag_pkt.data + eth_size + 2)) -- Protocol
       eth_size = eth_size + 4
-      -- Check extra 4 bytes: VLAN tags and protocol type
-      for offset = eth_proto:sizeof(), eth_size do
-         assert(orig_pkt.data[offset] == frag_pkt.data[offset],
-                "byte mismatch at offset " .. offset .. " (VLAN)")
-      end
    end
 
    -- IPv4 fields
@@ -302,14 +299,14 @@ function test_vlan_tagging()
 end
 
 
-function test_reassemble_unneeded(vlan_tag)
+function test_reassemble_unneeded(vlan_id)
    print("test:   no reassembly needed (single packet)")
 
    local eth_size = eth_proto:sizeof()
-   if vlan_tag then
+   if vlan_id then
       eth_size = eth_size + 4
    end
-   local pkt = make_ipv4_packet(500 - ip4_proto:sizeof() - eth_size, vlan_tag)
+   local pkt = make_ipv4_packet(500 - ip4_proto:sizeof() - eth_size, vlan_id)
    assert(pkt.length == 500)
    pattern_fill(pkt.data + ip4_proto:sizeof() + eth_size,
                 pkt.length - ip4_proto:sizeof() - eth_size)
@@ -322,9 +319,9 @@ function test_reassemble_unneeded(vlan_tag)
 end
 
 
-function test_reassemble_two_missing_fragments(vlan_tag)
+function test_reassemble_two_missing_fragments(vlan_id)
    print("test:   two fragments (one missing)")
-   local pkt = assert(make_ipv4_packet(1200), vlan_tag)
+   local pkt = assert(make_ipv4_packet(1200), vlan_id)
    local eth_size = eth_header_size(pkt)
    local code, fragments = fragmentv4.fragment_ipv4(pkt, eth_size, 1000)
    assert(code == fragmentv4.FRAGMENT_OK)
@@ -337,7 +334,7 @@ function test_reassemble_two_missing_fragments(vlan_tag)
 end
 
 
-function test_reassemble_three_missing_fragments(vlan_tag)
+function test_reassemble_three_missing_fragments(vlan_id)
    print("test:   three fragments (one/two missing)")
    local pkt = assert(make_ipv4_packet(1000))
    local eth_size = eth_header_size(pkt)
@@ -368,9 +365,9 @@ function test_reassemble_three_missing_fragments(vlan_tag)
 end
 
 
-function test_reassemble_two(vlan_tag)
+function test_reassemble_two(vlan_id)
    print("test:   payload=1200 mtu=1000")
-   local pkt = assert(make_ipv4_packet(1200), vlan_tag)
+   local pkt = assert(make_ipv4_packet(1200), vlan_id)
    assert(pkt.length > 1200, "packet shorter than payload size")
    local eth_size = eth_header_size(pkt)
 
@@ -399,9 +396,9 @@ function test_reassemble_two(vlan_tag)
 end
 
 
-function test_reassemble_three(vlan_tag)
+function test_reassemble_three(vlan_id)
    print("test:   payload=1000 mtu=400")
-   local pkt = assert(make_ipv4_packet(1000), vlan_tag)
+   local pkt = assert(make_ipv4_packet(1000), vlan_id)
    local eth_size = eth_header_size(pkt)
 
    -- Keep a copy of the packet, for comparisons
@@ -443,17 +440,17 @@ function selftest()
    test_reassemble_pattern_fragments()
    test_vlan_tagging()
 
-   local function testall(vlan_tag)
+   local function testall(vlan_id)
       local suffix = " (no vlan tag)"
-      if vlan_tag then
-         suffix = " (vlan tag=" .. vlan_tag .. ")"
+      if vlan_id then
+         suffix = " (vlan id=" .. vlan_id .. ")"
       end
       print("test: lwaftr.fragmentv4.reassemble_ipv4" .. suffix)
-      test_reassemble_unneeded(vlan_tag)
-      test_reassemble_two_missing_fragments(vlan_tag)
-      test_reassemble_three_missing_fragments(vlan_tag)
-      test_reassemble_two(vlan_tag)
-      test_reassemble_three(vlan_tag)
+      test_reassemble_unneeded(vlan_id)
+      test_reassemble_two_missing_fragments(vlan_id)
+      test_reassemble_three_missing_fragments(vlan_id)
+      test_reassemble_two(vlan_id)
+      test_reassemble_three(vlan_id)
    end
    testall(nil)
    testall(42)

--- a/src/apps/lwaftr/fragmentv4_test.lua
+++ b/src/apps/lwaftr/fragmentv4_test.lua
@@ -3,7 +3,6 @@ if type((...)) == "string" then module(..., package.seeall) end
 
 local constants = require("apps.lwaftr.constants")
 local fragmentv4 = require("apps.lwaftr.fragmentv4")
-local constants = require("apps.lwaftr.constants")
 local eth_proto = require("lib.protocol.ethernet")
 local ip4_proto = require("lib.protocol.ipv4")
 local lwutil = require("apps.lwaftr.lwutil")


### PR DESCRIPTION
This PR applies the cleanups suggested in the comments of PR #116.

The first patch is a cherry-pick of commit 1bae0e75ade7fa469a3e96970e7a9bf6fccdacae from `lwaftr_olive` and the second removes the duplicate import of the `apps.lwaftr.constants` module (which is not included in the cherry-picked commit because the code in `lwaftr_olive` didn't have that issue).