### PR TITLE
Switch to streaming lookup

### DIFF
--- a/src/apps/lwaftr/binding_table.lua
+++ b/src/apps/lwaftr/binding_table.lua
@@ -186,7 +186,7 @@ function BindingTable:enqueue_lookup(pkt, ipv4, port)
    return n == 32
 end
 
-function BindingTable:process_lookup_queue()
+function BindingTable:dequeue_lookups()
    if self.lookup_queue_len > 0 then
       local streamer = self.streamer
       for n = 0, self.lookup_queue_len-1 do
@@ -196,25 +196,23 @@ function BindingTable:process_lookup_queue()
       end
       streamer:stream()
    end
-   return self.lookup_queue_len
+   return self.dequeue_lookup, self, 0
 end
 
-function BindingTable:get_enqueued_lookup(n)
+function BindingTable:dequeue_lookup(n)
    if n < self.lookup_queue_len then
       local streamer = self.streamer
-      local pkt, b4_ipv6, br_ipv6
-      pkt = self.packet_queue[n]
-      self.packet_queue[n] = nil
+      local pkt = self.packet_queue[n]
+      local b4_ipv6, br_ipv6
       if not streamer:is_empty(n) then
          b4_ipv6 = streamer.entries[n].value.b4_ipv6
          br_ipv6 = self:get_br_address(streamer.entries[n].value.br)
       end
-      return pkt, b4_ipv6, br_ipv6
+      return n + 1, pkt, b4_ipv6, br_ipv6
+   else
+      self.lookup_queue_len = 0
+      return nil
    end
-end
-
-function BindingTable:reset_lookup_queue()
-   self.lookup_queue_len = 0
 end
 
 function BindingTable:is_managed_ipv4_address(ipv4)

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -301,13 +301,20 @@ end
 
 -- ICMPv6 type 1 code 5, as per RFC 7596.
 -- The source (ipv6, ipv4, port) tuple is not in the table.
-local function icmp_b4_lookup_failed(lwstate, pkt, to_ip)
+local function drop_ipv6_packet_from_bad_softwire(lwstate, pkt)
+   if lwstate.policy_icmpv6_outgoing == lwconf.policies['DROP'] then
+      -- ICMP error messages off by policy; silently drop.
+      return drop(pkt)
+   end
+
+   local ipv6_header = get_ethernet_payload(pkt)
+   local ipv6_src_addr = get_ipv6_src_address(ipv6_header)
    local icmp_config = {type = constants.icmpv6_dst_unreachable,
                         code = constants.icmpv6_failed_ingress_egress_policy,
                        }
-   local b4fail_icmp = icmp.new_icmpv6_packet(lwstate.aftr_mac_b4_side, lwstate.next_hop6_mac,
-                                              lwstate.aftr_ipv6_ip, to_ip, pkt,
-                                              ethernet_header_size, icmp_config)
+   local b4fail_icmp = icmp.new_icmpv6_packet(
+      lwstate.aftr_mac_b4_side, lwstate.next_hop6_mac, lwstate.aftr_ipv6_ip,
+      ipv6_src_addr, pkt, ethernet_header_size, icmp_config)
    drop(pkt)
    transmit_icmpv6_with_rate_limit(lwstate.o6, b4fail_icmp)
 end
@@ -545,6 +552,32 @@ local function icmpv6_incoming(lwstate, pkt)
    end
 end
 
+local function flush_decapsulation(lwstate)
+   local bt = lwstate.binding_table
+   bt:process_lookup_queue()
+   for n = 0, bt.lookup_queue_len - 1 do
+      local pkt, b4_addr, br_addr = bt:get_enqueued_lookup(n)
+
+      local ipv6_header = get_ethernet_payload(pkt)
+      if (b4_addr
+          and ipv6_equals(get_ipv6_src_address(ipv6_header), b4_addr)
+          and ipv6_equals(get_ipv6_dst_address(ipv6_header), br_addr)) then
+         -- Source softwire is valid; decapsulate and forward.
+         packet.shiftleft(pkt, ipv6_fixed_header_size)
+         write_eth_header(pkt.data, lwstate.aftr_mac_inet_side, lwstate.inet_mac,
+                          n_ethertype_ipv4)
+         transmit_ipv4(lwstate, pkt)
+      else
+         drop_ipv6_packet_from_bad_softwire(lwstate, pkt)
+      end
+   end
+   bt:reset_lookup_queue()
+end
+
+local function enqueue_decapsulation(lwstate, pkt, ipv4, port)
+   enqueue_lookup(lwstate, pkt, ipv4, port, flush_decapsulation)
+end
+
 -- FIXME: Verify that the packet length is big enough?
 local function from_b4(lwstate, pkt)
    local ipv6_header = get_ethernet_payload(pkt)
@@ -563,11 +596,7 @@ local function from_b4(lwstate, pkt)
       end
    end
 
-   local ipv6_src_ip = get_ipv6_src_address(ipv6_header)
-   local ipv6_dst_ip = get_ipv6_dst_address(ipv6_header)
    local tunneled_ipv4_header = get_ipv6_payload(ipv6_header)
-   local ipv4_src_ip = get_ipv4_src_address(tunneled_ipv4_header)
-   -- FIXME: Handle non-TCP, non-UDP payloads.
    local port
    if get_ipv4_proto(tunneled_ipv4_header) == proto_icmp then
       local icmp_header = get_ipv4_payload(tunneled_ipv4_header)
@@ -599,19 +628,8 @@ local function from_b4(lwstate, pkt)
       port = get_ipv4_payload_src_port(tunneled_ipv4_header)
    end
 
-   if in_binding_table(lwstate, ipv6_src_ip, ipv6_dst_ip, ipv4_src_ip, port) then
-      -- Incoming packet is from a valid softwire; decapsulate and
-      -- forward.
-      packet.shiftleft(pkt, ipv6_fixed_header_size)
-      write_eth_header(pkt.data, lwstate.aftr_mac_inet_side, lwstate.inet_mac,
-                       n_ethertype_ipv4)
-      return transmit_ipv4(lwstate, pkt)
-   elseif lwstate.policy_icmpv6_outgoing == lwconf.policies['ALLOW'] then
-      icmp_b4_lookup_failed(lwstate, pkt, ipv6_src_ip)
-      return drop(pkt)
-   else
-      return drop(pkt)
-   end
+   local ipv4 = get_ipv4_src_address(tunneled_ipv4_header)
+   return enqueue_decapsulation(lwstate, pkt, ipv4, port)
 end
 
 function LwAftr:push ()
@@ -651,6 +669,7 @@ function LwAftr:push ()
          drop(pkt)
       end
    end
+   flush_decapsulation(self)
 
    for _=1,link.nreadable(i4) do
       -- Encapsulate incoming IPv4 packets, including hairpinned

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -401,15 +401,19 @@ local function enqueue_lookup(lwstate, pkt, ipv4, port, flush)
 end
 
 local function flush_encapsulation(lwstate)
-   for _, pkt, b4_addr, br_addr in lwstate.binding_table:dequeue_lookups() do
-      if b4_addr then
-         encapsulate_and_transmit(lwstate, pkt, b4_addr, br_addr)
+   local bt = lwstate.binding_table
+   bt:process_lookup_queue()
+   for n = 0, bt.lookup_queue_len - 1 do
+      local pkt, ipv6_dst, ipv6_src = bt:get_enqueued_lookup(n)
+      if ipv6_dst then
+         encapsulate_and_transmit(lwstate, pkt, ipv6_dst, ipv6_src)
       else
          -- Lookup failed.
          if debug then print("lookup failed") end
          drop_ipv4_packet_to_unreachable_host(lwstate, pkt)
       end
    end
+   bt:reset_lookup_queue()
 end
 
 local function enqueue_encapsulation(lwstate, pkt, ipv4, port)
@@ -549,7 +553,11 @@ local function icmpv6_incoming(lwstate, pkt)
 end
 
 local function flush_decapsulation(lwstate)
-   for _, pkt, b4_addr, br_addr in lwstate.binding_table:dequeue_lookups() do
+   local bt = lwstate.binding_table
+   bt:process_lookup_queue()
+   for n = 0, bt.lookup_queue_len - 1 do
+      local pkt, b4_addr, br_addr = bt:get_enqueued_lookup(n)
+
       local ipv6_header = get_ethernet_payload(pkt)
       if (b4_addr
           and ipv6_equals(get_ipv6_src_address(ipv6_header), b4_addr)
@@ -563,6 +571,7 @@ local function flush_decapsulation(lwstate)
          drop_ipv6_packet_from_bad_softwire(lwstate, pkt)
       end
    end
+   bt:reset_lookup_queue()
 end
 
 local function enqueue_decapsulation(lwstate, pkt, ipv4, port)


### PR DESCRIPTION
This branch switches the lwAFTR to use the streaming PodHashMap lookups, under the theory that some of the low performance we have been seeing is due to the "side-trace problem" (https://github.com/lukego/blog/issues/8 for an example).  The theory was that the side traces originated not in our application code but in PodHashMap (see #97): we were using the one-at-a-time lookup() interface that, for big tables, could have unbiased branches while doing the linear probe.

I did not examine the traces to test this theory, but instead refactored the lwaftr to batch access to the binding table via the "StreamingLookup" interface, which uses custom AVX2 code to stream in results from the binding table.  Also, since all the results are in cache, it uses custom binary search code over the maximum probe length to find the matching hash values.  Side traces will only be generated when the lookup fails (unlikely in our case) or when there is a hash collision (again, unlikely, though I'm not sure).

The result is that for a binding table of 1M entries with 20K active flows, we go from a quite variable 1.4+1.4 MPPS before dropping packets, up to 1.8+1.8 or more before dropping *any* packets.  Here is my most recent loadtest run:

```
[wingo@snabb1:~/snabbswitch/src]$ make && sudo taskset -c 11 ./snabb-lwaftr loadtest 20K-1M-vlan-tests/from-inet-vlan-0550.pcap IPv4 IPv6 82:00.0 20K-1M-vlan-tests/from-b4-vlan-0550.pcap IPv6 IPv4 82:00.1
make: 'snabb-lwaftr' is up to date.
Warming up at 5.000000 Gb/s for 2 seconds.
Applying 1.000000 Gbps of load.
  IPv4:
    TX 1136364 packets (0.227273 MPPS), 625000200 bytes (1.000000 Gbps)
    RX 1136364 packets (0.227273 MPPS), 670454760 bytes (1.072728 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 1136364 packets (0.227273 MPPS), 625000200 bytes (1.000000 Gbps)
    RX 1136364 packets (0.227273 MPPS), 579545640 bytes (0.927273 Gbps)
    Loss: 0 packets (0.000000%)
Applying 2.000000 Gbps of load.
  IPv4:
    TX 2272727 packets (0.454545 MPPS), 1249999850 bytes (2.000000 Gbps)
    RX 2272727 packets (0.454545 MPPS), 1340908930 bytes (2.145454 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 2272727 packets (0.454545 MPPS), 1249999850 bytes (2.000000 Gbps)
    RX 2272727 packets (0.454545 MPPS), 1159090770 bytes (1.854545 Gbps)
    Loss: 0 packets (0.000000%)
Applying 3.000000 Gbps of load.
  IPv4:
    TX 3409090 packets (0.681818 MPPS), 1874999500 bytes (2.999999 Gbps)
    RX 3409090 packets (0.681818 MPPS), 2011363100 bytes (3.218181 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 3409090 packets (0.681818 MPPS), 1874999500 bytes (2.999999 Gbps)
    RX 3409090 packets (0.681818 MPPS), 1738635900 bytes (2.781817 Gbps)
    Loss: 0 packets (0.000000%)
Applying 4.000000 Gbps of load.
  IPv4:
    TX 4545453 packets (0.909091 MPPS), 2499999150 bytes (3.999999 Gbps)
    RX 4545453 packets (0.909091 MPPS), 2681817270 bytes (4.290908 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 4545453 packets (0.909091 MPPS), 2499999150 bytes (3.999999 Gbps)
    RX 4545453 packets (0.909091 MPPS), 2318181030 bytes (3.709090 Gbps)
    Loss: 0 packets (0.000000%)
Applying 5.000000 Gbps of load.
  IPv4:
    TX 5681813 packets (1.136363 MPPS), 3124997150 bytes (4.999995 Gbps)
    RX 5681813 packets (1.136363 MPPS), 3352269670 bytes (5.363631 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 5681813 packets (1.136363 MPPS), 3124997150 bytes (4.999995 Gbps)
    RX 5681813 packets (1.136363 MPPS), 2897724630 bytes (4.636359 Gbps)
    Loss: 0 packets (0.000000%)
Applying 6.000000 Gbps of load.
  IPv4:
    TX 6818183 packets (1.363637 MPPS), 3750000650 bytes (6.000001 Gbps)
    RX 6818183 packets (1.363637 MPPS), 4022727970 bytes (6.436365 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 6818183 packets (1.363637 MPPS), 3750000650 bytes (6.000001 Gbps)
    RX 6818183 packets (1.363637 MPPS), 3477273330 bytes (5.563637 Gbps)
    Loss: 0 packets (0.000000%)
Applying 7.000000 Gbps of load.
  IPv4:
    TX 7954535 packets (1.590907 MPPS), 4374994250 bytes (6.999991 Gbps)
    RX 7954535 packets (1.590907 MPPS), 4693175650 bytes (7.509081 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 7954535 packets (1.590907 MPPS), 4374994250 bytes (6.999991 Gbps)
    RX 7954535 packets (1.590907 MPPS), 4056812850 bytes (6.490901 Gbps)
    Loss: 0 packets (0.000000%)
Applying 8.000000 Gbps of load.
  IPv4:
    TX 9090891 packets (1.818178 MPPS), 4999990050 bytes (7.999984 Gbps)
    RX 9090880 packets (1.818176 MPPS), 5363619200 bytes (8.581791 Gbps)
    Loss: 11 packets (0.000121%)
  IPv6:
    TX 9090891 packets (1.818178 MPPS), 4999990050 bytes (7.999984 Gbps)
    RX 9090891 packets (1.818178 MPPS), 4636354410 bytes (7.418167 Gbps)
    Loss: 0 packets (0.000000%)
Applying 9.000000 Gbps of load.
  IPv4:
    TX 10227243 packets (2.045449 MPPS), 5624983650 bytes (8.999974 Gbps)
    RX 10178837 packets (2.035767 MPPS), 6005513830 bytes (9.608822 Gbps)
    Loss: 48406 packets (0.473304%)
  IPv6:
    TX 10227243 packets (2.045449 MPPS), 5624983650 bytes (8.999974 Gbps)
    RX 10226933 packets (2.045387 MPPS), 5215735830 bytes (8.345177 Gbps)
    Loss: 310 packets (0.003031%)
Applying 10.000000 Gbps of load.
  IPv4:
    TX 10888625 packets (2.177725 MPPS), 5988743750 bytes (9.581990 Gbps)
    RX 10178745 packets (2.035749 MPPS), 6005459550 bytes (9.608735 Gbps)
    Loss: 709880 packets (6.519464%)
  IPv6:
    TX 10888712 packets (2.177742 MPPS), 5988791600 bytes (9.582067 Gbps)
    RX 10516224 packets (2.103245 MPPS), 5363274240 bytes (8.581239 Gbps)
    Loss: 372488 packets (3.420864%)
```

Could be better, but it's pretty good.  Note that the maximum possible bitrate for this packet size (550 bytes) is less than 10 because of the L2 overhead etc.

This branch is based on #263, so probably that one should be reviewed and merged first, then this one.  I'm not satisfied with the interface to the binding table though: it's quite fiddly.  I will see if I can use `for in`; we'll see.

Onwards and upwards!