### PR TITLE
Rate limiter

### DIFF
--- a/src/apps/rate_limiter/README.md
+++ b/src/apps/rate_limiter/README.md
@@ -7,7 +7,7 @@ the `input` port and transmits conforming packets to the `output` port.
 
 ![RateLimiter](.images/RateLimiter.png)
 
-— Method **RateLimiter:snapshot**
+— Method **RateLimiter:get_stat_snapshot**
 
 Returns throughput statistics in form of a table with the following
 fields:
@@ -15,6 +15,11 @@ fields:
 * `rx` - Number of packets received
 * `tx` - Number of packets transmitted
 * `time` - Current time in nanoseconds
+
+— Method **RateLimiter:set_rate** byte_rate
+
+Configure the rate limiter to refill its empty its bucket at the new
+rate of `byte_rate` bytes per second.
 
 
 ## Configuration
@@ -26,6 +31,14 @@ following keys are defined:
 
 *Required*. Rate in bytes per second to which throughput should be
 limited.
+
+— Key **leaky**
+
+*Optional*.  If true, any incoming traffic that is beyond the configured
+throughput will be dropped.  Otherwise, incoming traffic beyond the
+configured threshold is left on the input link and will be dequeued when
+enough time has passed that the throughput will not be exceeded.
+Defaults to false.
 
 — Key **bucket_capacity**
 

--- a/src/apps/rate_limiter/rate_limiter.lua
+++ b/src/apps/rate_limiter/rate_limiter.lua
@@ -25,8 +25,10 @@ local PACKET_SIZE = 60
 
 function RateLimiter:new (arg)
    local conf = arg and config.parse_app_arg(arg) or {}
-   assert(conf.rate)
-   assert(conf.bucket_capacity)
+   --- By default, limit to 10 Mbps, just to have a default.
+   conf.rate = conf.rate or (10e6 / 8)
+   -- By default, allow for 255 standard packets in the queue.
+   conf.bucket_capacity = conf.bucket_capacity or (255 * 1500)
    conf.initial_capacity = conf.initial_capacity or conf.bucket_capacity
    local o =
    {

--- a/src/program/lwaftr/loadtest/loadtest.lua
+++ b/src/program/lwaftr/loadtest/loadtest.lua
@@ -6,6 +6,7 @@ local config = require("core.config")
 local pci = require("lib.hardware.pci")
 local Intel82599 = require("apps.intel.intel_app").Intel82599
 local basic_apps = require("apps.basic.basic_apps")
+local rate_limiter = require("apps.rate_limiter.rate_limiter")
 local main = require("core.main")
 local PcapReader = require("apps.pcap.pcap").PcapReader
 local lib = require("core.lib")
@@ -100,17 +101,20 @@ function run(args)
    for _,stream in ipairs(streams) do
       stream.pcap_id = 'pcap_'..stream.tx_id
       stream.repeater_id = 'repeater_'..stream.tx_id
+      stream.rate_limiter_id = 'rate_limiter_'..stream.tx_id
       stream.nic_tx_id = 'nic_'..stream.tx_id
       stream.nic_rx_id = 'nic_'..stream.rx_id
       stream.rx_sink_id = 'rx_sink_'..stream.rx_id
 
       config.app(c, stream.pcap_id, PcapReader, stream.capture_file)
-      config.app(c, stream.repeater_id, basic_apps.RateLimitedRepeater, {})
+      config.app(c, stream.repeater_id, basic_apps.Repeater, {})
+      config.app(c, stream.rate_limiter_id, rate_limiter.RateLimiter, { })
       config.app(c, stream.nic_tx_id, Intel82599, { pciaddr = stream.pci_addr })
       config.app(c, stream.rx_sink_id, basic_apps.Sink)
 
       config.link(c, stream.pcap_id..".output -> "..stream.repeater_id..".input")
-      config.link(c, stream.repeater_id..".output -> "..stream.nic_tx_id..".rx")
+      config.link(c, stream.repeater_id..".output -> "..stream.rate_limiter_id..".input")
+      config.link(c, stream.rate_limiter_id..".output -> "..stream.nic_tx_id..".rx")
 
       config.link(c, stream.nic_rx_id..".tx -> "..stream.rx_sink_id..".input")
    end
@@ -119,7 +123,7 @@ function run(args)
    local function adjust_rates(bit_rate)
       local byte_rate = bit_rate / 8
       for _,stream in ipairs(streams) do
-         local app = engine.app_table[stream.repeater_id]
+         local app = engine.app_table[stream.rate_limiter_id]
          app:set_rate(byte_rate)
       end
    end

--- a/src/program/snabbnfv/nfvconfig.lua
+++ b/src/program/snabbnfv/nfvconfig.lua
@@ -48,7 +48,8 @@ function load (file, pciaddr, sockpath)
       if t.tx_police_gbps then
          local TxLimit = name.."_TxLimit"
          local rate = t.tx_police_gbps * 1e9 / 8
-         config.app(c, TxLimit, RateLimiter, {rate = rate, bucket_capacity = rate})
+         config.app(c, TxLimit, RateLimiter,
+                    {rate = rate, bucket_capacity = rate, leaky = true})
          config.link(c, VM_tx.." -> "..TxLimit..".input")
          VM_tx = TxLimit..".output"
       end
@@ -95,7 +96,8 @@ function load (file, pciaddr, sockpath)
       if t.rx_police_gbps then
          local RxLimit = name.."_RxLimit"
          local rate = t.rx_police_gbps * 1e9 / 8
-         config.app(c, RxLimit, RateLimiter, {rate = rate, bucket_capacity = rate})
+         config.app(c, RxLimit, RateLimiter,
+                    {rate = rate, bucket_capacity = rate, leaky = true})
          config.link(c, RxLimit..".output -> "..VM_rx)
          VM_rx = RxLimit..".input"
       end


### PR DESCRIPTION
This PR adds a mode to the standard RateLimiter app where it isn't leaky -- it avoids reading off buffers from its input if they would exceed the throughput.  It also adds default values for "rate" and "bucket_capacity".  Finally it adapts our load generators to use this.  I tested it on our lab; it seems to work, without leaks and without being leaky.

Nota bene, this new "leaky" parameter is now off by default, a behavioral change relative to master.  I'll have to see if this works for Snabb.  Anyway this will let us remove our RateLimitedRepeater; see https://github.com/SnabbCo/snabbswitch/pull/782.