### PR TITLE
Drain input

### DIFF
--- a/src/apps/lwaftr/ipv4_apps.lua
+++ b/src/apps/lwaftr/ipv4_apps.lua
@@ -118,7 +118,7 @@ function Fragmenter:push ()
    local l2_size, mtu = self.l2_size, self.mtu
    local ethertype_offset = self.ethertype_offset
 
-   for _=1,math.min(link.nreadable(input), link.nwritable(output)) do
+   for _=1,link.nreadable(input) do
       local pkt = receive(input)
       if pkt.length > mtu + l2_size and is_ipv4(pkt, ethertype_offset) then
          local status, frags = fragmentv4.fragment(pkt, l2_size, mtu)

--- a/src/apps/lwaftr/ipv6_apps.lua
+++ b/src/apps/lwaftr/ipv6_apps.lua
@@ -80,7 +80,7 @@ function Reassembler:push ()
    local l2_size = self.l2_size
    local ethertype_offset = self.ethertype_offset
 
-   for _=1,math.min(link.nreadable(input), link.nwritable(output)) do
+   for _=1,link.nreadable(input) do
       local pkt = receive(input)
       if is_ipv6(pkt, ethertype_offset) and is_fragment(pkt, l2_size) then
          local frags = self:cache_fragment(pkt)
@@ -128,7 +128,7 @@ function Fragmenter:push ()
    local l2_size, mtu = self.l2_size, self.mtu
    local ethertype_offset = self.ethertype_offset
 
-   for _=1,math.min(link.nreadable(input), link.nwritable(output)) do
+   for _=1,link.nreadable(input) do
       local pkt = receive(input)
       if pkt.length > mtu + l2_size and is_ipv6(pkt, ethertype_offset) then
          -- It's possible that the IPv6 packet has an IPv4 packet as

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -145,7 +145,7 @@ local function get_icmp_payload(ptr)
 end
 
 local function drop(pkt)
-   pkt.free(pkt)
+   packet.free(pkt)
 end
 
 local transmit_icmpv6_with_rate_limit

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -599,18 +599,7 @@ function LwAftr:push ()
    local o4, o6 = self.output.v4, self.output.v6
    self.o4, self.o6 = o4, o6
 
-   -- If we are really slammed and can't keep up, packets are going to
-   -- drop one way or another.  The nwritable() check is just to prevent
-   -- us from burning the CPU on packets that we're pretty sure would be
-   -- dropped anyway, so that when we're in an overload situation things
-   -- don't get worse as the traffic goes up.  It's not a fool-proof
-   -- check that we in fact will be able to successfully handle the
-   -- packet, given that the packet might require fragmentation,
-   -- hairpinning, or ICMP error messages, all of which might result in
-   -- transmission of packets on the "other" interface or multiple
-   -- packets on the "right" interface.
-
-   for _=1,math.min(link.nreadable(i4), link.nwritable(o6)) do
+   for _=1,link.nreadable(i4) do
       -- Encapsulate incoming IPv4 packets from the internet interface.
       -- Drop anything that's not IPv4.
       local pkt = receive(i4)
@@ -621,7 +610,7 @@ function LwAftr:push ()
       end
    end
 
-   for _=1,math.min(link.nreadable(i6), link.nwritable(o4)) do
+   for _=1,link.nreadable(i6) do
       -- Decapsulate or hairpin incoming IPv6 packets from the B4
       -- interface.  Drop anything that's not IPv6.
       local pkt = receive(i6)

--- a/src/apps/lwaftr/vlan.lua
+++ b/src/apps/lwaftr/vlan.lua
@@ -29,7 +29,7 @@ end
 function Tagger:push ()
    local input, output = self.input.input, self.output.output
    local tag = self.tag
-   for _=1,math.min(link.nreadable(input), link.nwritable(output)) do
+   for _=1,link.nreadable(input) do
       local pkt = receive(input)
       local payload = pkt.data + o_ethernet_ethertype
       local length = pkt.length
@@ -49,7 +49,7 @@ end
 function Untagger:push ()
    local input, output = self.input.input, self.output.output
    local tag = self.tag
-   for _=1,math.min(link.nreadable(input), link.nwritable(output)) do
+   for _=1,link.nreadable(input) do
       local pkt = receive(input)
       local payload = pkt.data + o_ethernet_ethertype
       if cast(uint32_ptr_t, payload)[0] ~= tag then


### PR DESCRIPTION
Fix a bug introduced by a previous merge.  Also, always drain input.