### PR TITLE
Port #194 to lwaftr_rambutan

### DIFF
--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -220,15 +220,8 @@ end
 -- Return true if the destination ipv4 address is within our managed set of addresses
 local function ipv4_dst_in_binding_table(lwstate, pkt, pre_ipv4_bytes)
    local dst_ip_start = pre_ipv4_bytes + 16
-   local dst_port_start = pre_ipv4_bytes + get_ihl_from_offset(pkt, pre_ipv4_bytes) + 2
-
-   -- FIXME: we should be able to look in the address map for this and
-   -- avoid going through the binding table.
-
-   -- network byte order ip, regardless of host byte order
-   local ip = rd32(pkt.data + dst_ip_start)
-   local port = C.ntohs(rd16(pkt.data + dst_port_start))
-   return binding_lookup_ipv4(lwstate, ip, port) ~= nil
+   local host_endian_ipv4 = C.htonl(rd32(pkt.data + dst_ip_start))
+   return lwstate.binding_table:is_managed_ipv4_address(host_endian_ipv4)
 end
 
 local uint64_ptr_t = ffi.typeof('uint64_t*')

--- a/src/apps/lwaftr/lwheader.lua
+++ b/src/apps/lwaftr/lwheader.lua
@@ -8,12 +8,13 @@ local lib = require("core.lib")
 local lwutil = require("apps.lwaftr.lwutil")
 local lwtypes = require("apps.lwaftr.lwtypes")
 
-local C = ffi.C
 local cast = ffi.cast
 local bitfield = lib.bitfield
 local wr16, wr32 = lwutil.wr16, lwutil.wr32
 local ethernet_header_ptr_type = lwtypes.ethernet_header_ptr_type
 local ipv6_header_ptr_type = lwtypes.ipv6_header_ptr_type
+local htons, htonl = lwutil.htons, lwutil.htonl
+local ntohs, ntohl = htons, htonl
 
 -- Transitional header handling library.
 -- Over the longer term, something more lib.protocol-like has some nice advantages.
@@ -36,10 +37,10 @@ end
 
 function write_ipv6_header(dst_ptr, ipv6_src, ipv6_dst, dscp_and_ecn, next_hdr_type, payload_length)
    local ipv6_hdr = cast(ipv6_header_ptr_type, dst_ptr)
-   C.memset(ipv6_hdr, 0, ffi.sizeof(ipv6_hdr))
+   ffi.fill(ipv6_hdr, ffi.sizeof(ipv6_hdr), 0)
    bitfield(32, ipv6_hdr, 'v_tc_fl', 0, 4, 6)            -- IPv6 Version
    bitfield(32, ipv6_hdr, 'v_tc_fl', 4, 8, dscp_and_ecn) -- Traffic class
-   ipv6_hdr.payload_length = C.htons(payload_length)
+   ipv6_hdr.payload_length = htons(payload_length)
    ipv6_hdr.next_header = next_hdr_type
    ipv6_hdr.hop_limit = constants.default_ttl
    ipv6_hdr.src_ip = ipv6_src

--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -3,7 +3,7 @@ module(..., package.seeall)
 local bit = require("bit")
 local ffi = require("ffi")
 
-local band = bit.band
+local band, rshift, bswap = bit.band, bit.rshift, bit.bswap
 local cast = ffi.cast
 
 local uint16_ptr_t = ffi.typeof("uint16_t*")
@@ -31,6 +31,15 @@ end
 function wr32(offset, val)
    cast(uint32_ptr_t, offset)[0] = val
 end
+
+local to_uint32_buf = ffi.new('uint32_t[1]')
+local function to_uint32(x)
+   to_uint32_buf[0] = x
+   return to_uint32_buf[0]
+end
+
+function htons(s) return rshift(bswap(s), 16) end
+function htonl(s) return to_uint32(bswap(s)) end
 
 function keys(t)
    local result = {}

--- a/src/program/snabb_lwaftr/bench/bench.lua
+++ b/src/program/snabb_lwaftr/bench/bench.lua
@@ -4,6 +4,7 @@ local app = require("core.app")
 local basic_apps = require("apps.basic.basic_apps")
 local config = require("core.config")
 local lib = require("core.lib")
+local csv_stats  = require("lib.csv_stats")
 local pcap = require("apps.pcap.pcap")
 local lwaftr = require("apps.lwaftr.lwaftr")
 
@@ -34,21 +35,23 @@ function run(args)
    config.app(c, "repeaterv4", basic_apps.Repeater)
    config.app(c, "repeaterv6", basic_apps.Repeater)
    config.app(c, "lwaftr", lwaftr.LwAftr, conf_file)
-   config.app(c, "statisticsv4", basic_apps.Statistics)
-   config.app(c, "statisticsv6", basic_apps.Statistics)
    config.app(c, "sinkv4", basic_apps.Sink)
    config.app(c, "sinkv6", basic_apps.Sink)
 
    config.link(c, "capturev4.output -> repeaterv4.input")
    config.link(c, "repeaterv4.output -> lwaftr.v4")
-   config.link(c, "lwaftr.v4 -> statisticsv4.input")
-   config.link(c, "statisticsv4.output -> sinkv4.input")
+   config.link(c, "lwaftr.v4 -> sinkv4.input")
 
    config.link(c, "capturev6.output -> repeaterv6.input")
    config.link(c, "repeaterv6.output -> lwaftr.v6")
-   config.link(c, "lwaftr.v6 -> statisticsv6.input")
-   config.link(c, "statisticsv6.output -> sinkv6.input")
+   config.link(c, "lwaftr.v6 -> sinkv6.input")
 
    app.configure(c)
+
+   local csv = csv_stats.CSVStatsTimer.new()
+   csv:add_app('sinkv4', { 'input' }, { input='Encapsulation' })
+   csv:add_app('sinkv6', { 'input' }, { input='Decapsulation' })
+   csv:activate()
+
    app.main({duration=opts.duration})
 end


### PR DESCRIPTION
A port of https://github.com/Igalia/snabbswitch/pull/194.  I elided the one commit that was added then reverted.

Irritatingly, https://github.com/Igalia/snabbswitch/commit/0a6fbb2b3b0a6989e234a064f4e692eabb7b330c failed to port correctly; all the tail calls started to trigger some kind of loop unrolling thing that made LuaJIT have a cow and blacklist the lwaftr loop, tanking throughput to under 1 Gbps.  The fix is on line 301 in lwaftr, to not change it to a tail call.  I guess it's a warning that we're playing with fire.
