### PR TITLE
Docs recommend running "snabb lwaftr" instead of "snabb-lwaftr"

### DIFF
--- a/src/program/lwaftr/Makefile
+++ b/src/program/lwaftr/Makefile
@@ -5,9 +5,6 @@ E= @echo
 #Q=
 #E= @:
 
-snabb-lwaftr:
-	$(Q) (cd ../../; make snabb-lwaftr; ln -sf ../../$@ program/lwaftr/$@)
-
 snabb-lwaftr-doc: doc/snabb-lwaftr.pdf doc/snabb-lwaftr.html doc/snabb-lwaftr.epub
 
 doc/snabb-lwaftr.md:
@@ -25,11 +22,11 @@ doc/snabb-lwaftr.epub: doc/snabb-lwaftr.md
 	$(E) "PANDOC    $@"
 	$(Q) (cd doc; pandoc --self-contained --css="../../../doc/style.css" -S -s --toc --chapters -o snabb-lwaftr.epub snabb-lwaftr.md)
 
-CLEAN = snabb-lwaftr doc/snabb-lwaftr.*
+CLEAN = doc/snabb-lwaftr.*
 
 clean:
 	$(E) "RM        $(CLEAN)"
 	$(Q)-rm -rf $(CLEAN)
 	$(Q) (cd ../../; make clean)
 
-.PHONY: clean snabb-lwaftr
+.PHONY: clean

--- a/src/program/lwaftr/README
+++ b/src/program/lwaftr/README
@@ -1,13 +1,13 @@
 Usage:
-  snabb-lwaftr bench
-  snabb-lwaftr check
-  snabb-lwaftr run
-  snabb-lwaftr transient
-  snabb-lwaftr compile-binding-table
-  snabb-lwaftr generate-binding-table
-  snabb-lwaftr control
-  snabb-lwaftr loadtest
-  snabb-lwaftr generator
+  snabb lwaftr bench
+  snabb lwaftr check
+  snabb lwaftr run
+  snabb lwaftr transient
+  snabb lwaftr compile-binding-table
+  snabb lwaftr generate-binding-table
+  snabb lwaftr control
+  snabb lwaftr loadtest
+  snabb lwaftr generator
 
 Use --help for per-command usage.
 Example:

--- a/src/program/lwaftr/doc/README.ndp.md
+++ b/src/program/lwaftr/doc/README.ndp.md
@@ -1,6 +1,6 @@
 # NDP support
 
-There are conceptually two types of NDP support shipped with snabb-lwaftr.
+There are conceptually two types of NDP support shipped with Snabb lwAFTR.
 
 One listens for neighbor solicitations, and replies with neighbor advertisements.
 It replies to a solicitation if and only if the target address is one of the

--- a/src/program/lwaftr/doc/README.running.md
+++ b/src/program/lwaftr/doc/README.running.md
@@ -2,7 +2,7 @@
 
 ## Finding out the PCI addresses of your NICs
 
-Snabb-lwaftr is designed to run on **Intel 82599 10-Gigabit** NICs. Find the
+Snabb lwAFTR is designed to run on **Intel 82599 10-Gigabit** NICs. Find the
 address of NICs on your system with `lspci`:
 
 ```bash

--- a/src/program/lwaftr/doc/benchmarks-v1.0/Makefile
+++ b/src/program/lwaftr/doc/benchmarks-v1.0/Makefile
@@ -1,4 +1,4 @@
-LWAFTR=../snabb-lwaftr
+LWAFTR=../snabb
 
 IPV4_PCAP:=../snabbswitch/tests/apps/lwaftr/benchdata/ipv4-0550.pcap
 IPV6_PCAP:=../snabbswitch/tests/apps/lwaftr/benchdata/ipv6-0550.pcap
@@ -23,11 +23,11 @@ TRANSIENT_CPU=7
 SHELL=/bin/bash
 
 transient-self-test.csv: $(LWAFTR)
-	taskset -c $(TRANSIENT_CPU) ./snabb-lwaftr transient -s 0.25e9 -D 2 $(IPV4_PCAP) NIC1 $(TRANSIENT_SELF_TEST_NIC1_PCIADDR) $(IPV4_PCAP) NIC2 $(TRANSIENT_SELF_TEST_NIC2_PCIADDR) > $@
+	taskset -c $(TRANSIENT_CPU) ./snabb lwaftr transient -s 0.25e9 -D 2 $(IPV4_PCAP) NIC1 $(TRANSIENT_SELF_TEST_NIC1_PCIADDR) $(IPV4_PCAP) NIC2 $(TRANSIENT_SELF_TEST_NIC2_PCIADDR) > $@
 
 lwaftr-%.csv:: $(LWAFTR)
 	( set -m; set -o pipefail; \
-	  taskset -c 6 ./snabb-lwaftr run -D 170 --conf $(LWAFTR_CONF) --v4-pci $(LWAFTR_IPV4_PCIADDR) --v6-pci $(LWAFTR_IPV6_PCIADDR) & \
-	  taskset -c 7 ./snabb-lwaftr transient -s 0.25e9 -D 2 $(IPV4_PCAP) IPv4 $(TRANSIENT_IPV4_PCIADDR) $(IPV6_PCAP) IPv6 $(TRANSIENT_IPV6_PCIADDR) | tee $@.tmp && \
+	  taskset -c 6 ./snabb lwaftr run -D 170 --conf $(LWAFTR_CONF) --v4-pci $(LWAFTR_IPV4_PCIADDR) --v6-pci $(LWAFTR_IPV6_PCIADDR) & \
+	  taskset -c 7 ./snabb lwaftr transient -s 0.25e9 -D 2 $(IPV4_PCAP) IPv4 $(TRANSIENT_IPV4_PCIADDR) $(IPV6_PCAP) IPv6 $(TRANSIENT_IPV6_PCIADDR) | tee $@.tmp && \
 	  mv $@.tmp $@ && \
 	  wait )

--- a/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SNABB_LWAFTR=../../../../snabb-lwaftr
+SNABB_LWAFTR="../../../../snabb lwaftr"
 TEST_CONF=../data
 TEST_DATA=../data/vlan
 TEST_OUT=/tmp

--- a/src/program/lwaftr/tests/end-to-end/end-to-end.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SNABB_LWAFTR=../../../../snabb-lwaftr
+SNABB_LWAFTR="../../../../snabb lwaftr"
 TEST_BASE=../data
 TEST_OUT=/tmp
 EMPTY=${TEST_BASE}/empty.pcap


### PR DESCRIPTION
This change allows us to not rely on a modification to the core Snabb
makefile that created a "snabb-lwaftr" link.  We will recommend that
users run the lwaftr as "snabb lwaftr".  This will also allow them to
use other snabb facilities like "snabb top" from the same binary.