### PR TITLE
Fix PodHashMap key equality for struct keys

### DIFF
--- a/src/apps/lwaftr/podhashmap.lua
+++ b/src/apps/lwaftr/podhashmap.lua
@@ -44,12 +44,14 @@ local function make_equal_fn(key_type)
          return a == b
       end
    elseif size == 4 then
+      local uint32_ptr_t = ffi.typeof('uint32_t*')
       return function (a, b)
-         return cast('uint32_t*', a)[0] == cast('uint32_t*', b)[0]
+         return cast(uint32_ptr_t, a)[0] == cast(uint32_ptr_t, b)[0]
       end
    elseif size == 8 then
+      local uint64_ptr_t = ffi.typeof('uint64_t*')
       return function (a, b)
-         return cast('uint64_t*', a)[0] == cast('uint64_t*', b)[0]
+         return cast(uint64_ptr_t, a)[0] == cast(uint64_ptr_t, b)[0]
       end
    else
       return function (a, b)
@@ -606,24 +608,24 @@ function selftest()
 
    -- A check that our equality functions work as intended.
    local numbers_equal = make_equal_fn(ffi.typeof('int'))
-   local four_byte = ffi.typeof('struct { uint32_t x[1]; }')
-   local eight_byte = ffi.typeof('struct { uint32_t x[2]; }')
-   local twelve_byte = ffi.typeof('struct { uint32_t x[3]; }')
+   local four_byte = ffi.typeof('uint32_t[1]')
+   local eight_byte = ffi.typeof('uint32_t[2]')
+   local twelve_byte = ffi.typeof('uint32_t[3]')
    local four_byte_equal = make_equal_fn(four_byte)
    local eight_byte_equal = make_equal_fn(eight_byte)
    local twelve_byte_equal = make_equal_fn(twelve_byte)
    assert(numbers_equal(1,1))
    assert(not numbers_equal(1,2))
-   assert(four_byte_equal(ffi.new(four_byte, {{1}}),
-                          ffi.new(four_byte, {{1}})))
-   assert(not four_byte_equal(ffi.new(four_byte, {{1}}),
-                              ffi.new(four_byte, {{2}})))
-   assert(eight_byte_equal(ffi.new(eight_byte, {{1,1}}),
-                           ffi.new(eight_byte, {{1,1}})))
-   assert(not eight_byte_equal(ffi.new(eight_byte, {{1,1}}),
-                               ffi.new(eight_byte, {{1,2}})))
-   assert(twelve_byte_equal(ffi.new(twelve_byte, {{1,1,1}}),
-                            ffi.new(twelve_byte, {{1,1,1}})))
-   assert(not twelve_byte_equal(ffi.new(twelve_byte, {{1,1,1}}),
-                                ffi.new(twelve_byte, {{1,1,2}})))
+   assert(four_byte_equal(ffi.new(four_byte, {1}),
+                          ffi.new(four_byte, {1})))
+   assert(not four_byte_equal(ffi.new(four_byte, {1}),
+                              ffi.new(four_byte, {2})))
+   assert(eight_byte_equal(ffi.new(eight_byte, {1,1}),
+                           ffi.new(eight_byte, {1,1})))
+   assert(not eight_byte_equal(ffi.new(eight_byte, {1,1}),
+                               ffi.new(eight_byte, {1,2})))
+   assert(twelve_byte_equal(ffi.new(twelve_byte, {1,1,1}),
+                            ffi.new(twelve_byte, {1,1,1})))
+   assert(not twelve_byte_equal(ffi.new(twelve_byte, {1,1,1}),
+                                ffi.new(twelve_byte, {1,1,2})))
 end

--- a/src/apps/lwaftr/podhashmap.lua
+++ b/src/apps/lwaftr/podhashmap.lua
@@ -38,18 +38,18 @@ end
 
 local function make_equal_fn(key_type)
    local size = ffi.sizeof(key_type)
-   if pcall(tonumber, ffi.new(key_type)) then
+   local cast = ffi.cast
+   if tonumber(ffi.new(key_type)) then
       return function (a, b)
          return a == b
       end
    elseif size == 4 then
-      local cast = ffi.cast
       return function (a, b)
-         return cast('uint32_t[1]', a)[0] == cast('uint32_t[1]', b)[0]
+         return cast('uint32_t*', a)[0] == cast('uint32_t*', b)[0]
       end
    elseif size == 8 then
       return function (a, b)
-         return cast('uint64_t[1]', a)[0] == cast('uint64_t[1]', b)[0]
+         return cast('uint64_t*', a)[0] == cast('uint64_t*', b)[0]
       end
    else
       return function (a, b)
@@ -603,4 +603,27 @@ function selftest()
    until stride > 256
 
    check_perf(test_lookup, 2e6, 300, 100, 'lookup (40% occupancy)')
+
+   -- A check that our equality functions work as intended.
+   local numbers_equal = make_equal_fn(ffi.typeof('int'))
+   local four_byte = ffi.typeof('struct { uint32_t x[1]; }')
+   local eight_byte = ffi.typeof('struct { uint32_t x[2]; }')
+   local twelve_byte = ffi.typeof('struct { uint32_t x[3]; }')
+   local four_byte_equal = make_equal_fn(four_byte)
+   local eight_byte_equal = make_equal_fn(eight_byte)
+   local twelve_byte_equal = make_equal_fn(twelve_byte)
+   assert(numbers_equal(1,1))
+   assert(not numbers_equal(1,2))
+   assert(four_byte_equal(ffi.new(four_byte, {{1}}),
+                          ffi.new(four_byte, {{1}})))
+   assert(not four_byte_equal(ffi.new(four_byte, {{1}}),
+                              ffi.new(four_byte, {{2}})))
+   assert(eight_byte_equal(ffi.new(eight_byte, {{1,1}}),
+                           ffi.new(eight_byte, {{1,1}})))
+   assert(not eight_byte_equal(ffi.new(eight_byte, {{1,1}}),
+                               ffi.new(eight_byte, {{1,2}})))
+   assert(twelve_byte_equal(ffi.new(twelve_byte, {{1,1,1}}),
+                            ffi.new(twelve_byte, {{1,1,1}})))
+   assert(not twelve_byte_equal(ffi.new(twelve_byte, {{1,1,1}}),
+                                ffi.new(twelve_byte, {{1,1,2}})))
 end


### PR DESCRIPTION
LuaJIT compares structs by reference, not by value.  For example:

```lua
ffi = require('ffi')
ffi.cdef('struct foo { int x; }')
print (ffi.new('struct foo', {1}) == ffi.new('struct foo', {1}))
```

This will print false.  So on structs we should use memcmp.  But LuaJIT
doesn't inline memcmp, so if the struct is only 4 or 8 bytes long, we
should cast the struct value to a pointer, dereference, and compare
integer values.  And, if the key value is a numeric type, we should just
compare directly.  That's what this commit adds.  Happily, the user
doesn't have to specify anything, though I suppose they could do so
manually.