### PR TITLE
Add LwAftr as another tunnel option to snabbnfv (quick and dirty)

### DIFF
--- a/src/apps/lwaftr/binding_table.lua
+++ b/src/apps/lwaftr/binding_table.lua
@@ -16,7 +16,7 @@ end
 local machine_friendly_binding_table
 
 -- b4_v6 is for the B4, br_v6 is for the border router (lwAFTR)
-local function pton_binding_table(bt)
+function pton_binding_table(bt)
    local pbt = {}
    for _, v in ipairs(bt) do
       local b4_v6 = ipv6:pton(v[1])


### PR DESCRIPTION
This is a quick-and-dirty patch to use your lwaftr app from within snabbnfv traffic as tunnel module, similar to how L2TPv3 can be configured. I'm not sure about your plans on configuring lwaftr, so I simply adjusted things in order to get some simple traffic working. I don't intend this to be merged into your code as is, but rather as a base for discussion.

The basic app flow within snabbnfv is 10GE -- nd_light -- lwaftr -- vhost_user (qemu VM)

A config example for LwAftr with snabbnfv is the following:

```
cat igalia-port-example.cfg
return {
  {
    vlan = nil,
    mac_address = "44:44:44:44:44:44",
    port_id = "xe0",
    ingress_filter = nil,
    gbps = nil,
    tunnel = {
      type = "LwAftr",
      ipv6_interface = {
             address = "fc00::100",
             next_hop = "fc00::1",
      },
      ipv4_interface = {
             address  = "10.0.0.100",
             next_hop = "10.0.0.1",
             next_hop_mac = "52:54:00:00:ff:02",
      },
      icmpv6_rate_limiter_n_seconds = 10,
      icmpv6_rate_limiter_n_packets = 100,
      ipv4_mtu = 1500,
      ipv6_mtu = 1500,
      binding_table = {
        {'127:2:3:4:5:6:7:128', '178.79.150.233', 1, 100, '8:9:a:b:c:d:e:f'},
        {'127:11:12:13:14:15:16:128', '178.79.150.233', 101, 64000},
        {'127:22:33:44:55:66:77:128', '178.79.150.15', 5, 7000},
        {'127:24:35:46:57:68:79:128', '178.79.150.2', 7800, 7900, '1E:1:1:1:1:1:1:af'},
        {'127:14:25:36:47:58:69:128', '178.79.150.3', 4000, 5050, '1E:2:2:2:2:2:2:af'},
        {'fc00:1:2:3:4:5:7:127', '193.5.1.100', 1024, 2047},
        {'fc00:1:2:3:4:5:7:128', '193.5.1.100', 2048, 3071},
        {'fc00:1:2:3:4:5:7:129', '193.5.1.100', 3072, 4095}
      },
    },
  },
}
```

Snabbnfv can be launched via
```
sudo ./src/snabb snabbnfv traffic 0000:05:00.0 ./igalia-port-example.cfg /tmp/socket
```

Using a simple iptables based B4 client I was able to successfully ssh into the VM via the IPv4 in IPv6 softwire tunnel and ping it as well. 

Happy to discuss the format of the configuration and if it makes sense or not to use the lwaftr app as another tunnel config within snabbnfv.

