### PR TITLE
Add log-bucketed histogram, use it to record breathe() latencies

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -236,6 +236,15 @@ function main (options)
       assert(not done, "You can not have both 'duration' and 'done'")
       done = lib.timer(options.duration * 1e9)
    end
+
+   local breathe = breathe
+   if options.measure_latency or options.measure_latency == nil then
+      local histogram = require('lib.histogram')
+      local latency = histogram.create('engine/latency', 1e-6, 1e0)
+      print('hi')
+      breathe = latency:wrap_thunk(breathe, now)
+   end
+
    monotonic_now = C.get_monotonic_time()
    repeat
       breathe()

--- a/src/lib/histogram.lua
+++ b/src/lib/histogram.lua
@@ -81,7 +81,7 @@ local function map_ptr(fd, len, type)
 end
 
 local function create_ptr(name, type, ...)
-   local path = mkdir_p(S.getpid(), name)
+   local path = mkdir_p(build_path(S.getpid(), name))
    local len = ffi.sizeof(type, ...)
    local fd, err = S.open(path, "creat, rdwr", '0664')
    if not fd then

--- a/src/lib/histogram.lua
+++ b/src/lib/histogram.lua
@@ -1,0 +1,136 @@
+-- histogram.lua -- a histogram with logarithmic buckets
+--
+-- API:
+--   histogram.new(min, max) => histogram
+--     Make a new histogram, with buckets covering the range from MIN to MAX.
+--     The range between MIN and MAX will be divided logarithmically.
+--
+--   histogram.add(histogram, measurement)
+--     Add a measurement to a histogram.
+--
+--   histogram.report(histogram, prev)
+--     Print out non-empty buckets and their ranges.  If PREV is given,
+--     it should be a snapshot of the previous version of the histogram.
+--
+--   histogram.snapshot(a, b)
+--     Copy out the contents of A into B and return B.  If B is not given,
+--     the result will be a fresh histogram.
+--
+--   histogram.clear(a)
+--     Clear the counters in A.
+--
+--   histogram.wrap_thunk(histogram, thunk, now)
+--     Return a closure that wraps THUNK, but which measures the difference
+--     between calls to NOW before and after the thunk, recording that
+--     difference into HISTOGRAM.
+--
+module(...,package.seeall)
+
+local app  = require("core.app")
+local ffi = require("ffi")
+
+-- Fill a 4096-byte page with buckets.  4096/8 = 512, minus the three
+-- header words means 509 buckets.  The first and last buckets are catch-alls.
+local histogram_t = ffi.typeof([[struct {
+   double minimum;
+   double growth_factor_log;
+   uint64_t count;
+   uint64_t buckets[509];
+}]])
+
+function new(minimum, maximum)
+   assert(minimum > 0)
+   assert(maximum > minimum)
+   -- 507 buckets for precise steps within minimum and maximum, 2 for
+   -- the catch-alls.
+   local growth_factor_log = math.log(maximum / minimum) / 507
+   return histogram_t(minimum, growth_factor_log)
+end
+
+local log, floor, max, min = math.log, math.floor, math.max, math.min
+function add(histogram, measurement)
+   local bucket
+   if measurement <= 0 then
+      bucket = 0
+   else
+      bucket = log(measurement / histogram.minimum)
+      bucket = bucket / histogram.growth_factor_log
+      bucket = floor(bucket) + 1
+      bucket = max(0, bucket)
+      bucket = min(508, bucket)
+   end
+   histogram.count = histogram.count + 1
+   histogram.buckets[bucket] = histogram.buckets[bucket] + 1
+end
+
+function report(histogram, prev)
+   local lo, hi = 0, histogram.minimum
+   local factor = math.exp(histogram.growth_factor_log)
+   local total = histogram.count
+   if prev then total = total - prev.total end
+   total = tonumber(total)
+   for bucket = 0, 508 do
+      local count = histogram.buckets[bucket]
+      if prev then count = count - prev.buckets[bucket] end
+      if count ~= 0 then
+         print(string.format('%.3e - %.3e: %u (%.5f%%)', lo, hi, tonumber(count),
+                             tonumber(count) / total * 100.))
+      end
+      lo, hi = hi, hi * factor
+   end
+end
+
+function snapshot(a, b)
+   b = b or histogram_t()
+   ffi.copy(b, a, ffi.sizeof(a))
+   return b
+end
+
+function clear(histogram)
+   histogram.count = 0
+   for bucket = 0, 508 do histogram.buckets[bucket] = 0 end
+end
+
+function wrap_thunk(histogram, thunk, now)
+   return function()
+      local start = now()
+      thunk()
+      histogram:add(now() - start)
+   end
+end
+
+ffi.metatype(histogram_t, {__index = {
+   add = add,
+   report = report,
+   snapshot = snapshot,
+   wrap_thunk = wrap_thunk,
+   clear = clear
+}})
+
+function selftest ()
+   print("selftest: histogram")
+
+   local h = new(1e-6, 1e0)
+   assert(ffi.sizeof(h) == 4096)
+
+   h:add(1e-7)
+   assert(h.buckets[0] == 1)
+   h:add(1e-6 + 1e-9)
+   assert(h.buckets[1] == 1)
+   h:add(1.0 - 1e-9)
+   assert(h.buckets[507] == 1)
+   h:add(1.5)
+   assert(h.buckets[508] == 1)
+
+   assert(h.count == 4)
+   assert(h:snapshot().count == 4)
+
+   h:report()
+
+   h:clear()
+   assert(h.count == 0)
+   assert(h.buckets[508] == 0)
+
+   print("selftest ok")
+end
+

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -19,9 +19,7 @@ function parse_args(args)
       assert(opts.duration >= 0, "duration can't be negative")
    end
    function handlers.h() show_usage(0) end
-   handlers["measure-latency"] = function() opts.measure_latency = true end
-   args = lib.dogetopt(args, handlers, "hD:",
-                       { help="h", duration="D", ["measure-latency"]=0 })
+   args = lib.dogetopt(args, handlers, "hD:", { help="h", duration="D", })
    if #args ~= 3 then show_usage(1) end
    return opts, unpack(args)
 end
@@ -38,14 +36,6 @@ function run(args)
    csv:add_app('sinkv4', { 'input' }, { input='Decapsulation' })
    csv:add_app('sinkv6', { 'input' }, { input='Encapsulation' })
    csv:activate()
-
-   if opts.measure_latency then
-      -- Record breathe() latencies between a range of 1us and 1s
-      local latency = require('lib.histogram').create('bench/breaths', 1e-6, 1e0)
-      app.breathe = latency:wrap_thunk(app.breathe, app.now)
-      local function report() latency:report(); latency:clear() end
-      timer.activate(timer.new("latency", report, 10e9, 'repeating'))
-   end
 
    app.main({duration=opts.duration})
 end

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -19,7 +19,9 @@ function parse_args(args)
       assert(opts.duration >= 0, "duration can't be negative")
    end
    function handlers.h() show_usage(0) end
-   args = lib.dogetopt(args, handlers, "hD:", { help="h", duration="D" })
+   handlers["measure-latency"] = function() opts.measure_latency = true end
+   args = lib.dogetopt(args, handlers, "hD:",
+                       { help="h", duration="D", ["measure-latency"]=0 })
    if #args ~= 3 then show_usage(1) end
    return opts, unpack(args)
 end
@@ -37,6 +39,13 @@ function run(args)
    csv:add_app('sinkv6', { 'input' }, { input='Encapsulation' })
    csv:activate()
 
-   app.busywait = true
+   if opts.measure_latency then
+      -- Record breathe() latencies between a range of 1us and 1s
+      local latency = require('lib.histogram').new(1e-6, 1e0)
+      app.breathe = latency:wrap_thunk(app.breathe, app.now)
+      local function report() latency:report(); latency:clear() end
+      timer.activate(timer.new("latency", report, 10e9, 'repeating'))
+   end
+
    app.main({duration=opts.duration})
 end

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -41,7 +41,7 @@ function run(args)
 
    if opts.measure_latency then
       -- Record breathe() latencies between a range of 1us and 1s
-      local latency = require('lib.histogram').new(1e-6, 1e0)
+      local latency = require('lib.histogram').create('bench/breaths', 1e-6, 1e0)
       app.breathe = latency:wrap_thunk(app.breathe, app.now)
       local function report() latency:report(); latency:clear() end
       timer.activate(timer.new("latency", report, 10e9, 'repeating'))

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -6,6 +6,7 @@ local lib = require("core.lib")
 local shm = require("core.shm")
 local counter = require("core.counter")
 local S = require("syscall")
+local histogram = require("lib.histogram")
 local usage = require("program.top.README_inc")
 
 local long_opts = {
@@ -36,6 +37,7 @@ function run (args)
          clearterm()
          print_global_metrics(new_stats, last_stats)
          io.write("\n")
+         print_latency_metrics(new_stats, last_stats)
          print_link_metrics(new_stats, last_stats)
          io.flush()
       end
@@ -67,6 +69,9 @@ function open_counters (tree)
    for _, name in ipairs({"configs", "breaths", "frees", "freebytes"}) do
       counters[name] = counter.open(tree.."/engine/"..name, 'readonly')
    end
+   local success, latency = pcall(histogram.open,
+                                  tree:match('^//([^/]+)'), 'engine/latency')
+   if success then counters.latency = latency end
    counters.links = {} -- These will be populated on demand.
    return counters
 end
@@ -96,6 +101,7 @@ function get_stats (counters)
    for _, name in ipairs({"configs", "breaths", "frees", "freebytes"}) do
       new_stats[name] = counter.read(counters[name])
    end
+   if counters.latency then new_stats.latency = counters.latency:snapshot() end
    new_stats.links = {}
    for linkspec, link in pairs(counters.links) do
       new_stats.links[linkspec] = {}
@@ -115,6 +121,18 @@ function print_global_metrics (new_stats, last_stats)
    print_row(global_metrics_row, {"Kfrees/s", "freeGbytes/s", "breaths/s"})
    print_row(global_metrics_row,
              {float_s(frees / 1000), float_s(bytes / (1000^3)), tostring(breaths)})
+end
+
+function print_latency_metrics (new_stats, last_stats)
+   local cur, prev = new_stats.latency, last_stats.latency
+   if not cur then return end
+   local min, avg, max = cur:summarize(prev)
+   print_row(global_metrics_row,
+             {"Min breath (us)", "Average", "Maximum"})
+   
+   print_row(global_metrics_row,
+             {float_s(min*1e6), float_s(avg*1e6), float_s(max*1e6)})
+   print("\n")
 end
 
 local link_metrics_row = {31, 7, 7, 7, 7, 7}


### PR DESCRIPTION
The feature is currently only wired up to snabb lwaftr bench, where you
can turn it on by passing --measure-latency.
