### PR TITLE
Improve lwaftr config parser error messages

### DIFF
--- a/src/apps/lwaftr/conf_parser.lua
+++ b/src/apps/lwaftr/conf_parser.lua
@@ -147,7 +147,11 @@ end
 
 -- Returns a uint8_t[4].
 function Parser:parse_ipv4()
-   local addr, err = ipv4:pton(self:take_while('[%d.]'))
+   local addr_string = self:take_while('[%d.]')
+   if not addr_string or #addr_string == 0 then
+      self:error("IPv4 address expected")
+   end
+   local addr, err = ipv4:pton(addr_string)
    if not addr then self:error('%s', err) end
    return addr
 end
@@ -159,17 +163,24 @@ end
 
 -- Returns a uint8_t[16].
 function Parser:parse_ipv6()
-   local addr, err = ipv6:pton(self:take_while('[%x:]'))
+   local addr_string = self:take_while('[%x:]')
+   if not addr_string or #addr_string == 0 then
+      self:error("IPv6 address expected")
+   end
+   local addr, err = ipv6:pton(addr_string)
    if not addr then self:error('%s', err) end
    return addr
 end
 
 -- Returns a uint8_t[6].
 function Parser:parse_mac()
+   local addr_string = self:take_while('[%x:]')
+   if not addr_string or #addr_string == 0 then
+      self:error("Ethernet MAC address expected")
+   end
    -- FIXME: Unlike ipv6:pton, ethernet:pton raises an error if the
    -- address is invalid.
-   local success, addr_or_err = pcall(
-      ethernet.pton, ethernet, self:take_while('[%x:]'))
+   local success, addr_or_err = pcall(ethernet.pton, ethernet, addr_string)
    if not success then self:error('%s', addr_or_err) end
    return addr_or_err
 end


### PR DESCRIPTION
Given the following input in a configuration file for the lwaftr (note the unneeded double quotes):

```
aftr_ipv4_ip = "1.2.3.4"
```

The following error would be generated when parsing it:

```
lib/protocol/ipv4.lua:79: variable 'address' is not declared
```

...which is confusing, because the error does not point to the configuration file, and does not point out the actual problem. With this patch applied the message is instead:

```
apps/lwaftr/conf_parser.lua:28: lwaftr.conf:1:15: error: IPv4 address expected
```

...which points out exactly the problem, and what the parser was expecting to find. This patch also modifies parsing of IPv6 addresses and Ethernet MAC addresses in the same way.