### PR TITLE
PSID map covers only the configured addresses

### DIFF
--- a/src/apps/lwaftr/icmp.lua
+++ b/src/apps/lwaftr/icmp.lua
@@ -16,6 +16,8 @@ local ffi = require("ffi")
 local band, bnot = bit.band, bit.bnot
 local C = ffi.C
 local wr16, wr32 = lwutil.wr16, lwutil.wr32
+local htons, htonl = lwutil.htons, lwutil.htonl
+local ntohs, ntohl = htons, htonl
 local write_eth_header = lwheader.write_eth_header
 
 local dgram
@@ -48,7 +50,7 @@ local function write_icmp(dst_pkt, initial_pkt, l2_size, max_size, base_checksum
    wr16(dst_pkt.data + off + 2, 0) -- checksum
    wr32(dst_pkt.data + off + 4, 0) -- Reserved
    if config.next_hop_mtu then
-      wr16(dst_pkt.data + off + 6, C.htons(config.next_hop_mtu))
+      wr16(dst_pkt.data + off + 6, htons(config.next_hop_mtu))
    end
    local dest = dst_pkt.data + non_payload_bytes
    C.memmove(dest, initial_pkt.data + original_bytes_to_skip, payload_size)
@@ -56,7 +58,7 @@ local function write_icmp(dst_pkt, initial_pkt, l2_size, max_size, base_checksum
    local icmp_bytes = constants.icmp_base_size + payload_size
    local icmp_start = dst_pkt.data + dst_pkt.length
    local csum = checksum.ipsum(icmp_start, icmp_bytes, base_checksum)
-   wr16(dst_pkt.data + off + 2, C.htons(csum))
+   wr16(dst_pkt.data + off + 2, htons(csum))
 
    dst_pkt.length = dst_pkt.length + icmp_bytes
 end
@@ -85,11 +87,11 @@ function new_icmpv4_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, l2_siz
    -- Fix up the IPv4 total length and checksum
    local new_ipv4_len = new_pkt.length - l2_size
    local ip_tl_p = new_pkt.data + l2_size + constants.o_ipv4_total_length
-   wr16(ip_tl_p, C.ntohs(new_ipv4_len))
+   wr16(ip_tl_p, ntohs(new_ipv4_len))
    local ip_checksum_p = new_pkt.data + l2_size + constants.o_ipv4_checksum
    wr16(ip_checksum_p,  0) -- zero out the checksum before recomputing
    local csum = checksum.ipsum(new_pkt.data + l2_size, new_ipv4_len, 0)
-   wr16(ip_checksum_p, C.htons(csum))
+   wr16(ip_checksum_p, htons(csum))
 
    return new_pkt
 end
@@ -113,7 +115,7 @@ function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, l2_siz
 
    local new_ipv6_len = new_pkt.length - (constants.ipv6_fixed_header_size + l2_size)
    local ip_pl_p = new_pkt.data + l2_size + constants.o_ipv6_payload_len
-   wr16(ip_pl_p, C.ntohs(new_ipv6_len))
+   wr16(ip_pl_p, ntohs(new_ipv6_len))
 
    ipv6_header:free()
    return new_pkt

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -220,15 +220,8 @@ end
 -- Return true if the destination ipv4 address is within our managed set of addresses
 local function ipv4_dst_in_binding_table(lwstate, pkt, pre_ipv4_bytes)
    local dst_ip_start = pre_ipv4_bytes + 16
-   local dst_port_start = pre_ipv4_bytes + get_ihl_from_offset(pkt, pre_ipv4_bytes) + 2
-
-   -- FIXME: we should be able to look in the address map for this and
-   -- avoid going through the binding table.
-
-   -- network byte order ip, regardless of host byte order
-   local ip = rd32(pkt.data + dst_ip_start)
-   local port = C.ntohs(rd16(pkt.data + dst_port_start))
-   return binding_lookup_ipv4(lwstate, ip, port) ~= nil
+   local host_endian_ipv4 = C.htonl(rd32(pkt.data + dst_ip_start))
+   return lwstate.binding_table:is_managed_ipv4_address(host_endian_ipv4)
 end
 
 local uint64_ptr_t = ffi.typeof('uint64_t*')

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -56,19 +56,6 @@ local proto_icmp = constants.proto_icmp
 local proto_icmpv6 = constants.proto_icmpv6
 local proto_ipv4 = constants.proto_ipv4
 
-local function guarded_transmit(pkt, o)
-   -- The assert was never being hit, and the assert+link check slow the code
-   -- down about 5-18%, by comparing best and worst runs of 5 seconds at their
-   -- starts and ends.
-   -- The downside is that if the link actually is full, the packet will be dropped.
-   -- Given the requirements of this project, rare dropped packets (none so far in
-   -- testing) are better than a non-trivial speed decrease).
-   -- The assert should never appear in production, but code to cache packets
-   -- on a link full condition could.
-   --assert(not full(o), "need a cache...")
-   transmit(o, pkt)
-end
-
 local transmit_icmpv6_with_rate_limit
 
 local function init_transmit_icmpv6_with_rate_limit(lwstate)
@@ -80,7 +67,7 @@ local function init_transmit_icmpv6_with_rate_limit(lwstate)
    local icmpv6_rate_limiter_n_packets = lwstate.icmpv6_rate_limiter_n_packets
    local counter = 0
    local last_time
-   return function (pkt, o)
+   return function (o, pkt)
       local cur_now = tonumber(engine.now())
       last_time = last_time or cur_now
       -- Reset if elapsed time reached.
@@ -90,8 +77,8 @@ local function init_transmit_icmpv6_with_rate_limit(lwstate)
       end
       -- Send packet if limit not reached.
       if counter < icmpv6_rate_limiter_n_packets then
-         guarded_transmit(pkt, o)
          counter = counter + 1
+         return transmit(o, pkt)
       else
          packet.free(pkt)
       end
@@ -269,7 +256,7 @@ local function icmp_after_discard(lwstate, pkt, to_ip)
    local icmp_dis = icmp.new_icmpv4_packet(lwstate.aftr_mac_inet_side, lwstate.inet_mac,
                                            lwstate.aftr_ipv4_ip, to_ip, pkt,
                                            lwstate.l2_size, icmp_config)
-   guarded_transmit(icmp_dis, lwstate.o4)
+   return transmit(lwstate.o4, icmp_dis)
 end
 
 -- ICMPv6 type 1 code 5, as per RFC 7596.
@@ -282,7 +269,7 @@ local function icmp_b4_lookup_failed(lwstate, pkt, to_ip)
    local b4fail_icmp = icmp.new_icmpv6_packet(lwstate.aftr_mac_b4_side, lwstate.b4_mac,
                                               lwstate.aftr_ipv6_ip, to_ip, pkt,
                                               lwstate.l2_size, icmp_config)
-   transmit_icmpv6_with_rate_limit(b4fail_icmp, lwstate.o6)
+   transmit_icmpv6_with_rate_limit(lwstate.o6, b4fail_icmp)
 end
 
 -- Given a packet containing IPv4 and Ethernet, encapsulate the IPv4 portion.
@@ -311,8 +298,7 @@ local function ipv6_encapsulate(lwstate, pkt, next_hdr_type, ipv6_src, ipv6_dst,
          print("encapsulated packet:")
          lwdebug.print_pkt(pkt)
       end
-      guarded_transmit(pkt, lwstate.o6)
-      return
+      return transmit(lwstate.o6, pkt)
    end
 
    -- Otherwise, fragment if possible
@@ -336,8 +322,7 @@ local function ipv6_encapsulate(lwstate, pkt, next_hdr_type, ipv6_src, ipv6_dst,
                                               lwstate.aftr_ipv4_ip, dst_ip, pkt,
                                               lwstate.l2_size, icmp_config)
       packet.free(pkt)
-      guarded_transmit(icmp_pkt, lwstate.o4)
-      return
+      return transmit(lwstate.o4, icmp_pkt)
    end
 
    -- DF wasn't set; fragment the large packet
@@ -350,7 +335,7 @@ local function ipv6_encapsulate(lwstate, pkt, next_hdr_type, ipv6_src, ipv6_dst,
       end
    end
    for i=1,#pkts do
-      guarded_transmit(pkts[i], lwstate.o6)
+      transmit(lwstate.o6, pkts[i])
    end
 end
 
@@ -442,7 +427,7 @@ local function from_inet(lwstate, pkt)
             if lwstate.policy_icmpv4_outgoing == lwconf.policies["DROP"] then
                packet.free(maybe_pkt)
             else
-               guarded_transmit(maybe_pkt, lwstate.o4)
+               return transmit(lwstate.o4, maybe_pkt)
             end
          end
          return
@@ -498,8 +483,7 @@ local function from_inet(lwstate, pkt)
       local ttl0_icmp =  icmp.new_icmpv4_packet(lwstate.aftr_mac_inet_side, lwstate.inet_mac,
                                                 lwstate.aftr_ipv4_ip, dst_ip, pkt,
                                                 lwstate.l2_size, icmp_config)
-      guarded_transmit(ttl0_icmp, lwstate.o4)
-      return
+      return transmit(lwstate.o4, ttl0_icmp)
    end
 
    local next_hdr = proto_ipv4
@@ -591,7 +575,7 @@ local function icmpv6_incoming(lwstate, pkt)
       -- like notifications to any non-bound host.
       return icmpv4_incoming(lwstate, icmpv4_reply) -- to B4
    else
-      guarded_transmit(icmpv4_reply, lwstate.o4)
+      return transmit(lwstate.o4, icmpv4_reply)
    end
 end
 
@@ -642,7 +626,7 @@ local function from_b4(lwstate, pkt)
             if lwstate.policy_icmpv6_outgoing == lwconf.policies['DROP'] then
                packet.free(maybe_pkt)
             else
-               guarded_transmit(maybe_pkt, lwstate.o6)
+               return transmit(lwstate.o6, maybe_pkt)
             end
             return
          end
@@ -703,7 +687,7 @@ local function from_b4(lwstate, pkt)
             local fragstatus, frags = fragmentv4.fragment_ipv4(pkt, lwstate.l2_size, lwstate.ipv4_mtu)
             if fragstatus == fragmentv4.FRAGMENT_OK then
                for i=1,#frags do
-                  guarded_transmit(frags[i], lwstate.o4)
+                  transmit(lwstate.o4, frags[i])
                end
                return
             else
@@ -712,8 +696,7 @@ local function from_b4(lwstate, pkt)
                return
             end
          else -- No fragmentation needed
-            guarded_transmit(pkt, lwstate.o4)
-            return
+            return transmit(lwstate.o4, pkt)
          end
       end
    elseif lwstate.policy_icmpv6_outgoing == lwconf.policies['ALLOW'] then

--- a/src/apps/lwaftr/lwheader.lua
+++ b/src/apps/lwaftr/lwheader.lua
@@ -3,14 +3,12 @@ module(..., package.seeall)
 local constants = require("apps.lwaftr.constants")
 local ethernet = require("lib.protocol.ethernet")
 local ffi = require("ffi")
-local bit = require("bit")
 local ipv6 = require("lib.protocol.ipv6")
 local lib = require("core.lib")
 local lwutil = require("apps.lwaftr.lwutil")
 
 local cast = ffi.cast
 local bitfield = lib.bitfield
-local bor, lshift = bit.bor, bit.lshift
 local wr16, wr32 = lwutil.wr16, lwutil.wr32
 local htons, htonl = lwutil.htons, lwutil.htonl
 local ntohs, ntohl = htons, htonl
@@ -34,20 +32,14 @@ function write_eth_header(dst_ptr, ether_src, ether_dst, eth_type, vlan_tag)
    end
 end
 
-local function v_tc_fl(version, traffic_class, flow_label)
-   return htonl(bor(version,
-                    bor(lshift(traffic_class, 4),
-                        lshift(flow_label, 12))))
-end
-
-local ipv6_header_size = ffi.sizeof(ipv6._header_type)
-local default_ttl = constants.default_ttl
 function write_ipv6_header(dst_ptr, ipv6_src, ipv6_dst, dscp_and_ecn, next_hdr_type, payload_length)
    local ipv6_hdr = cast(ipv6._header_ptr_type, dst_ptr)
-   ipv6_hdr.v_tc_fl = v_tc_fl(6, dscp_and_ecn, 0)
+   ffi.fill(ipv6_hdr, ffi.sizeof(ipv6_hdr), 0)
+   bitfield(32, ipv6_hdr, 'v_tc_fl', 0, 4, 6)            -- IPv6 Version
+   bitfield(32, ipv6_hdr, 'v_tc_fl', 4, 8, dscp_and_ecn) -- Traffic class
    ipv6_hdr.payload_length = htons(payload_length)
    ipv6_hdr.next_header = next_hdr_type
-   ipv6_hdr.hop_limit = default_ttl
+   ipv6_hdr.hop_limit = constants.default_ttl
    ipv6_hdr.src_ip = ipv6_src
    ipv6_hdr.dst_ip = ipv6_dst
 end

--- a/src/apps/lwaftr/lwheader.lua
+++ b/src/apps/lwaftr/lwheader.lua
@@ -7,10 +7,11 @@ local ipv6 = require("lib.protocol.ipv6")
 local lib = require("core.lib")
 local lwutil = require("apps.lwaftr.lwutil")
 
-local C = ffi.C
 local cast = ffi.cast
 local bitfield = lib.bitfield
 local wr16, wr32 = lwutil.wr16, lwutil.wr32
+local htons, htonl = lwutil.htons, lwutil.htonl
+local ntohs, ntohl = htons, htonl
 
 -- Transitional header handling library.
 -- Over the longer term, something more lib.protocol-like has some nice advantages.
@@ -33,10 +34,10 @@ end
 
 function write_ipv6_header(dst_ptr, ipv6_src, ipv6_dst, dscp_and_ecn, next_hdr_type, payload_length)
    local ipv6_hdr = cast(ipv6._header_ptr_type, dst_ptr)
-   C.memset(ipv6_hdr, 0, ffi.sizeof(ipv6_hdr))
+   ffi.fill(ipv6_hdr, ffi.sizeof(ipv6_hdr), 0)
    bitfield(32, ipv6_hdr, 'v_tc_fl', 0, 4, 6)            -- IPv6 Version
    bitfield(32, ipv6_hdr, 'v_tc_fl', 4, 8, dscp_and_ecn) -- Traffic class
-   ipv6_hdr.payload_length = C.htons(payload_length)
+   ipv6_hdr.payload_length = htons(payload_length)
    ipv6_hdr.next_header = next_hdr_type
    ipv6_hdr.hop_limit = constants.default_ttl
    ipv6_hdr.src_ip = ipv6_src

--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -3,7 +3,7 @@ module(..., package.seeall)
 local bit = require("bit")
 local ffi = require("ffi")
 
-local band = bit.band
+local band, rshift, bswap = bit.band, bit.rshift, bit.bswap
 local cast = ffi.cast
 
 local uint16_ptr_t = ffi.typeof("uint16_t*")
@@ -31,6 +31,15 @@ end
 function wr32(offset, val)
    cast(uint32_ptr_t, offset)[0] = val
 end
+
+local to_uint32_buf = ffi.new('uint32_t[1]')
+local function to_uint32(x)
+   to_uint32_buf[0] = x
+   return to_uint32_buf[0]
+end
+
+function htons(s) return rshift(bswap(s), 16) end
+function htonl(s) return to_uint32(bswap(s)) end
 
 function keys(t)
    local result = {}

--- a/src/program/snabb_lwaftr/bench/bench.lua
+++ b/src/program/snabb_lwaftr/bench/bench.lua
@@ -4,6 +4,7 @@ local app = require("core.app")
 local basic_apps = require("apps.basic.basic_apps")
 local config = require("core.config")
 local lib = require("core.lib")
+local csv_stats  = require("lib.csv_stats")
 local pcap = require("apps.pcap.pcap")
 local lwaftr = require("apps.lwaftr.lwaftr")
 
@@ -34,21 +35,23 @@ function run(args)
    config.app(c, "repeaterv4", basic_apps.Repeater)
    config.app(c, "repeaterv6", basic_apps.Repeater)
    config.app(c, "lwaftr", lwaftr.LwAftr, conf_file)
-   config.app(c, "statisticsv4", basic_apps.Statistics)
-   config.app(c, "statisticsv6", basic_apps.Statistics)
    config.app(c, "sinkv4", basic_apps.Sink)
    config.app(c, "sinkv6", basic_apps.Sink)
 
    config.link(c, "capturev4.output -> repeaterv4.input")
    config.link(c, "repeaterv4.output -> lwaftr.v4")
-   config.link(c, "lwaftr.v4 -> statisticsv4.input")
-   config.link(c, "statisticsv4.output -> sinkv4.input")
+   config.link(c, "lwaftr.v4 -> sinkv4.input")
 
    config.link(c, "capturev6.output -> repeaterv6.input")
    config.link(c, "repeaterv6.output -> lwaftr.v6")
-   config.link(c, "lwaftr.v6 -> statisticsv6.input")
-   config.link(c, "statisticsv6.output -> sinkv6.input")
+   config.link(c, "lwaftr.v6 -> sinkv6.input")
 
    app.configure(c)
+
+   local csv = csv_stats.CSVStatsTimer.new()
+   csv:add_app('sinkv4', { 'input' }, { input='Encapsulation' })
+   csv:add_app('sinkv6', { 'input' }, { input='Decapsulation' })
+   csv:activate()
+
    app.main({duration=opts.duration})
 end


### PR DESCRIPTION
This changes so that the PSID map covers only the configured addresses.  Also it switches to LuaJIT htons/htonl implementations.  The speedup is from

```
statisticsv6: 3.395 MPPS, 16.023 Gbps.
statisticsv4: 3.395 MPPS, 13.850 Gbps.
```

to

```
statisticsv6: 3.581 MPPS, 16.902 Gbps.
statisticsv4: 3.581 MPPS, 14.610 Gbps.
```