### PR TITLE
Refactor header handling, make outgoing ICMP work

### DIFF
--- a/src/apps/lwaftr/icmp.lua
+++ b/src/apps/lwaftr/icmp.lua
@@ -1,6 +1,7 @@
 module(..., package.seeall)
 
 local constants = require("apps.lwaftr.constants")
+local lwheader = require("apps.lwaftr.lwheader")
 local lwutil = require("apps.lwaftr.lwutil")
 
 local checksum = require("lib.checksum")
@@ -15,6 +16,7 @@ local ffi = require("ffi")
 local band, bnot = bit.band, bit.bnot
 local C = ffi.C
 local wr16, wr32 = lwutil.wr16, lwutil.wr32
+local write_eth_header = lwheader.write_eth_header
 
 local dgram = datagram:new()
 
@@ -66,15 +68,10 @@ function new_icmpv4_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, l2_siz
    local ipv4_header = ipv4:new({ttl = constants.default_ttl,
                                  protocol = constants.proto_icmp,
                                  src = from_ip, dst = to_ip})
-   ipv4_header:version(4) -- It was being set to 0, which is bogus...
-
-   local ethernet_header = ethernet:new({src = from_eth,
-                                         dst = to_eth,
-                                         type = constants.ethertype_ipv4})
    dgram:push(ipv4_header)
-   dgram:push(ethernet_header)
-   ethernet_header:free()
    ipv4_header:free()
+   packet.shiftright(new_pkt, l2_size)
+   write_eth_header(new_pkt.data, from_eth, to_eth, constants.n_ethertype_ipv4, config.vlan_tag)
 
    -- Generate RFC 1812 ICMPv4 packets, which carry as much payload as they can,
    -- rather than RFC 792 packets, which only carry the original IPv4 header + 8 octets
@@ -98,13 +95,9 @@ function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, l2_siz
    local ipv6_header = ipv6:new({hop_limit = constants.default_ttl,
                                  next_header = constants.proto_icmpv6,
                                  src = from_ip, dst = to_ip})
-   local ethernet_header = ethernet:new({src = from_eth,
-                                         dst = to_eth,
-                                         type = constants.ethertype_ipv6})
    dgram:push(ipv6_header)
-   dgram:push(ethernet_header)
-   ethernet_header:free()
-   ipv6_header:free()
+   packet.shiftright(new_pkt, l2_size)
+   write_eth_header(new_pkt.data, from_eth, to_eth, constants.n_ethertype_ipv6, config.vlan_tag)
 
    local max_size = constants.max_icmpv6_packet_size
    local ph_len = calculate_payload_size(new_pkt, initial_pkt, l2_size, max_size, config) + constants.icmp_base_size
@@ -117,5 +110,6 @@ function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, l2_siz
    local ip_pl_p = new_pkt.data + l2_size + constants.o_ipv6_payload_len
    wr16(ip_pl_p, C.ntohs(new_ipv6_len))
 
+   ipv6_header:free()
    return new_pkt
 end

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -6,6 +6,7 @@ local fragmentv6 = require("apps.lwaftr.fragmentv6")
 local icmp = require("apps.lwaftr.icmp")
 local lwconf = require("apps.lwaftr.conf")
 local lwdebug = require("apps.lwaftr.lwdebug")
+local lwheader = require("apps.lwaftr.lwheader")
 local lwutil = require("apps.lwaftr.lwutil")
 
 local checksum = require("lib.checksum")
@@ -17,12 +18,11 @@ local bit = require("bit")
 local ffi = require("ffi")
 
 local band, bor, bnot, rshift, lshift = bit.band, bit.bor, bit.bnot, bit.rshift, bit.lshift
-local bitfield = lib.bitfield
 local C = ffi.C
 local cast, fstring = ffi.cast, ffi.string
 local receive, transmit = link.receive, link.transmit
-local rd16, rd32, wr16, wr32, get_ihl_from_offset = lwutil.rd16,
-   lwutil.rd32, lwutil.wr16, lwutil.wr32, lwutil.get_ihl_from_offset
+local rd16, rd32, get_ihl_from_offset  = lwutil.rd16, lwutil.rd32, lwutil.get_ihl_from_offset
+local write_eth_header, write_ipv6_header = lwheader.write_eth_header, lwheader.write_ipv6_header 
 
 local debug = false
 
@@ -79,7 +79,6 @@ end
 LwAftr = {}
 
 function LwAftr:new(conf)
-   if debug then lwdebug.pp(conf) end
    local o = {}
    for k,v in pairs(conf) do
       o[k] = v
@@ -101,6 +100,7 @@ function LwAftr:new(conf)
    o.binding_table_by_ipv4 = compute_binding_table_by_ipv4(o.binding_table)
    o.fragment6_cache = {}
    transmit_icmpv6_with_rate_limit = init_transmit_icmpv6_with_rate_limit(o)
+   if debug then lwdebug.pp(conf) end
    return setmetatable(o, {__index=LwAftr})
 end
 
@@ -219,6 +219,7 @@ end
 local function icmp_after_discard(lwstate, pkt, to_ip)
    local icmp_config = {type = constants.icmpv4_dst_unreachable,
                         code = constants.icmpv4_host_unreachable,
+                        vlan_tag = lwstate.v4_vlan_tag
                         }
    local icmp_dis = icmp.new_icmpv4_packet(lwstate.aftr_mac_inet_side, lwstate.inet_mac,
                                            lwstate.aftr_ipv4_ip, to_ip, pkt,
@@ -231,6 +232,7 @@ end
 local function icmp_b4_lookup_failed(lwstate, pkt, to_ip)
    local icmp_config = {type = constants.icmpv6_dst_unreachable,
                         code = constants.icmpv6_failed_ingress_egress_policy,
+                        vlan_tag = lwstate.v6_vlan_tag
                        }
    local b4fail_icmp = icmp.new_icmpv6_packet(lwstate.aftr_mac_b4_side, lwstate.b4_mac,
                                               lwstate.aftr_ipv6_ip, to_ip, pkt,
@@ -251,28 +253,13 @@ local function ipv6_encapsulate(lwstate, pkt, next_hdr_type, ipv6_src, ipv6_dst,
    local dscp_and_ecn = pkt.data[offset + constants.o_ipv4_dscp_and_ecn]
    -- Make room at the beginning for IPv6 header.
    packet.shiftright(pkt, constants.ipv6_fixed_header_size)
-   C.memset(pkt.data, 0, lwstate.l2_size + constants.ipv6_fixed_header_size)
    -- Modify Ethernet header.
-   local eth_hdr = cast(ethernet._header_ptr_type, pkt.data)
-   eth_hdr.ether_shost = ether_src
-   eth_hdr.ether_dhost = ether_dst
-   if lwstate.vlan_tagging then
-      wr32(pkt.data + lwstate.o_ethernet_tag, lwstate.v6_vlan_tag)
-      wr16(pkt.data + lwstate.o_ethernet_ethertype,
-           C.htons(constants.ethertype_ipv6))
-   else
-      eth_hdr.ether_type = C.htons(constants.ethertype_ipv6)
-   end
+   local eth_type = constants.n_ethertype_ipv6
+   write_eth_header(pkt.data, ether_src, ether_dst, eth_type, lwstate.v6_vlan_tag)
+
    -- Modify IPv6 header.
-   local ipv6_hdr = cast(ipv6._header_ptr_type,
-      pkt.data + lwstate.l2_size)
-   bitfield(32, ipv6_hdr, 'v_tc_fl', 0, 4, 6)            -- IPv6 Version
-   bitfield(32, ipv6_hdr, 'v_tc_fl', 4, 8, dscp_and_ecn) -- Traffic class
-   ipv6_hdr.payload_length = C.htons(payload_length)
-   ipv6_hdr.next_header = next_hdr_type
-   ipv6_hdr.hop_limit = constants.default_ttl
-   ipv6_hdr.src_ip = ipv6_src
-   ipv6_hdr.dst_ip = ipv6_dst
+   write_ipv6_header(pkt.data + lwstate.l2_size, ipv6_src, ipv6_dst,
+                     dscp_and_ecn, next_hdr_type, payload_length)
 
    if pkt.length <= lwstate.ipv6_mtu then
       if debug then
@@ -297,7 +284,8 @@ local function ipv6_encapsulate(lwstate, pkt, next_hdr_type, ipv6_src, ipv6_dst,
       local icmp_config = {type = constants.icmpv4_dst_unreachable,
                            code = constants.icmpv4_datagram_too_big_df,
                            extra_payload_offset = constants.ipv6_fixed_header_size,
-                           next_hop_mtu = lwstate.ipv6_mtu - constants.ipv6_fixed_header_size
+                           next_hop_mtu = lwstate.ipv6_mtu - constants.ipv6_fixed_header_size,
+                           vlan_tag = lwstate.v4_vlan_tag
                            }
       local icmp_pkt = icmp.new_icmpv4_packet(lwstate.aftr_mac_inet_side, lwstate.inet_mac,
                                               lwstate.aftr_ipv4_ip, dst_ip, pkt,
@@ -415,6 +403,7 @@ local function from_inet(lwstate, pkt)
       local dst_ip = pkt.data + o_src
       local icmp_config = {type = constants.icmpv4_time_exceeded,
                            code = constants.icmpv4_ttl_exceeded_in_transit,
+                           vlan_tag = lwstate.v4_vlan_tag
                            }
       local ttl0_icmp =  icmp.new_icmpv4_packet(lwstate.aftr_mac_inet_side, lwstate.inet_mac,
                                                 lwstate.aftr_ipv4_ip, dst_ip, pkt,
@@ -440,7 +429,8 @@ local function tunnel_packet_too_big(lwstate, pkt)
    local icmp_config = {type = constants.icmpv4_dst_unreachable,
                         code = constants.icmpv4_datagram_too_big_df,
                         extra_payload_offset = orig_packet_offset - eth_hs,
-                        next_hop_mtu = specified_mtu - constants.ipv6_fixed_header_size
+                        next_hop_mtu = specified_mtu - constants.ipv6_fixed_header_size,
+                        vlan_tag = lwstate.v4_vlan_tag,
                         }
    local o_src = orig_packet_offset + constants.o_ipv4_src_addr
    local dst_ip = pkt.data + o_src
@@ -458,7 +448,8 @@ local function tunnel_generic_unreachable(lwstate, pkt)
    local orig_packet_offset = eth_hs + ipv6_hs + icmp_hs + ipv6_hs
    local icmp_config = {type = constants.icmpv4_dst_unreachable,
                         code = constants.icmpv4_host_unreachable,
-                        extra_payload_offset = orig_packet_offset - eth_hs
+                        extra_payload_offset = orig_packet_offset - eth_hs,
+                        vlan_tag = lwstate.v4_vlan_tag
                         }
    local o_src = orig_packet_offset + constants.o_ipv4_src_addr
    local dst_ip = pkt.data + o_src
@@ -595,31 +586,15 @@ local function from_b4(lwstate, pkt)
       if lwstate.hairpinning and ipv4_dst_in_binding_table(lwstate, pkt, offset) then
          -- Remove IPv6 header.
          packet.shiftleft(pkt, constants.ipv6_fixed_header_size)
-         local eth_hdr = cast(ethernet._header_ptr_type, pkt.data)
-         eth_hdr.ether_shost = lwstate.b4_mac
-         eth_hdr.ether_dhost = lwstate.aftr_mac_b4_side
-         if lwstate.vlan_tagging then
-            wr32(pkt.data + lwstate.o_ethernet_tag, lwstate.v6_vlan_tag)
-            wr16(pkt.data + lwstate.o_ethernet_ethertype,
-                 C.htons(constants.ethertype_ipv6))
-         else
-            eth_hdr.ether_type = C.htons(constants.ethertype_ipv6)
-         end
+         write_eth_header(pkt.data, lwstate.b4_mac, lwstate.aftr_mac_b4_side,
+                          constants.n_ethertype_ipv4, lwstate.v4_vlan_tag)
          -- TODO:  refactor so this doesn't actually seem to be from the internet?
          return from_inet(lwstate, pkt)
       else
          -- Remove IPv6 header.
          packet.shiftleft(pkt, constants.ipv6_fixed_header_size)
-         local eth_hdr = cast(ethernet._header_ptr_type, pkt.data)
-         eth_hdr.ether_shost = lwstate.aftr_mac_inet_side
-         eth_hdr.ether_dhost = lwstate.inet_mac
-         if lwstate.vlan_tagging then
-            wr32(pkt.data + lwstate.o_ethernet_tag, lwstate.v4_vlan_tag)
-            wr16(pkt.data + lwstate.o_ethernet_ethertype,
-                 C.htons(constants.ethertype_ipv4))
-         else
-            eth_hdr.ether_type = C.htons(constants.ethertype_ipv4)
-         end
+         write_eth_header(pkt.data, lwstate.aftr_mac_inet_side, lwstate.inet_mac,
+                          constants.n_ethertype_ipv4, lwstate.v4_vlan_tag)
          -- Fragment if necessary
          if pkt.length > lwstate.ipv4_mtu then
             local fragstatus, frags = fragmentv4.fragment_ipv4(pkt, lwstate.l2_size, lwstate.ipv4_mtu)

--- a/src/apps/lwaftr/lwheader.lua
+++ b/src/apps/lwaftr/lwheader.lua
@@ -1,0 +1,44 @@
+module(..., package.seeall)
+
+local constants = require("apps.lwaftr.constants")
+local ethernet = require("lib.protocol.ethernet")
+local ffi = require("ffi")
+local ipv6 = require("lib.protocol.ipv6")
+local lib = require("core.lib")
+local lwutil = require("apps.lwaftr.lwutil")
+
+local C = ffi.C
+local cast = ffi.cast
+local bitfield = lib.bitfield
+local wr16, wr32 = lwutil.wr16, lwutil.wr32
+
+-- Transitional header handling library.
+-- Over the longer term, something more lib.protocol-like has some nice advantages.
+
+-- All addresses should be in network byte order, as should eth_type and vlan_tag.
+-- payload lengths should be in host byte order.
+-- next_hdr_type and dscp_and_ecn are <= 1 byte, so byte order is irrelevant.
+
+function write_eth_header(dst_ptr, ether_src, ether_dst, eth_type, vlan_tag)
+   local eth_hdr = cast(ethernet._header_ptr_type, dst_ptr)
+   eth_hdr.ether_shost = ether_src
+   eth_hdr.ether_dhost = ether_dst
+   if vlan_tag then -- TODO: don't have bare constant offsets here
+      wr32(dst_ptr + 12, vlan_tag)
+      wr16(dst_ptr + 16, eth_type)
+   else
+      eth_hdr.ether_type = eth_type
+   end
+end
+
+function write_ipv6_header(dst_ptr, ipv6_src, ipv6_dst, dscp_and_ecn, next_hdr_type, payload_length)
+   local ipv6_hdr = cast(ipv6._header_ptr_type, dst_ptr)
+   C.memset(ipv6_hdr, 0, ffi.sizeof(ipv6_hdr))
+   bitfield(32, ipv6_hdr, 'v_tc_fl', 0, 4, 6)            -- IPv6 Version
+   bitfield(32, ipv6_hdr, 'v_tc_fl', 4, 8, dscp_and_ecn) -- Traffic class
+   ipv6_hdr.payload_length = C.htons(payload_length)
+   ipv6_hdr.next_header = next_hdr_type
+   ipv6_hdr.hop_limit = constants.default_ttl
+   ipv6_hdr.src_ip = ipv6_src
+   ipv6_hdr.dst_ip = ipv6_dst
+end

--- a/tests/apps/lwaftr/end-to-end/end-to-end-vlan.sh
+++ b/tests/apps/lwaftr/end-to-end/end-to-end-vlan.sh
@@ -54,11 +54,10 @@ function snabb_run_and_cmp {
 #    ${TEST_DATA}/tcp-frominet-trafficclass.pcap ${EMPTY} \
 #    ${EMPTY} ${TEST_DATA}/tcp-afteraftr-ipv6-trafficclass.pcap
 
-# Fail
-# echo "Testing: from-internet IPv4 packet found in the binding table, original TTL=1."
-# snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
-#    ${TEST_DATA}/tcp-frominet-bound-ttl1.pcap ${EMPTY}\
-#    ${TEST_DATA}/icmpv4-time-expired.pcap ${EMPTY}
+echo "Testing: from-internet IPv4 packet found in the binding table, original TTL=1."
+snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
+   ${TEST_DATA}/tcp-frominet-bound-ttl1.pcap ${EMPTY}\
+   ${TEST_DATA}/icmpv4-time-expired.pcap ${EMPTY}
 
 # Fail
 # echo "Testing: from-B4 IPv4 fragmentation (2)"
@@ -101,11 +100,10 @@ snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
    ${TEST_DATA}/tcp-frominet-unbound.pcap ${EMPTY} \
    ${EMPTY} ${EMPTY}
 
-# Fail
-# echo "Testing: from-internet IPv4 packet NOT found in the binding table (ICMP-on-fail)."
-# snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
-#    ${TEST_DATA}/tcp-frominet-unbound.pcap ${EMPTY} \
-#    ${TEST_DATA}/icmpv4-dst-host-unreachable.pcap ${EMPTY}
+echo "Testing: from-internet IPv4 packet NOT found in the binding table (ICMP-on-fail)."
+snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
+   ${TEST_DATA}/tcp-frominet-unbound.pcap ${EMPTY} \
+   ${TEST_DATA}/icmpv4-dst-host-unreachable.pcap ${EMPTY}
 
 echo "Testing: from-to-b4 IPv6 packet NOT found in the binding table, no ICMP."
 snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
@@ -123,11 +121,10 @@ snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
    ${EMPTY} ${TEST_DATA}/tcp-fromb4-ipv6-unbound.pcap \
    ${EMPTY} ${EMPTY}
 
-# Fail
-# echo "Testing: from-b4 to-internet IPv6 packet NOT found in the binding table (ICMP-on-fail)"
-# snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/tcp-fromb4-ipv6-unbound.pcap \
-#    ${EMPTY} ${TEST_DATA}/icmpv6-nogress.pcap
+echo "Testing: from-b4 to-internet IPv6 packet NOT found in the binding table (ICMP-on-fail)"
+snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/tcp-fromb4-ipv6-unbound.pcap \
+   ${EMPTY} ${TEST_DATA}/icmpv6-nogress.pcap
 
 # Fail
 # echo "Testing: from-to-b4 IPv6 packet, no hairpinning"
@@ -201,40 +198,34 @@ snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
 #    ${TEST_DATA}/incoming-icmpv4-34toobig.pcap ${EMPTY} \
 #    ${EMPTY} ${TEST_DATA}/ipv6-tunneled-incoming-icmpv4-34toobig.pcap
 
-# Fail
-# echo "Testing: incoming ICMPv6 1,3 destination/address unreachable, OPE from internet"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-13dstaddressunreach-inet-OPE.pcap \
-#    ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
+echo "Testing: incoming ICMPv6 1,3 destination/address unreachable, OPE from internet"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-13dstaddressunreach-inet-OPE.pcap \
+   ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
 
-# Fail
-# echo "Testing: incoming ICMPv6 2,0 'too big' notification, OPE from internet"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-20pkttoobig-inet-OPE.pcap \
-#    ${TEST_DATA}/response-ipv4-icmp34-inet.pcap ${EMPTY}
+echo "Testing: incoming ICMPv6 2,0 'too big' notification, OPE from internet"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-20pkttoobig-inet-OPE.pcap \
+   ${TEST_DATA}/response-ipv4-icmp34-inet.pcap ${EMPTY}
 
-# Fail
-# echo "Testing: incoming ICMPv6 3,0 hop limit exceeded, OPE from internet"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-30hoplevelexceeded-inet-OPE.pcap \
-#    ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
+echo "Testing: incoming ICMPv6 3,0 hop limit exceeded, OPE from internet"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-30hoplevelexceeded-inet-OPE.pcap \
+   ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
 
-# Fail
-# echo "Testing: incoming ICMPv6 3,1 frag reasembly time exceeded, OPE from internet"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-31fragreassemblytimeexceeded-inet-OPE.pcap \
-#    ${EMPTY} ${EMPTY}
+echo "Testing: incoming ICMPv6 3,1 frag reasembly time exceeded, OPE from internet"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-31fragreassemblytimeexceeded-inet-OPE.pcap \
+   ${EMPTY} ${EMPTY}
 
-# Fail
-# echo "Testing: incoming ICMPv6 4,3 parameter problem, OPE from internet"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-43paramprob-inet-OPE.pcap \
-#    ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
+echo "Testing: incoming ICMPv6 4,3 parameter problem, OPE from internet"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-43paramprob-inet-OPE.pcap \
+   ${TEST_DATA}/response-ipv4-icmp31-inet.pcap ${EMPTY}
 
-# Fail
-# echo "Testing: incoming ICMPv6 3,0 hop limit exceeded, OPE hairpinned"
-# snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
-#    ${EMPTY} ${TEST_DATA}/incoming-icmpv6-30hoplevelexceeded-hairpinned-OPE.pcap \
-#    ${EMPTY} ${TEST_DATA}/response-ipv6-tunneled-icmpv4_31-tob4.pcap
+echo "Testing: incoming ICMPv6 3,0 hop limit exceeded, OPE hairpinned"
+snabb_run_and_cmp ${TEST_CONF}/tunnel_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/incoming-icmpv6-30hoplevelexceeded-hairpinned-OPE.pcap \
+   ${EMPTY} ${TEST_DATA}/response-ipv6-tunneled-icmpv4_31-tob4.pcap
 
 echo "All end-to-end lwAFTR tests passed."

--- a/tests/apps/lwaftr/end-to-end/end-to-end.sh
+++ b/tests/apps/lwaftr/end-to-end/end-to-end.sh
@@ -62,7 +62,7 @@ snabb_run_and_cmp ${TEST_BASE}/icmp_on_fail.conf \
 
 echo "Testing: from-internet IPv4 packet found in the binding table, original TTL=1."
 snabb_run_and_cmp ${TEST_BASE}/icmp_on_fail.conf \
-   ${TEST_BASE}/tcp-frominet-bound-ttl1.pcap ${EMPTY}\
+   ${TEST_BASE}/tcp-frominet-bound-ttl1.pcap ${EMPTY} \
    ${TEST_BASE}/icmpv4-time-expired.pcap ${EMPTY}
 
 echo "Testing: from-B4 IPv4 fragmentation (2)"


### PR DESCRIPTION
All ICMP vlan tests are enabled and pass with this change.
This patch properly sets vlan information in ICMP headers.