### PR TITLE
Support TUN/TAP devices in “snabb-lwaftr run-nohw”

### DIFF
--- a/src/program/lwaftr/run_nohw/README.inc
+++ b/src/program/lwaftr/run_nohw/README.inc
@@ -1,8 +1,19 @@
 Usage: run-nohw --help
-       run-nohw --conf PATH --b4-if NAME --inet-if NAME [--verbose]
+       run-nohw --bt PATH --conf PATH --b4-if DEVICE --inet-if DEVICE [-v]
 
-       --conf, -c PATH      Path to the lwAFTR configuration file.
-       --b4-if, -B NAME     Name of the B4-side network interface.
-       --inet-if, -I NAME   Name of the Internet-side network interface.
-       --verbose, -v        Be verbose. Can be used multiple times.
-       --help, -h           Show this help message.
+       --bt, -b PATH         Path to the file containing the binding table.
+       --conf, -c PATH       Path to the lwAFTR configuration file.
+       --b4-if, -B DEVICE    Name of the B4-side network interface.
+       --inet-if, -I DEVICE  Name of the Internet-side network interface.
+       --verbose, -v         Be verbose. Can be used multiple times.
+       --help, -h            Show this help message.
+
+    DEVICEs arguments have the form KIND:NAME, where the NAME is the name of
+    an existing network interface, as seen by the operating system, and KIND
+    one of the following:
+
+       tap  The device is a TUN/TAP interface. It must be created before
+            running the lwAFTR, and configured using using ip(8).
+
+       raw  The device is any NIC which can be accessed at the link layer
+            using RAW sockets.

--- a/src/program/lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/lwaftr/run_nohw/run_nohw.lua
@@ -25,7 +25,7 @@ local function parse_args(args)
       tap = { app = Tap, tx = "output", rx = "input" };
       raw = { app = RawSocket, tx = "tx", rx = "rx" };
    }
-   local verbosity = 0
+   local verbosity, debug = 0, false
    local bt_file, conf_file, b4_if, b4_if_kind, inet_if, inet_if_kind
    local handlers = {
       v = function ()
@@ -54,25 +54,29 @@ local function parse_args(args)
                "invalid/missing device kind in '%s'", arg)
          inet_if_kind = device_kind_map[inet_if_kind]
       end;
+      D = function ()
+         debug = true
+      end;
       h = function (arg)
          print(require("program.lwaftr.run_nohw.README_inc"))
          main.exit(0)
       end;
    }
-   lib.dogetopt(args, handlers, "b:c:B:I:vh", {
-      help = "h", conf = "c", verbose = "v",
+   lib.dogetopt(args, handlers, "b:c:B:I:vDh", {
+      help = "h", conf = "c", verbose = "v", debug = "D",
       ["b4-if"] = "B", ["inet-if"] = "I",
    })
    check(conf_file, "no configuration specified (--conf/-c)")
    check(b4_if, "no B4-side interface specified (--b4-if/-B)")
    check(inet_if, "no Internet-side interface specified (--inet-if/-I)")
-   return verbosity, bt_file, conf_file, b4_if, b4_if_kind, inet_if, inet_if_kind
+   return verbosity, bt_file, conf_file, b4_if, b4_if_kind, inet_if, inet_if_kind, debug
 end
 
 
 function run(parameters)
-   local verbosity, bt_file, conf_file, b4_if, b4_if_kind, inet_if, inet_if_kind = parse_args(parameters)
+   local verbosity, bt_file, conf_file, b4_if, b4_if_kind, inet_if, inet_if_kind, debug = parse_args(parameters)
    local conf = require("apps.lwaftr.conf").load_lwaftr_config(conf_file)
+   conf.debug = debug
 
    local c = config.new()
    setup.lwaftr_app(c, conf)

--- a/src/program/lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/lwaftr/run_nohw/run_nohw.lua
@@ -68,7 +68,7 @@ local function parse_args(args)
       end;
    }
    lib.dogetopt(args, handlers, "b:c:B:I:vDh", {
-      help = "h", conf = "c", verbose = "v", debug = "D",
+      help = "h", conf = "c", verbose = "v", debug = "D", bt = "b",
       ["b4-if"] = "B", ["inet-if"] = "I",
    })
    check(conf_file, "no configuration specified (--conf/-c)")

--- a/src/program/lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/lwaftr/run_nohw/run_nohw.lua
@@ -36,6 +36,11 @@ local function parse_args(args)
          check(file_exists(arg), "no such file '%s'", arg)
          conf_file = arg
       end;
+      b = function (arg)
+         check(arg, "argument to '--bt' not specified")
+         check(file_exists(arg), "no such file '%s'", arg)
+         bt_file = arg
+      end;
       B = function (arg)
          check(arg, "argument to '--b4-if' not specified")
          b4_if_kind, b4_if = arg:match("^([a-z]+):([^%s]+)$")


### PR DESCRIPTION
Updated version of #183, which does not need a local copy of the `Tap` application, as it is included as `apps.tap.tap.Tap` in `lwaftr_starfruit`.
