### PR TITLE
Add script lwaftrctl

### DIFF
--- a/src/program/lwaftr/doc/README.virtualization.md
+++ b/src/program/lwaftr/doc/README.virtualization.md
@@ -5,83 +5,193 @@
 Currently, SnabbSwitch works on the 'host' (bare metal) and uses a driver called
 **VhostUser** (See `apps/vhost/vhost_user.lua`) to bypass several things: the
 typical linux bridge used in VMs, the tun/tap device, the QEMU device emulator
-and the host kernel vhost-net handler. That way, the SnabbSwitch process gets
+and the host kernel vhost-net handler.  That way, the SnabbSwitch process gets
 access to the very same memory pages presented to the virtio device in the VM.
 
 However the implementation of Snabb Switch running within a VM can be still
-further improved. The current approach assumes the VM would run third-party
+further improved.  The current approach assumes the VM would run third-party
 applications that use TCP/UDP endpoints given by a stock OS, and with a
 virtio-net driver that interacts with the virtio device by attaching buffers to
-the virtqueues. With the VhostUser driver mentioned above just behind the
+the virtqueues.  With the VhostUser driver mentioned above just behind the
 guest/host frontier, we can basically negate the virtualization overhead.
 
 The lwAFTR application is packet-based, so there's no value in using TCP
-streams provided by the Guest OS.  We can use the RawSocket to push/pull
+streams provided by the guest OS.  We can use the RawSocket to push/pull
 packets directly from any existing ethernet interface, including the virtio-net
- guest driver. But this still passes through the guest kernel to queue and
+ guest driver.  But this still passes through the guest kernel to queue and
 prioritize the packets, and through the virtio-net driver to actually put them
-in the virtqueues. At multi-million-packets-per-second, the context switching
+in the virtqueues.  At multi-million-packets-per-second, the context switching
 is noticeable.
 
-To really avoid user/kernel context switches in the guest, it is necessary to
-drive the virtqueues ourselves.
-
-## The Vguest driver
+To be able to obtain the maximum performance running the lwAFTR inside a VM,  it
+ is necessary to run it paravirtualized using the 'vguest' driver.
 
 The 'vguest' driver implements a virtio-net guest driver, replacing in
-userspace both virtio-net and virtio-pci. For that, it handles the emulated
+userspace both virtio-net and virtio-pci.  For that, it handles the emulated
 PCI bus device to get hold of the virtqueues, that allow communication with
 the outer world.
 
-The design is at this point pretty much solid and unlikely to change. There is
-a virtqueue object, a 'device' that initializes it and sets up the virtqueues,
-and the 'app' that implements the 'push/pull' methods. See `src/apps/vguest`.
+# How to run lwAFTR inside a VM
 
-## Example of use
+The script `program/lwaftr/virt/lwaftrctl` eases the process of launching a 
+virtualized lwAFTR.  The script provides a series of commands and actions to start
+and stop a VM and the lwAFTR inside of it from a host.
 
-The development of the Vguest driver is still work in progress, but the approach
-has been proved successful. The driver contains a test app that basically sends
-packets from the guest to the host side. It's possible to observe packets arriving
-on the host using tcpdump.
+## Settings
 
-In order to run the selftest, it is necessary to prepare a Linux OS image and launch
-it with QEMU:
+In order to run successfully, the `lwaftrctl` script needs a configuration with all
+its parameters.  Use `program/lwaftr/virt/conf/lwaftrctl1.conf` as a reference 
+for such configuration file.
 
-```
-#!/bin/bash
-img=vma.img
+## Steps
 
-sudo qemu-system-x86_64 \
-     -kernel vmlinuz \
-     -append "earlyprintk root=/dev/vda rw console=tty0 console=ttyS0
-intel_iommu=on" \
-     -m 1024 -machine type=q35,iommu=on \
-     -smp 1 -cpu host --enable-kvm -serial stdio \
-     -drive if=virtio,file=$img -curses \
-     -netdev type=bridge,id=netuser0,br=virbr0 \
-     -device virtio-net-pci,netdev=netuser0 \
-     -netdev type=tap,id=netuser1 \
-     -device virtio-net-pci,netdev=netuser1
-```
+### Start SnabbNFV
 
-In our case, `vma.img` contains a simple Ubuntu 14.04 system with a copy of
-SnabbSwitch. The VM has two ethernet interfaces:
-
-- **eth0** to communicate with the host system
-- **eth1** to communicate with SnabbSwitch.
-
-
-To run the selftest:
+The snabbnfv command will take two NICs and make them available to QEMU.  Basically,
+the snabbnfv command makes the NIC to be handle with the Vhost-User driver.  Each
+NIC will be a handled by a single core.
 
 ```
-./snabb snsh -t apps.vguest.vguest_app
+$ ./lwaftrctl snabbnfv start
+
+Start snabbnfv (screen: 'snabbnfv-1') at core 1 (pci: 0000:02:00.0; conf: 
+  /.../src/program/lwaftr/virt/ports/lwaftr1/a.cfg}; socket: /tmp/vh1a.sock)
+Start snabbnfv (screen: 'snabbnfv-2') at core 2 (pci: 0000:02:00.1; conf: 
+  /.../src/program/lwaftr/virt/ports/lwaftr1/b.cfg}; socket: /tmp/vh1b.sock)
 ```
 
-And see packets out on the host's tap1 (with tcpdump).
+A SnabbNFV process needs three parameters: config file, PCI and socket file.
+  These parameters are taken from the `lwaftrctl.conf` file.  See SnabbNFV 
+documentation for more information about these parameters.
 
-## Current status
+The SnabbNFV processes are running each of them in a _screen_.  The _screens_ 
+as:
 
-It does handle guest-to-host traffic very well, but incoming traffic is still
-work in progress. The default virtio device has little virtqueue rings and
-a light trigger for interrupts. That doesn't play well with the QEMU-KVM, which
-occasionally terminates abruptly.
+```
+$ screen -ls
+There are screens on:
+    14888.snabbnfv-1    (Detached)
+    14891.snabbnfv-2    (Detached)
+2 Sockets in /tmp/uscreens/S-dpino.
+```
+
+It is possible to connect to _screen_ running:
+
+```
+$ screen -r 14888.snabbnfv-1
+load: time: 1.00s  fps: 0         fpGbps: 0.000 fpb: 0   bpp: -    sleep: 100 us
+load: time: 1.00s  fps: 0         fpGbps: 0.000 fpb: 0   bpp: -    sleep: 100 us
+load: time: 1.00s  fps: 0         fpGbps: 0.000 fpb: 0   bpp: -    sleep: 100 us
+```
+
+Press Ctrl-A + Ctrl-D to deattach from the current screen.
+
+### Start VM
+
+Once SnabbNFV is running it will possible to launch the VM with QEMU.
+
+```
+$ ./lwaftrctl vm start
+Starting QEMU. Please wait...
+QEMU waiting for connection on: disconnected:unix:/tmp/vh1a.sock,server
+QEMU waiting for connection on: disconnected:unix:/tmp/vh1b.sock,server
+qemu-system-x86_64: -netdev type=vhost-user,id=net0,chardev=char1: chardev "char1" went up
+qemu-system-x86_64: -netdev type=vhost-user,id=net1,chardev=char2: chardev "char2" went up
+pid 14913's current affinity list: 0,6
+pid 14913's new affinity list: 0
+pid 14914's current affinity list: 0,6
+pid 14914's new affinity list: 0
+pid 14931's current affinity list: 0,6
+pid 14931's new affinity list: 0
+pid 14932's current affinity list: 0,6
+pid 14932's new affinity list: 0
+pid 14934's current affinity list: 0,6
+pid 14934's new affinity list: 0
+Pinned QEMU to core 0
+```
+
+See `confs/lwaftrctl1.conf` for the parameters related with the VM settings.  
+It expects to be able to connect to the VM with user `igalia` at 10.21.21.2.
+You will need to have a user already created inside the VM as well as a network
+interface correctly configured.  Example of `/etc/network/interfaces` inside the
+guest:
+
+```
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+auto eth2
+iface eth2 inet static
+        address 10.21.21.2
+        netmask 255.255.255.0
+        gateway 10.21.21.1
+```
+
+The `lwaftrctl vm` commands makes a pause of 30 seconds, after that it pins QEMU
+and all its child process to a core.
+
+# Start lwAFTR in a guest
+
+It is possible to automatically start the lwAFTR inside the guest from the host:
+
+```
+lwaftrctl lwaftr start
+```
+
+Alternatively, it is possible to log into the VM and start the lwAFTR manually.
+
+Under the current setup, the source code of the lwAFTR lives in the host.  It is
+located at `~/workspace/snabb_guest`.  The code is available inside the guest 
+through a mounting point setup when QEMU is launched:
+
+```
+-fsdev local,security_model=passthrough,id=fsdev0,path=${SHARED_LOCATION} \
+  -device virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=share \
+```
+
+What the `lwaftrctl lwaftr start` command does is actually log into the VM with
+VM_USER and execute the script `~/run_lwaftr`.  This script must contains the
+inscrutions necessary to run the lwAFTR in the guest.  Basically, just copy 
+`program/lwaftr/virt/run_lwaftr.sh.example` into your HOME folder in the VM
+and rename it as `run_lwaftr.sh`.
+
+If you guest and host use different architectures or operating systems,  you must
+log into the guest and build the lwAFTR code.  Using the current settings as 
+example:
+
+```
+$ ssh igalia@10.21.21.2
+$ cd /mnt/host/snabb_guest/
+$ sudo make clean
+$ sudo make -C /mnt/host/snabb_guest/
+```
+
+The `lwaftrctl lwaftr start` command also launches a process inside a screen to
+which is possible to attach.
+
+```
+igalia@testsystem:~$ screen -ls
+There is a screen on:
+    1331.lwaftr (02/09/2016 06:59:36 PM)    (Detached)
+1 Socket in /var/run/screen/S-igalia.
+```
+
+Attach to this screen to see the RX/TX statistics of the runnign lwAFTR process.
+
+```
+
+# Stop lwAFTR in a guest
+
+All the listed command so far can take a `stop` action that will stop them running.
+There is also a `restart` action that will stop a command and start it again.
+
+As the lwAFTR is started running `snabbnfv`, `vm` and `lwaftr` commands one after
+another, the whole process should be stopped in inverse order, that is:  `lwaftr`,
+`vm` and `snabbnfv`.
+
+There is a special command, called `all` that will do the whole process in one step.

--- a/src/program/lwaftr/virt/confs/lwaftrctl1.conf
+++ b/src/program/lwaftr/virt/confs/lwaftrctl1.conf
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# General
+
+SNABB_HOST_PATH=~/workspace/snabb_host
+SNABB_HOST_LWAFTR=$SNABB_HOST_PATH/src/program/snabb_lwaftr
+
+# QEMU
+
+NAME=lwaftr1
+DISK=~/vm/vm_lwaftr1.qcow2
+MEM=1024M
+
+IFACE=mgmt0
+NETSCRIPT=$SNABB_HOST_LWAFTR/virt/setup_networks/lwaftr1.sh
+
+SHARED_LOCATION=~/workspace
+VHU_SOCK1=/tmp/vh1a.sock
+VHU_SOCK2=/tmp/vh1b.sock
+VNC_DISPLAY=22
+
+# VM
+
+QEMU_CORE=0
+VM_DIR=~/vm
+VM_IP=10.21.21.2
+VM_USER=igalia   # Must be in the list of sudoers        
+
+# Guest
+
+SNABB_GUEST_PATH=/mnt/host/snabb_guest/src
+
+# SnabbNFV
+
+SNABBNFV_CORE1=1
+SNABBNFV_CONF1=$SNABB_HOST_LWAFTR/virt/ports/lwaftr1/a.cfg
+SNABBNFV_PCI1=0000:02:00.0
+
+SNABBNFV_CORE2=2
+SNABBNFV_CONF2=$SNABB_HOST_LWAFTR/virt/ports/lwaftr1/b.cfg
+SNABBNFV_PCI2=0000:02:00.1

--- a/src/program/lwaftr/virt/confs/lwaftrctl1.conf
+++ b/src/program/lwaftr/virt/confs/lwaftrctl1.conf
@@ -3,7 +3,7 @@
 # General
 
 SNABB_HOST_PATH=~/workspace/snabb_host
-SNABB_HOST_LWAFTR=$SNABB_HOST_PATH/src/program/snabb_lwaftr
+SNABB_HOST_LWAFTR=$SNABB_HOST_PATH/src/program/lwaftr
 
 # QEMU
 

--- a/src/program/lwaftr/virt/lwaftrctl
+++ b/src/program/lwaftr/virt/lwaftrctl
@@ -8,24 +8,24 @@
 # * lwaftrctl vm       start|stop. Starts or stops virtual machine
 # * lwaftrctl lwaftr   start|stop. Starts or stops lwaftr inside virtual machine.
 #
-# A configuration file named 'lwaftrctl.conf' must exist in the current 
-# directory. This file contains all the variable definitions needed to run the 
+# A configuration file named 'lwaftrctl.conf' must exist in the current
+# directory. This file contains all the variable definitions needed to run the
 # available commands. See 'lwaftrctl.conf.example'.
 #
 # The usual workflow to run the script would be the following:
 #
-# * lwaftrctl snabbnfv start. 
+# * lwaftrctl snabbnfv start.
 #       Brings up NICs in host that will be used by virtual machine.
 #
-# * lwaftrctl vm start. 
-#       Brings up VM. After this step it should be possible to log into 
+# * lwaftrctl vm start.
+#       Brings up VM. After this step it should be possible to log into
 #       the VM: ssh igalia@10.21.21.2.
 #
 # * lwaftrctl lwaftr start.
-#       Starts lwaftr inside VM. This commands logs into VM and runs file 
+#       Starts lwaftr inside VM. This commands logs into VM and runs file
 #       "~/run_lwaftr.sh". See run_lwaftr.sh.example.
 #
-# Once the lwaftr is running within the VM, run 'snabb_lwaftr transient' from 
+# Once the lwaftr is running within the VM, run 'lwaftr transient' from
 # host to check everything is working fine.
 #
 # The command 'lwaftrctl all start', run all the steps above.

--- a/src/program/lwaftr/virt/lwaftrctl
+++ b/src/program/lwaftr/virt/lwaftrctl
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+
+# Eases deployment of lwaftr inside a virtual machine.
+#
+# The scripts enables several commands:
+#
+# * lwaftrctl snabbnfv start|stop. Starts or stops snabbnfv.
+# * lwaftrctl vm       start|stop. Starts or stops virtual machine
+# * lwaftrctl lwaftr   start|stop. Starts or stops lwaftr inside virtual machine.
+#
+# A configuration file named 'lwaftrctl.conf' must exist in the current 
+# directory. This file contains all the variable definitions needed to run the 
+# available commands. See 'lwaftrctl.conf.example'.
+#
+# The usual workflow to run the script would be the following:
+#
+# * lwaftrctl snabbnfv start. 
+#       Brings up NICs in host that will be used by virtual machine.
+#
+# * lwaftrctl vm start. 
+#       Brings up VM. After this step it should be possible to log into 
+#       the VM: ssh igalia@10.21.21.2.
+#
+# * lwaftrctl lwaftr start.
+#       Starts lwaftr inside VM. This commands logs into VM and runs file 
+#       "~/run_lwaftr.sh". See run_lwaftr.sh.example.
+#
+# Once the lwaftr is running within the VM, run 'snabb_lwaftr transient' from 
+# host to check everything is working fine.
+#
+# The command 'lwaftrctl all start', run all the steps above.
+
+qemu_start_vm() {
+    echo "Starting QEMU. Please wait..."
+    cd $VM_DIR
+    sudo qemu-system-x86_64 \
+        --enable-kvm -name ${NAME} -drive file=${DISK},if=virtio \
+        -m ${MEM} -cpu host -smp 2 \
+        -fsdev local,security_model=passthrough,id=fsdev0,path=${SHARED_LOCATION} \
+            -device virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=share \
+        -object memory-backend-file,id=mem,size=${MEM},mem-path=/dev/hugepages,share=on \
+        -numa node,memdev=mem \
+        -chardev socket,id=char1,path=${VHU_SOCK1},server \
+            -netdev type=vhost-user,id=net0,chardev=char1 \
+            -device virtio-net-pci,netdev=net0,addr=0x8,mac=52:54:00:00:00:01 \
+        -chardev socket,id=char2,path=${VHU_SOCK2},server \
+            -netdev type=vhost-user,id=net1,chardev=char2 \
+            -device virtio-net-pci,netdev=net1,addr=0x9,mac=52:54:00:00:00:02 \
+        -netdev type=tap,id=net2,ifname=${IFACE},vhost=on,script=${NETSCRIPT} \
+            -device virtio-net-pci,netdev=net2,addr=0xa,mac=52:54:00:00:00:03 \
+        -vnc :${VNC_DISPLAY} -daemonize &
+}
+
+vm_pid() {
+    echo `ps aux | grep -i "name $1" | grep -v "grep" | awk '{ print $2 }'`
+}
+
+start_vm() {
+    qemu_start_vm
+    sleep 30
+
+    pid=$(vm_pid "${NAME}")
+    for each in `ls /proc/$pid/task`; do sudo taskset -cp $QEMU_CORE $each; done
+    echo "Pinned QEMU to core $QEMU_CORE"
+}
+
+stop_vm() {
+    echo "Switching off VM. Please wait..."
+    ssh ${VM_USER}@${VM_IP} 'sudo halt'
+    sleep 10
+    pid=`pidof qemu-system-x86_64`
+    sudo kill ${pid} 2>/dev/null
+    echo "VM switched off"
+}
+
+restart_vm() {
+    stop_vm
+    start_vm
+}
+
+start_lwaftr() {
+    echo "Start lwAFTR"
+
+    ssh ${VM_USER}@${VM_IP} "~/run_lwaftr.sh"
+}
+
+stop_lwaftr() {
+    echo "Stop lwAFTR"
+
+    ssh ${VM_USER}@${VM_IP} 'sudo killall snabb 2>/dev/null'
+}
+
+restart_lwaftr() {
+    stop_lwaftr
+    start_lwaftr
+}
+
+start_snabbnfv() {
+    start_snabbnfv_process "snabbnfv-1" $SNABBNFV_CORE1 $SNABBNFV_PCI1 $SNABBNFV_CONF1 $VHU_SOCK1
+    start_snabbnfv_process "snabbnfv-2" $SNABBNFV_CORE2 $SNABBNFV_PCI2 $SNABBNFV_CONF2 $VHU_SOCK2
+}
+
+start_snabbnfv_process() {
+    local screen=$1
+    local core=$2
+    local pci=$3
+    local conf=$4
+    local sock=$5
+
+    echo "Start snabbnfv (screen: '$screen') at core $core (pci: $pci; conf: $conf}; socket: $sock)"
+    screen -dmS $screen bash -c "cd ${SNABB_HOST_PATH}/src; sudo taskset -c ${core} sudo ./snabb snabbnfv traffic ${pci} ${conf} ${sock}"
+}
+
+restart_snabbnfv() {
+    stop_snabbnfv
+    start_snabbnfv
+}
+
+kill_all() {
+    local name=$1
+    pids=`ps aux | grep "$name" | awk '{ print $2 }'`
+    for pid in ${pids[@]}; do
+        sudo kill $pid 2>/dev/null
+    done
+    sleep 1
+    screen -wipe
+}
+
+remove_file() {
+    sudo rm -f $1
+}
+
+stop_snabbnfv() {
+    echo "Stop snabbnfv"
+
+    kill_all "snabbnfv traffic"
+    remove_file $VHU_SOCK1
+    remove_file $VHU_SOCK2
+}
+
+start_command() {
+    COMMAND=$1
+    case $COMMAND in
+        "all")
+            start_snabbnfv
+            start_vm
+            start_lwaftr
+            ;;
+        "snabbnfv")
+            start_snabbnfv
+            ;;
+        "lwaftr")
+            start_lwaftr
+            ;;
+        "vm")
+            start_vm
+            ;;
+        *)
+            bad_usage
+            ;;
+    esac
+}
+
+restart_command() {
+    COMMAND=$1
+    case $COMMAND in
+        "all")
+            restart_vm
+            restart_lwaftr
+            ;;
+        "snabbnfv")
+            restart_snabbnfv
+            ;;
+        "lwaftr")
+            restart_lwaftr
+            ;;
+        "vm")
+            restart_vm
+            ;;
+        *)
+            bad_usage
+            ;;
+    esac
+}
+
+stop_command() {
+    COMMAND=$1
+    case $COMMAND in
+        "all")
+            stop_lwaftr
+            stop_vm
+            stop_snabbnfv
+            ;;
+        "snabbnfv")
+            stop_snabbnfv
+            ;;
+        "lwaftr")
+            stop_lwaftr
+            ;;
+        "vm")
+            stop_vm
+            ;;
+        *)
+            bad_usage
+            ;;
+    esac
+}
+
+# Main
+
+usage() {
+    local exit_code=$1
+    echo "Usage: lwaftrctl -f lwaftrctl.conf [all|snabbnfv|vm|lwaftr] [start|stop|restart]"
+    exit $exit_code
+}
+
+bad_usage() {
+    usage -1
+}
+
+help() {
+    usage 0
+}
+
+AFTRCTL_CONF=confs/lwaftrctl1.conf
+ARGS=()
+while [[ $# > 0 ]]; do
+    key="$1"
+
+    case $key in
+        -f|--file)
+            AFTRCTL_CONF="$2"
+            shift
+            ;;
+        *)
+            ARGS+=($key)
+            ;;
+    esac
+    shift
+done
+
+if [ ${#ARGS[@]} -ne 2 ]; then
+    help
+fi
+
+if [ ! -f "$AFTRCTL_CONF" ]; then
+    echo "Could not find lwaftrctl.conf in current directory. See lwaftrctl.conf.example."
+    exit -1
+fi
+
+source $AFTRCTL_CONF
+
+PROGRAM_NAME=$0
+COMMAND=${ARGS[0]}
+ACTION=${ARGS[1]}
+
+case $ACTION in
+    "start")
+        start_command $COMMAND;
+        ;;
+    "stop")
+        stop_command $COMMAND;
+        ;;
+    "restart")
+        restart_command $COMMAND;
+        ;;
+    *)
+        echo "Unknown action: $ACTION"
+        exit -1
+        ;;
+esac
+
+exit 0

--- a/src/program/lwaftr/virt/lwaftrctl.conf.example
+++ b/src/program/lwaftr/virt/lwaftrctl.conf.example
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# General
+
+SNABB_HOST_PATH=~/workspace/snabb_host
+SNABB_HOST_LWAFTR=$SNABB_HOST_PATH/src/program/snabb_lwaftr
+
+# QEMU
+
+NAME=lwaftr1
+DISK=~/vm/vm_lwaftr1.qcow2
+MEM=1024M
+
+IFACE=mgmt0
+NETSCRIPT=$SNABB_HOST_LWAFTR/virt/setup_networks/lwaftr1.sh
+
+SHARED_LOCATION=~/workspace
+VHU_SOCK1=/tmp/vh1a.sock
+VHU_SOCK2=/tmp/vh1b.sock
+VNC_DISPLAY=22
+
+# VM
+
+QEMU_CORE=0
+VM_DIR=~/vm
+VM_IP=10.21.21.2
+VM_USER=igalia   # Must be in the list of sudoers        
+
+# Guest
+
+SNABB_GUEST_PATH=/mnt/host/snabb_guest/src
+
+# SnabbNFV
+
+SNABBNFV_CORE1=1
+SNABBNFV_CONF1=$SNABB_HOST_LWAFTR/virt/ports/lwaftr1/a.cfg
+SNABBNFV_PCI1=0000:02:00.0
+
+SNABBNFV_CORE2=2
+SNABBNFV_CONF2=$SNABB_HOST_LWAFTR/virt/ports/lwaftr1/b.cfg
+SNABBNFV_PCI2=0000:02:00.1

--- a/src/program/lwaftr/virt/lwaftrctl.conf.example
+++ b/src/program/lwaftr/virt/lwaftrctl.conf.example
@@ -3,7 +3,7 @@
 # General
 
 SNABB_HOST_PATH=~/workspace/snabb_host
-SNABB_HOST_LWAFTR=$SNABB_HOST_PATH/src/program/snabb_lwaftr
+SNABB_HOST_LWAFTR=$SNABB_HOST_PATH/src/program/lwaftr
 
 # QEMU
 

--- a/src/program/lwaftr/virt/ports/lwaftr1/a.cfg
+++ b/src/program/lwaftr/virt/ports/lwaftr1/a.cfg
@@ -1,0 +1,5 @@
+return {
+  { port_id = "1A",
+    disable_mergeable_rx_buffer = true,
+  },
+}

--- a/src/program/lwaftr/virt/ports/lwaftr1/b.cfg
+++ b/src/program/lwaftr/virt/ports/lwaftr1/b.cfg
@@ -1,0 +1,5 @@
+return {
+  { port_id = "1B",
+    disable_mergeable_rx_buffer = true,
+  },
+}

--- a/src/program/lwaftr/virt/run_lwaftr.sh.example
+++ b/src/program/lwaftr/virt/run_lwaftr.sh.example
@@ -3,7 +3,7 @@
 SNABB_GUEST=/mnt/host/snabb_guest/src
 V4_PCI=0000:00:08.0
 V6_PCI=0000:00:09.0
-LWAFTR_CONF=program/snabb_lwaftr/tests/data/icmp_on_fail.conf 
+LWAFTR_CONF=program/lwaftr/tests/data/icmp_on_fail.conf
 OUTPUT=/tmp/lwaftr.csv
 
-screen -dmS lwaftr bash -c "cd ${SNABB_GUEST};sudo taskset -c 1 ./snabb snsh -p snabb_lwaftr run -v -i --conf $LWAFTR_CONF --v4-pci ${V4_PCI} --v6-pci ${V6_PCI} | tee $OUTPUT"
+screen -dmS lwaftr bash -c "cd ${SNABB_GUEST};sudo taskset -c 1 ./snabb snsh -p lwaftr run -v -i --conf $LWAFTR_CONF --v4-pci ${V4_PCI} --v6-pci ${V6_PCI} | tee $OUTPUT"

--- a/src/program/lwaftr/virt/run_lwaftr.sh.example
+++ b/src/program/lwaftr/virt/run_lwaftr.sh.example
@@ -1,0 +1,9 @@
+#!/usr/bin/evn bash
+
+SNABB_GUEST=/mnt/host/snabb_guest/src
+V4_PCI=0000:00:08.0
+V6_PCI=0000:00:09.0
+LWAFTR_CONF=program/snabb_lwaftr/tests/data/icmp_on_fail.conf 
+OUTPUT=/tmp/lwaftr.csv
+
+screen -dmS lwaftr bash -c "cd ${SNABB_GUEST};sudo taskset -c 1 ./snabb snsh -p snabb_lwaftr run -v -i --conf $LWAFTR_CONF --v4-pci ${V4_PCI} --v6-pci ${V6_PCI} | tee $OUTPUT"

--- a/src/program/lwaftr/virt/setup_networks/lwaftr1.sh
+++ b/src/program/lwaftr/virt/setup_networks/lwaftr1.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+IFACE=mgmt0
+IP=10.21.21.1/24
+
+if [ -n "$1" ]
+then
+    sleep 0.5s
+    if [ "$1" = ${IFACE} ]; then
+        ip addr add ${IP} dev ${IFACE}
+        sleep 0.5s
+    fi;
+    exit 0
+else
+    echo "No interface specified."
+    exit 1
+fi


### PR DESCRIPTION
Rebased PR of #206. Configuration files are structured is several folders, so it's easier to add new VMs if necessary.

This script eases the process of running the lwaftr from within a VM. To run lwaftr virtualized is necessary to go through the following steps:

1) Bring up two NICs from the host using snabbnfv (vhost-user).
2) Start VM with QEMU.
3) Run lwaftr from within VM.

The lwaftr is run inside the VM using the virtio_net driver.

Once the lwaftr is running, it should be possible to send packets to and from the guest. Run the "snabb-lwaftr transient" from within the host for testing purposes.

The script exposes the following commands to ease this process:

1) lwaftrctl snabbnfv start
2) lwaftrctl vm start
3) lwaftrctl lwaftr start

A file lwaftrctl.conf, containing all the necessary parameters, must exist within the same folder the lwaftrctl command is run. See lwaftrctl.conf.example.

It is also necessary to create user VM_USER in the VM. This user must be in the list of sudoers. It is necessary to create a script "run_lwaftr.sh" in VM_USER home. See run_lwaftr.sh.example.