### PR TITLE
Fix snabb-lwaftr `run`

### DIFF
--- a/src/program/snabb_lwaftr/run/run.lua
+++ b/src/program/snabb_lwaftr/run/run.lua
@@ -2,14 +2,8 @@ module(..., package.seeall)
 
 local S          = require("syscall")
 local config     = require("core.config")
-local lib        = require("core.lib")
 local csv_stats  = require("lib.csv_stats")
-local ethernet   = require("lib.protocol.ethernet")
-local Intel82599 = require("apps.intel.intel_app").Intel82599
-local basic_apps = require("apps.basic.basic_apps")
-local lwaftr     = require("apps.lwaftr.lwaftr")
-local ipv4_apps  = require("apps.lwaftr.ipv4_apps")
-local ipv6_apps  = require("apps.lwaftr.ipv6_apps")
+local lib        = require("core.lib")
 local setup      = require("program.snabb_lwaftr.setup")
 
 local function show_usage(exit_code)
@@ -84,8 +78,10 @@ end
 
 function run(args)
    local opts, conf_file, v4_pci, v6_pci = parse_args(args)
+   local conf = require('apps.lwaftr.conf').load_lwaftr_config(conf_file)
 
-   local c = setup.load(conf_file, 'inetNic', v4_pci, 'b4sideNic', v6_pci)
+   local c = config.new()
+   setup.load_phy(c, conf, 'inetNic', v4_pci, 'b4sideNic', v6_pci)
 
    engine.configure(c)
 

--- a/src/program/snabb_lwaftr/setup.lua
+++ b/src/program/snabb_lwaftr/setup.lua
@@ -8,6 +8,7 @@ local pcap       = require("apps.pcap.pcap")
 local ipv4_apps  = require("apps.lwaftr.ipv4_apps")
 local ipv6_apps  = require("apps.lwaftr.ipv6_apps")
 local vlan       = require("apps.lwaftr.vlan")
+local ethernet   = require("lib.protocol.ethernet")
 
 function lwaftr_app(c, conf)
    assert(type(conf) == 'table')


### PR DESCRIPTION
It seems run command was broken after the last refactoring.

There's not such function as load in setup.lua (I think is meant to use load_phy) and ethernet library was missing too. Removed unnecessary headers in run,lua.
