### PR TITLE
Add support for running `snabb-lwaftr run` with virtio_net drivers

### DIFF
--- a/src/program/snabb_lwaftr/run/run.lua
+++ b/src/program/snabb_lwaftr/run/run.lua
@@ -39,6 +39,7 @@ function parse_args(args)
    local opts = { verbosity = 0 }
    local handlers = {}
    function handlers.v () opts.verbosity = opts.verbosity + 1 end
+   function handlers.i () opts.virtio_net = true end
    function handlers.D (arg)
       opts.duration = assert(tonumber(arg), "duration must be a number")
    end
@@ -70,9 +71,10 @@ function parse_args(args)
       end
    end
    function handlers.h() show_usage(0) end
-   lib.dogetopt(args, handlers, "b:c:n:m:vD:h",
+   lib.dogetopt(args, handlers, "b:c:n:m:vD:hi",
       { conf = "c", ["v4-pci"] = "n", ["v6-pci"] = "m",
-        verbose = "v", duration = "D", help = "h" })
+        verbose = "v", duration = "D", help = "h",
+        virtio = "i" })
    return opts, conf_file, v4_pci, v6_pci
 end
 
@@ -81,8 +83,11 @@ function run(args)
    local conf = require('apps.lwaftr.conf').load_lwaftr_config(conf_file)
 
    local c = config.new()
-   setup.load_phy(c, conf, 'inetNic', v4_pci, 'b4sideNic', v6_pci)
-
+   if opts.virtio_net then
+      setup.load_virt(c, conf, 'inetNic', v4_pci, 'b4sideNic', v6_pci)
+   else
+      setup.load_phy(c, conf, 'inetNic', v4_pci, 'b4sideNic', v6_pci)
+   end
    engine.configure(c)
 
    if opts.verbosity >= 2 then

--- a/src/program/snabb_lwaftr/setup.lua
+++ b/src/program/snabb_lwaftr/setup.lua
@@ -2,6 +2,7 @@ module(..., package.seeall)
 
 local config     = require("core.config")
 local Intel82599 = require("apps.intel.intel_app").Intel82599
+local VirtioNet  = require("apps.virtio_net.virtio_net").VirtioNet
 local lwaftr     = require("apps.lwaftr.lwaftr")
 local basic_apps = require("apps.basic.basic_apps")
 local pcap       = require("apps.pcap.pcap")
@@ -45,6 +46,22 @@ function load_phy(c, conf, v4_nic_name, v4_nic_pci, v6_nic_name, v6_nic_pci)
       vlan=conf.vlan_tagging and conf.v4_vlan_tag,
       macaddr=ethernet:ntop(conf.aftr_mac_inet_side)})
    config.app(c, v6_nic_name, Intel82599, {
+      pciaddr=v6_nic_pci,
+      vlan=conf.vlan_tagging and conf.v4_vlan_tag,
+      macaddr = ethernet:ntop(conf.aftr_mac_b4_side)})
+
+   link_source(c, v4_nic_name..'.tx', v6_nic_name..'.tx')
+   link_sink(c, v4_nic_name..'.rx', v6_nic_name..'.rx')
+end
+
+function load_virt(c, conf, v4_nic_name, v4_nic_pci, v6_nic_name, v6_nic_pci)
+   lwaftr_app(c, conf)
+
+   config.app(c, v4_nic_name, VirtioNet, {
+      pciaddr=v4_nic_pci,
+      vlan=conf.vlan_tagging and conf.v4_vlan_tag,
+      macaddr=ethernet:ntop(conf.aftr_mac_inet_side)})
+   config.app(c, v6_nic_name, VirtioNet, {
       pciaddr=v6_nic_pci,
       vlan=conf.vlan_tagging and conf.v4_vlan_tag,
       macaddr = ethernet:ntop(conf.aftr_mac_b4_side)})


### PR DESCRIPTION
Ditto. Running `snabb-lwaftr run` using virtio_net requires to pass flag --virtio_net or -i (next letter after 'v', as it was already taken by verbosity). Example:

```
sudo ./snabb-lwaftr run -v -i --conf program/snabb_lwaftr/tests/data/icmp_on_fail.conf \
   --v4-pci 0000:00:08.0 --v6-pci 0000:00:09.0
```

This PR depends on #202, it should be merged after it.
