### PR TITLE
Changed handling of fragmentation status.

### DIFF
--- a/src/apps/lwaftr/ipv4_apps.lua
+++ b/src/apps/lwaftr/ipv4_apps.lua
@@ -80,12 +80,13 @@ function Reassembler:push ()
             transmit(output, maybe_pkt)
          elseif status == fragmentv4.REASSEMBLE_MISSING_FRAGMENT then
             -- Nothing to do, just wait.
-         else
-            assert(frag_status == fragmentv4.REASSEMBLE_INVALID)
+         elseif status == fragmentv4.REASSEMBLE_INVALID then
             self:clean_fragment_cache(frags)
             if maybe_pkt then -- This is an ICMP packet
                transmit(errors, maybe_pkt)
             end
+         else -- unreachable
+            packet.free(pkt)
          end
       else
          -- Forward all packets that aren't IPv4 fragments.

--- a/src/apps/lwaftr/ipv6_apps.lua
+++ b/src/apps/lwaftr/ipv6_apps.lua
@@ -93,12 +93,13 @@ function Reassembler:push ()
             transmit(output, maybe_pkt)
          elseif status == fragmentv6.FRAGMENT_MISSING then
             -- Nothing useful to be done yet
-         else
-            assert(frag_status == fragmentv6.REASSEMBLY_INVALID)
+         elseif status == fragmentv6.REASSEMBLY_INVALID then
             self:clean_fragment_cache(frags)
             if maybe_pkt then -- This is an ICMP packet
                transmit(errors, maybe_pkt)
             end
+         else -- unreachable
+            packet.free(pkt)
          end
       else
          -- Forward all packets that aren't IPv6 fragments.


### PR DESCRIPTION
There were two problems:
a) The non-existent variable frag_status was used
b) There was an assert. That is unacceptable in this context, even in
   unreachable code.