### PR TITLE
Large dataset samples

### DIFF
--- a/src/program/lwaftr/tests/data/large/.gitignore
+++ b/src/program/lwaftr/tests/data/large/.gitignore
@@ -1,0 +1,4 @@
+binding_table.txt
+from-b4-0550.pcap
+from-inet-0550.pcap
+lwaftr.conf


### PR DESCRIPTION
* Adds a 1 million subscribers binding-table.
* 20K active subscribers for from-inet traffic.
* 20K active subscribers for from-b4 traffic.
* Adds a sample lwaftr.conf file.

Untar file to obtain datasets:
```
cd program/lwaftr/tests/large; tar xfvz 1-million-subscribers.tar.gz
```