### PR TITLE
Fix variable 'bt' is not declared

### DIFF
--- a/src/program/snabb_lwaftr/compile_binding_table/compile_binding_table.lua
+++ b/src/program/snabb_lwaftr/compile_binding_table/compile_binding_table.lua
@@ -27,6 +27,6 @@ function run(args)
       io.stderr:write(tostring(bt_or_err)..'\n')
       main.exit(1)
    end
-   bt:save(out_file, stream.mtime_sec, stream.mtime_nsec)
+   bt_or_err:save(out_file, stream.mtime_sec, stream.mtime_nsec)
    main.exit(0)
 end


### PR DESCRIPTION
Compiled table saving fails as it tries to execute `bt:save`. Compiled binding table is named as `bt_or_err`.