### PR TITLE
Revert changes in BasicApps/Tee

### DIFF
--- a/src/apps/basic/basic_apps.lua
+++ b/src/apps/basic/basic_apps.lua
@@ -96,14 +96,20 @@ function Tee:new ()
 end
 
 function Tee:push ()
-   for _, inport in ipairs(self.input) do
-      while not inport:empty() do
-         local pkt = inport:receive()
-         local used = false
-         for _, outport in ipairs(self.output) do
-            if not outport:full() then
-               outport:transmit(used and pkt:clone() or pkt)
-               used = true
+   noutputs = #self.output
+   if noutputs > 0 then
+      local maxoutput = link.max
+      for _, o in ipairs(self.output) do
+         maxoutput = math.min(maxoutput, link.nwritable(o))
+      end
+      for _, i in ipairs(self.input) do
+         for _ = 1, math.min(link.nreadable(i), maxoutput) do
+            local p = receive(i)
+            maxoutput = maxoutput - 1
+            do local output = self.output
+               for k = 1, #output do
+                  transmit(output[k], k == #output and p or packet.clone(p))
+               end
             end
          end
       end


### PR DESCRIPTION
Commit 38c4d3 (initial vguest app, packets are transmitted) made changes in basic_apps/Tee that broke packetblaster app. This patch reverts the implementation of Tee back to master, which fixes packetblaster. 

It's not possible to revert the patch because the commit changes other files too.