### PR TITLE
Support for running the AFTR in “development mode”

### DIFF
--- a/src/program/snabb_lwaftr/run_nohw/README.inc
+++ b/src/program/snabb_lwaftr/run_nohw/README.inc
@@ -1,0 +1,9 @@
+Usage: run-nohw --help
+       run-nohw --bt PATH --conf PATH --b4-if NAME --inet-if NAME [--verbose]
+
+       --bt, -b PATH        Path to the file containing the binding table.
+       --conf, -c PATH      Path to the lwAFTR configuration file.
+       --b4-if, -B NAME     Name of the B4-side network interface.
+       --inet-if, -I NAME   Name of the Internet-side network interface.
+       --verbose, -v        Be verbose. Can be used multiple times.
+       --help, -h           Show this help message.

--- a/src/program/snabb_lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/snabb_lwaftr/run_nohw/run_nohw.lua
@@ -1,0 +1,107 @@
+module(..., package.seeall)
+
+local CSVStatsTimer = require("lib.csv_stats").CSVStatsTimer
+local ethernet = require("lib.protocol.ethernet")
+local RawSocket = require("apps.socket.raw").RawSocket
+local LwAftr = require("apps.lwaftr.lwaftr").LwAftr
+local conf = require("apps.lwaftr.conf")
+local bt = require("apps.lwaftr.binding_table")
+local lib = require("core.lib")
+local S = require("syscall")
+
+local function check(flag, fmt, ...)
+   if not flag then
+      io.stderr:write(fmt:format(...), "\n")
+      main.exit(1)
+   end
+end
+
+local function file_exists(path)
+   local stat = S.stat(path)
+   return stat and stat.isreg
+end
+
+local function parse_args(args)
+   local verbosity = 0
+   local bt_file, conf_file, b4_if, inet_if
+   local handlers = {
+      v = function ()
+         verbosity = verbosity + 1
+      end;
+      b = function (arg)
+         check(arg, "argument to '--bt' not specified")
+         check(file_exists(arg), "no such file '%s'", arg)
+         bt_file = arg
+      end;
+      c = function (arg)
+         check(arg, "argument to '--conf' not specified")
+         check(file_exists(arg), "no such file '%s'", arg)
+         conf_file = arg
+      end;
+      B = function (arg)
+         check(arg, "argument to '--b4-if' not specified")
+         b4_if = arg
+      end;
+      I = function (arg)
+         check(arg, "argument to '--inet-if' not specified")
+         inet_if = arg
+      end;
+      h = function (arg)
+		print(require("program.snabb_lwaftr.run_nohw.README_inc"))
+		main.exit(0)
+	  end;
+   }
+   lib.dogetopt(args, handlers, "b:c:B:I:vh", {
+      help = "h", bt = "b", conf = "c", verbose = "v",
+      ["b4-if"] = "B", ["inet-if"] = "I",
+   })
+   check(bt_file, "no binding table specified (--bt/-b)")
+   check(conf_file, "no configuration specified (--conf/-c)")
+   check(b4_if, "no B4-side interface specified (--b4-if/-B)")
+   check(inet_if, "no Internet-side interface specified (--inet-if/-I)")
+   return verbosity, bt_file, conf_file, b4_if, inet_if
+end
+
+
+function run(parameters)
+   local verbosity, bt_file, conf_file, b4_if, inet_if = parse_args(parameters)
+   local c = config.new()
+
+   -- AFTR
+   bt.get_binding_table(bt_file)
+   local aftrconf = conf.get_aftrconf(conf_file)
+   aftrconf.bt_file = bt_file
+   config.app(c, "aftr", LwAftr, aftrconf)
+
+   -- B4 side interface
+   config.app(c, "b4if", RawSocket, b4_if)
+
+   -- Internet interface
+   config.app(c, "inet", RawSocket, inet_if)
+
+   -- Connect apps
+   config.link(c, "inet.tx -> aftr.v4")
+   config.link(c, "b4if.tx -> aftr.v6")
+   config.link(c, "aftr.v4 -> inet.rx")
+   config.link(c, "aftr.v6 -> b4if.rx")
+
+   if verbosity >= 1 then
+      local csv = CSVStatsTimer.new()
+      csv:add_app("inet", {"tx", "rx"}, { tx = "IPv4 TX", rx = "IPv4 RX" })
+      csv:add_app("tob4", {"tx", "rx"}, { tx = "IPv6 TX", rx = "IPv6 RX" })
+      csv:activate()
+
+      if verbosity >= 2 then
+         timer.activate(timer.new("report", function ()
+            app.report_apps()
+         end, 1e9, "repeating"))
+      end
+   end
+
+   engine.configure(c)
+   engine.main {
+      report = {
+         showlinks = true;
+      }
+   }
+end

--- a/src/program/snabb_lwaftr/tests/qemu-b4/run-b4-tap
+++ b/src/program/snabb_lwaftr/tests/qemu-b4/run-b4-tap
@@ -1,0 +1,11 @@
+#! /bin/sh
+
+exec qemu-system-x86_64 -enable-kvm \
+	-M pc-q35-2.0 \
+	-drive file=openwrt.img,id=d0,if=none \
+	-device ide-hd,drive=d0,bus=ide.0 \
+	-netdev tap,ifname=olan,script=./tap-b4,downscript=./tap-b4-down,id=hn0 \
+	-device e1000,netdev=hn0,id=nic1 \
+	-netdev tap,ifname=aftr,script=./tap-b4,downscript=./tap-b4-down,id=hn1 \
+	-device e1000,netdev=hn1,id=nic2 \
+	-serial mon:stdio -nographic

--- a/src/program/snabb_lwaftr/tests/qemu-b4/tap-b4
+++ b/src/program/snabb_lwaftr/tests/qemu-b4/tap-b4
@@ -1,0 +1,14 @@
+#! /bin/bash
+echo "Configuring $1"
+ifconfig $1 up
+if [[ $1 == aftr ]] ; then
+	echo "A: 2003:1b0b:fffd:ffff::4000/64 | H: e2:20:35:1b:01:41"
+	ip -6 addr add '2003:1b0b:fffd:ffff::4000/64' dev $1
+	ip link set $1 address 'e2:20:35:1b:01:41'
+fi
+if [[ $1 == olan ]] ; then
+	echo "Adding $1 to bridge, H: 6a:44:d8:7e:73:f7"
+	ip link set $1 address '6a:44:d8:7e:73:f7'
+	brctl addif owrt olan
+fi
+sleep 1

--- a/src/program/snabb_lwaftr/tests/qemu-b4/tap-b4-down
+++ b/src/program/snabb_lwaftr/tests/qemu-b4/tap-b4-down
@@ -1,0 +1,7 @@
+#! /bin/bash
+echo "Stopping $1"
+ifconfig $1 down
+if [[ $1 == olan ]] ; then
+	echo "Removing $1 from bridge"
+	brctl delif owrt olan
+fi


### PR DESCRIPTION
So, the idea is to provide a `snabb-lwaftr run-nohw` subcommand which runs the AFTR ~~in what I would call “development mode”~~ without needing physical hardware:

* Raw sockets are used, which allows plugging both the “B4 side” and the “Internet side” of the AFTR to any network interface:
  - Dummy network interfaces (`modprobe dummy numdummies=N`). Requires extra setup to move packets in and out of the `dummy${N}` interfaces (using Netfilter or bridging the interface should be possible).
  - It is possible to run a B4 virtual machine using qemu, using `-netdev tap -net nic` to make qemu create a TUN/TAP device in the host, to which the AFTR raw socket is attached.
* Physical NICs are not needed, which makes it easier for developers to test the AFTR for correctness using any computer (e.g. our personal laptops or cheap PCs we have at home or the office).

One of the commits also includes example scritps to run qemu, but I am not completely sure that we want to include them in the resitory. If we think having the `snabb-lwaftr run` subcommand is handy, we may prefer to document it and include documentation with examples on how to set up a testing environment in which the AFTR can be run in development mode.