### PR TITLE
Pre-allocate buffer for reading signalfd events

### DIFF
--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -89,7 +89,7 @@ local function on_signal(sig, f)
    local fd = S.signalfd(sig, "nonblock") -- handle signal via fd
    local buf = S.types.t.siginfos(8)
    S.sigprocmask("block", sig)            -- block traditional handler
-   timer.activate(timer.new("sighup-reload-binding-table", function ()
+   timer.activate(timer.new(sig, function ()
       local events, err = S.util.signalfd_read(fd, buf)
       if events and #events > 0 then
          print(("[snabb-lwaftr: %s caught]"):format(sig:upper()))

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -87,9 +87,11 @@ end
 
 local function on_signal(sig, f)
    local fd = S.signalfd(sig, "nonblock") -- handle signal via fd
+   local buf = S.types.t.siginfos(8)
    S.sigprocmask("block", sig)            -- block traditional handler
    timer.activate(timer.new("sighup-reload-binding-table", function ()
-      if (#S.util.signalfd_read(fd) > 0) then
+      local events, err = S.util.signalfd_read(fd, buf)
+      if events and #events > 0 then
          print(("[snabb-lwaftr: %s caught]"):format(sig:upper()))
          f()
       end


### PR DESCRIPTION
This prevents an NYI in ljsyscall's signalfd_read function when trying
to convert nil to some kind of ctype:

```
0006  . . . . ISTC     1   2
0007  . . . . JMP      3 => 0015
0008  . . . . UGET     2   1      ; t
0009  . . . . TGETS    2   2   0  ; "siginfos"
0010  . . . . ISTC     3   1
0011  . . . . JMP      3 => 0013
0012  . . . . KSHORT   3   8
0013  . . . . CALL     2   2   2
0000  . . . . . FUNCC               ; ffi.meta.__call
0000  . . . . . FUNCF    7          ; types.lua:623
0001  . . . . . UGET     2   0      ; ffi
0002  . . . . . TGETS    2   2   0  ; "new"
0003  . . . . . MOV      3   0
0004  . . . . . MOV      4   1
0005  . . . . . MOV      5   1
0006  . . . . . UGET     6   1      ; s
0007  . . . . . TGETS    6   6   1  ; "signalfd_siginfo"
0008  . . . . . MULVV    6   1   6
0009  . . . . . CALLT    2   5
0000  . . . . . FUNCC               ; ffi.new
---- TRACE 78 abort util.lua:177 -- NYI: unsupported C type conversion
```