### PR TITLE
Enable VMDq if using 82599 cards to handle VLANs

### DIFF
--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -118,10 +118,12 @@ function load_phy(c, conf, v4_nic_name, v4_nic_pci, v6_nic_name, v6_nic_pci)
 
    config.app(c, v4_nic_name, Intel82599, {
       pciaddr=v4_nic_pci,
+      vmdq=conf.vlan_tagging,
       vlan=conf.vlan_tagging and conf.v4_vlan_tag,
       macaddr=ethernet:ntop(conf.aftr_mac_inet_side)})
    config.app(c, v6_nic_name, Intel82599, {
       pciaddr=v6_nic_pci,
+      vmdq=conf.vlan_tagging,
       vlan=conf.vlan_tagging and conf.v6_vlan_tag,
       macaddr = ethernet:ntop(conf.aftr_mac_b4_side)})
 


### PR DESCRIPTION
* src/program/lwaftr/setup.lua: Enable VMDq if we are stripping VLAN
  tags.  This also enabled VLAN filtering, which was busted before.  It
  also enables MAC filtering, whereby *only* packets with the correct
  destination MAC will be routed to the interface.