### PR TITLE
Print out RX statistics

### DIFF
--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -120,11 +120,13 @@ function load_phy(c, conf, v4_nic_name, v4_nic_pci, v6_nic_name, v6_nic_pci)
       pciaddr=v4_nic_pci,
       vmdq=conf.vlan_tagging,
       vlan=conf.vlan_tagging and conf.v4_vlan_tag,
+      rxcounter=1,
       macaddr=ethernet:ntop(conf.aftr_mac_inet_side)})
    config.app(c, v6_nic_name, Intel82599, {
       pciaddr=v6_nic_pci,
       vmdq=conf.vlan_tagging,
       vlan=conf.vlan_tagging and conf.v6_vlan_tag,
+      rxcounter=1,
       macaddr = ethernet:ntop(conf.aftr_mac_b4_side)})
 
    link_source(c, v4_nic_name..'.tx', v6_nic_name..'.tx')


### PR DESCRIPTION
Unconditionally prints out QPRC and QPRDC registers. In order to be printed out, the lwAFTR must run during a limited amount of time.

QPRC: Queue Packets Received Count
QPRDC: Queue Packets Received Drop Count
