### PR TITLE
Binary search, rangemap lookups return pointer instead of an offset

### DIFF
--- a/src/apps/lwaftr/binary_search.dasl
+++ b/src/apps/lwaftr/binary_search.dasl
@@ -35,14 +35,15 @@ local function assemble (name, prototype, generator)
    return ffi.cast(prototype, mcode)
 end
 
-function gen(count, entry_byte_size)
+function gen(count, entry_type)
    local function gen_binary_search(Dst)
       if count == 1 then
-         | mov rax, 0
+         | mov rax, rdi
          | ret
          return
       end
 
+      local entry_byte_size = ffi.sizeof(entry_type)
       local size = 1
       while size < count do size = size * 2 end
 
@@ -75,31 +76,12 @@ function gen(count, entry_byte_size)
          size = next_size
       end
 
-      -- Now rdi points at the answer (if we have one).  Subtract off
-      -- the base and convert to an index.
-      | sub rdi, rdx
-
-      if bit.band(entry_byte_size, entry_byte_size - 1) == 0 then
-         -- The entry size is a power of two, yay.
-         local bits = 0
-         while bit.lshift(1, bits) ~= entry_byte_size do
-            bits = bits + 1
-         end
-         | sar rdi, bits
-         | mov rax, rdi
-      else
-         -- Not a power of two: boo.  Subtract rdx and divide by the
-         -- entry size to get the offset into the vector.
-         | mov rax, rdi
-         | xor rdx, rdx
-         | mov esi, entry_byte_size
-         | div esi
-      end
-
-      -- Div leaves its result in eax, which is what we want.  Done.
+      -- Now rdi points at the answer (if we have one).  Done!
+      | mov rax, rdi
       | ret
    end
-   return assemble("binary_search_"..count, "int(*)(void*, uint32_t)",
+   return assemble("binary_search_"..count,
+                   ffi.typeof("$*(*)($*, uint32_t)", entry_type, entry_type),
                    gen_binary_search)
 end
 
@@ -108,10 +90,10 @@ function selftest ()
    local test = ffi.new('uint32_t[15]',
                         { 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5 })
    local searchers = {}
-   for i=1,10 do searchers[i] = gen(i, 4) end
+   for i=1,10 do searchers[i] = gen(i, ffi.typeof('uint32_t')) end
 
    local function assert_search(size, key, expected)
-      local res = searchers[size](test, key)
+      local res = searchers[size](test, key) - test
       if res ~= expected then
          error(('in search of size %d for key %d: expected %d, got %d'):format(
                   size, key, expected, res))

--- a/src/apps/lwaftr/rangemap.lua
+++ b/src/apps/lwaftr/rangemap.lua
@@ -114,17 +114,13 @@ function RangeMapBuilder:build()
       entries = packed_entries,
       size = range_count
    }
-   map.binary_search = binary_search.gen(map.size, ffi.sizeof(map.entry_type))
+   map.binary_search = binary_search.gen(map.size, map.entry_type)
    map = setmetatable(map, { __index = RangeMap })
    return map
 end
 
 function RangeMap:lookup(k)
    return self.binary_search(self.entries, k)
-end
-
-function RangeMap:val_at(i)
-   return self.entries[i].value
 end
 
 function selftest()
@@ -146,29 +142,29 @@ function selftest()
    local map = builder:build()
 
    assert(map.size == 12)
-   assert(map:val_at(map:lookup(0)) == 1)
-   assert(map:val_at(map:lookup(1)) == 2)
-   assert(map:val_at(map:lookup(2)) == 10)
-   assert(map:val_at(map:lookup(99)) == 10)
-   assert(map:val_at(map:lookup(100)) == 10)
-   assert(map:val_at(map:lookup(101)) == 20)
-   assert(map:val_at(map:lookup(102)) == 30)
-   assert(map:val_at(map:lookup(199)) == 30)
-   assert(map:val_at(map:lookup(200)) == 30)
-   assert(map:val_at(map:lookup(201)) == 40)
-   assert(map:val_at(map:lookup(300)) == 40)
-   assert(map:val_at(map:lookup(301)) == 50)
-   assert(map:val_at(map:lookup(302)) == 60)
-   assert(map:val_at(map:lookup(303)) == 70)
-   assert(map:val_at(map:lookup(349)) == 70)
-   assert(map:val_at(map:lookup(350)) == 70)
-   assert(map:val_at(map:lookup(399)) == 70)
-   assert(map:val_at(map:lookup(400)) == 70)
-   assert(map:val_at(map:lookup(401)) == 80)
-   assert(map:val_at(map:lookup(402)) == 99)
-   assert(map:val_at(map:lookup(UINT32_MAX-2)) == 99)
-   assert(map:val_at(map:lookup(UINT32_MAX-1)) == 99)
-   assert(map:val_at(map:lookup(UINT32_MAX)) == 100)
+   assert(map:lookup(0).value == 1)
+   assert(map:lookup(1).value == 2)
+   assert(map:lookup(2).value == 10)
+   assert(map:lookup(99).value == 10)
+   assert(map:lookup(100).value == 10)
+   assert(map:lookup(101).value == 20)
+   assert(map:lookup(102).value == 30)
+   assert(map:lookup(199).value == 30)
+   assert(map:lookup(200).value == 30)
+   assert(map:lookup(201).value == 40)
+   assert(map:lookup(300).value == 40)
+   assert(map:lookup(301).value == 50)
+   assert(map:lookup(302).value == 60)
+   assert(map:lookup(303).value == 70)
+   assert(map:lookup(349).value == 70)
+   assert(map:lookup(350).value == 70)
+   assert(map:lookup(399).value == 70)
+   assert(map:lookup(400).value == 70)
+   assert(map:lookup(401).value == 80)
+   assert(map:lookup(402).value == 99)
+   assert(map:lookup(UINT32_MAX-2).value == 99)
+   assert(map:lookup(UINT32_MAX-1).value == 99)
+   assert(map:lookup(UINT32_MAX).value == 100)
 
    local pmu = require('lib.pmu')
    local has_pmu_counters, err = pmu.is_available()
@@ -216,7 +212,7 @@ function selftest()
    local function test_lookup(iterations)
       local inc = math.floor(UINT32_MAX / iterations)
       local result = 0
-      for i=0,UINT32_MAX,inc do result = map:lookup(i) end
+      for i=0,UINT32_MAX,inc do result = map:lookup(i).value end
       return result
    end
 


### PR DESCRIPTION
It seems that LuaJIT's allocation sinker is good enough to pretty much
never require the allocation of an intermediate FFI object for a
pointer.  Returning a pointer directly from various lookup routines
simplifies a lot of code and actually seems to be a marginal speedup
on podhashmap lookups.