### PR TITLE
Ensure the status of the end-to-end tests are used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ dist: trusty
 script:
     - make
     - sudo make -C src test
+    - cd src/program/snabb_lwaftr/tests/end-to-end/ && sudo ./end-to-end.sh
+    - sudo ./end-to-end-vlan.sh


### PR DESCRIPTION
'make test' is ignoring the exit status of tests. Ensure that the
lwaftr-specific tests can cause Travis to fail, regardless of whether
the branch has a problematic 'make test' or not.