### PR TITLE
Implement dumping of lwaftr configuration file and binding table to a file

### DIFF
--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -31,3 +31,34 @@ end
 function wr32(offset, val)
    cast(uint32_ptr_t, offset)[0] = val
 end
+
+function set(...)
+   local result = {}
+   for _, v in ipairs({...}) do
+      result[v] = true
+   end
+   return result
+end
+
+function keys(t)
+   local result = {}
+   for k,_ in pairs(t) do
+      table.insert(result, k)
+   end
+   return result
+end
+
+function write_to_file(filename, content)
+   local fd = io.open(filename, "wt")
+   fd:write(content)
+   fd:close()
+end
+
+-- 'ip' is in host bit order, convert to network bit order
+function ipv4number_to_str(ip)
+   local a = bit.band(ip, 0xff)
+   local b = bit.band(bit.rshift(ip, 8), 0xff)
+   local c = bit.band(bit.rshift(ip, 16), 0xff)
+   local d = bit.rshift(ip, 24)
+   return ("%d.%d.%d.%d"):format(a, b, c, d)
+end


### PR DESCRIPTION
I printed out the conf dump temporarily. This is the result:

Output:

```
[snabb-lwaftr: USR1 caught - dump configuration]
b4_mac = ethernet:pton('44:44:44:44:44:44'),
policy_icmpv6_outgoing = 2,
ipv4_mtu = 1460,
hairpinning = true,
aftr_ipv4_ip = ipv4:pton('10.10.10.10'),
aftr_mac_b4_side = ethernet:pton('22:22:22:22:22:22'),
icmpv6_rate_limiter_n_packets = 600000,
policy_icmpv6_incoming = 1,
aftr_ipv6_ip = ipv6:pton('8:9:a:b:c:d:e:f'),
binding_table = bt.get_binding_table(),
bt_file = program/snabb_lwaftr/tests/data/binding.table,
policy_icmpv4_outgoing = 2,
aftr_mac_inet_side = ethernet:pton('12:12:12:12:12:12'),
policy_icmpv4_incoming = 1,
ipv6_mtu = 1500,
vlan_tagging = false,
icmpv6_rate_limiter_n_seconds = 2,
inet_mac = ethernet:pton('68:68:68:68:68:68')
```

This PR partially solves #146.