### PR TITLE
All the incoming-ICMPv6 tests now pass

### DIFF
--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -99,7 +99,6 @@ end
 LwAftr = {}
 
 function LwAftr:new(conf)
-   if debug then lwdebug.pp(conf) end
    local o = {}
    for k,v in pairs(conf) do
       o[k] = v
@@ -122,6 +121,7 @@ function LwAftr:new(conf)
    o.fragment6_cache = {}
    transmit_icmpv6_with_rate_limit = init_transmit_icmpv6_with_rate_limit(o)
    reload_binding_table_on_hup(o)
+   if debug then lwdebug.pp(conf) end
    return setmetatable(o, {__index=LwAftr})
 end
 
@@ -449,7 +449,7 @@ local function tunnel_packet_too_big(lwstate, pkt)
                         code = constants.icmpv4_datagram_too_big_df,
                         extra_payload_offset = orig_packet_offset - eth_hs,
                         next_hop_mtu = specified_mtu - constants.ipv6_fixed_header_size,
-                        vlan_tag = lwstate.l4_vlan_tag,
+                        vlan_tag = lwstate.v4_vlan_tag,
                         }
    local o_src = orig_packet_offset + constants.o_ipv4_src_addr
    local dst_ip = pkt.data + o_src
@@ -467,7 +467,8 @@ local function tunnel_generic_unreachable(lwstate, pkt)
    local orig_packet_offset = eth_hs + ipv6_hs + icmp_hs + ipv6_hs
    local icmp_config = {type = constants.icmpv4_dst_unreachable,
                         code = constants.icmpv4_host_unreachable,
-                        extra_payload_offset = orig_packet_offset - eth_hs
+                        extra_payload_offset = orig_packet_offset - eth_hs,
+                        vlan_tag = lwstate.v4_vlan_tag
                         }
    local o_src = orig_packet_offset + constants.o_ipv4_src_addr
    local dst_ip = pkt.data + o_src

--- a/src/program/snabb_lwaftr/tests/end-to-end/end-to-end-vlan.sh
+++ b/src/program/snabb_lwaftr/tests/end-to-end/end-to-end-vlan.sh
@@ -181,40 +181,34 @@ snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
    ${TEST_DATA}/incoming-icmpv4-34toobig.pcap ${EMPTY} \
    ${EMPTY} ${TEST_DATA}/ipv6-tunneled-incoming-icmpv4-34toobig.pcap
 
-# Fail
-# echo "Testing: incoming ICMPv6 1,3 destination/address unreachable, OPE from internet"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-13dstaddressunreach-inet-OPE.pcap \
-#    ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
+echo "Testing: incoming ICMPv6 1,3 destination/address unreachable, OPE from internet"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-13dstaddressunreach-inet-OPE.pcap \
+   ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
 
-# Fail
-# echo "Testing: incoming ICMPv6 2,0 'too big' notification, OPE from internet"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-20pkttoobig-inet-OPE.pcap \
-#    ${TEST_DATA}/response-ipv4-icmp34-inet.pcap ${EMPTY}
+echo "Testing: incoming ICMPv6 2,0 'too big' notification, OPE from internet"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-20pkttoobig-inet-OPE.pcap \
+   ${TEST_DATA}/response-ipv4-icmp34-inet.pcap ${EMPTY}
 
-# Fail
-# echo "Testing: incoming ICMPv6 3,0 hop limit exceeded, OPE from internet"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-30hoplevelexceeded-inet-OPE.pcap \
-#    ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
+echo "Testing: incoming ICMPv6 3,0 hop limit exceeded, OPE from internet"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-30hoplevelexceeded-inet-OPE.pcap \
+   ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
 
-# Fail
-# echo "Testing: incoming ICMPv6 3,1 frag reasembly time exceeded, OPE from internet"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-31fragreassemblytimeexceeded-inet-OPE.pcap \
-#    ${EMPTY} ${EMPTY}
+echo "Testing: incoming ICMPv6 3,1 frag reasembly time exceeded, OPE from internet"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-31fragreassemblytimeexceeded-inet-OPE.pcap \
+   ${EMPTY} ${EMPTY}
 
-# Fail
-# echo "Testing: incoming ICMPv6 4,3 parameter problem, OPE from internet"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-43paramprob-inet-OPE.pcap \
-#    ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
+echo "Testing: incoming ICMPv6 4,3 parameter problem, OPE from internet"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-43paramprob-inet-OPE.pcap \
+   ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
 
-# Fail
-# echo "Testing: incoming ICMPv6 3,0 hop limit exceeded, OPE hairpinned"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-30hoplevelexceeded-hairpinned-OPE.pcap \
-#    ${EMPTY} ${TEST_DATA}/response-ipv6-tunneled-icmpv4_31-tob4.pcap
+echo "Testing: incoming ICMPv6 3,0 hop limit exceeded, OPE hairpinned"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-30hoplevelexceeded-hairpinned-OPE.pcap \
+   ${EMPTY} ${TEST_DATA}/response-ipv6-tunneled-icmpv4_31-tob4.pcap
 
 echo "All end-to-end lwAFTR tests passed."


### PR DESCRIPTION
The core fix was to make outgoing ICMP work correctly with vlans.
This patch cleans up passing wrong vlan details in two cases,
and enables the tests.
