### PR TITLE
Lwaftr refactorings

### DIFF
--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -177,12 +177,6 @@ local function decrement_ttl(pkt)
    return new_ttl
 end
 
-local function get_lwAFTR_ipv6(lwstate, binding_entry)
-   local lwaftr_ipv6 = binding_entry[4]
-   if not lwaftr_ipv6 then lwaftr_ipv6 = lwstate.aftr_ipv6_ip end
-   return lwaftr_ipv6
-end
-
 local function binding_lookup_ipv4(lwstate, ipv4_ip, port)
    if debug then
       print(lwdebug.format_ipv4(ipv4_ip), 'port: ', port, string.format("%x", port))


### PR DESCRIPTION
Cc @kbara for reiew on this one.  See the individual commits and commit notes for best explanations.

So, I don't know which one of these patches pushes us over the limit, but as we saw in #196, I get terrible perf sometimes with this one.  The reason is lots of unroll errors in the trace, culminating in a blacklist:

```
[TRACE 126 app.lua:236 -> 93]
[TRACE --- lwaftr.lua:415 -- loop unroll limit reached at lib.lua:361]
[TRACE --- lwutil.lua:41 -- leaving loop in root trace at lwaftr.lua:433]
[TRACE --- lwaftr.lua:102 -- blacklisted at lwutil.lua:41]
```

The real reason is that tail calls in LuaJIT count towards the loop unrolling limit.  Do more than 15 tail calls in a loop and you run afoul of this hazard!  It turns out to be quite easy to do.  If I comment out this bit in lj_record.c:

```
  /* Note: the new TREF_FRAME is now at J->base[-1] (even for slot #0). */
  /* Tailcalls can form a loop, so count towards the loop unroll limit. */
  if (++J->tailcalled > J->loopunroll)
    lj_trace_err(J, LJ_TRERR_LUNROLL);
```

then the perf is fine.  However I didn't see these errors on olive -- I suspect that something changed in Snabb between the olive and rambutan releases that in total is pushing us over the limit.  Quite silly.  Cc @lukego because I think he'll be amused (no action needed).  I think for our upcoming milestone, knowing that we don't loop via tail calls, it would be OK to comment out these lines in our LuaJIT, to remove this hazard.