### PR TITLE
Improved logging for the lwaftr

### DIFF
--- a/src/apps/lwaftr/dump.lua
+++ b/src/apps/lwaftr/dump.lua
@@ -3,6 +3,7 @@ module(..., package.seeall)
 local ethernet = require("lib.protocol.ethernet")
 local ipv6 = require("lib.protocol.ipv6")
 local ipv4 = require("lib.protocol.ipv4")
+local log = require("apps.lwaftr.log")
 
 local CONF_FILE_DUMP = "/tmp/lwaftr-%s.conf"
 local BINDING_TABLE_FILE_DUMP = "/tmp/binding-%s.table"
@@ -31,7 +32,7 @@ local function ipv4number_to_str(ip)
 end
 
 function dump_configuration(lwstate)
-   print("Dump configuration")
+   log.info("Dump configuration...")
    local result = {}
    local etharr = set('aftr_mac_b4_side', 'aftr_mac_inet_side', 'next_hop6_mac', 'inet_mac')
    local ipv4arr = set('aftr_ipv4_ip')
@@ -52,11 +53,11 @@ function dump_configuration(lwstate)
    local filename = (CONF_FILE_DUMP):format(os.date("%Y-%m-%d-%H:%M:%S"))
    local content = table.concat(result, "\n")
    write_to_file(filename, content)
-   print(("Configuration written to %s"):format(filename))
+   log.info("Configuration written to ${%q}", filename)
 end
 
 function dump_binding_table(lwstate)
-   print("Dump binding table")
+   log.info("Dump binding table...")
    local content = {}
    local function write(str)
       table.insert(content, str)
@@ -85,5 +86,5 @@ function dump_binding_table(lwstate)
    -- Dump content to file
    local filename = (BINDING_TABLE_FILE_DUMP):format(os.date("%Y-%m-%d-%H:%M:%S"))
    write_to_file(filename, dump())
-   print(("Binding table written to %s"):format(filename))
+   log.info("Binding table written to ${%q}", filename)
 end

--- a/src/apps/lwaftr/log.lua
+++ b/src/apps/lwaftr/log.lua
@@ -1,0 +1,55 @@
+local log = {
+   usecolor = true;
+   level    = "warn";
+   output   = io.stderr;
+}
+
+local modes = {
+   { name = "trace", color = "\27[34m" };
+   { name = "debug", color = "\27[36m" };
+   { name = "info" , color = "\27[32m" };
+   { name = "warn" , color = "\27[33m" };
+   { name = "error", color = "\27[31m" };
+   { name = "fatal", color = "\27[35m" };
+}
+
+local debug_getinfo = debug.getinfo
+local string_format = string.format
+local os_date = os.date
+local _type = type
+
+local msgformat = "%s[%-6s%s]%s %s:%d: %s\n"
+local levels = {}
+
+for i, v in ipairs(modes) do
+   levels[v.name] = i
+   local name_upper = v.name:upper()
+
+   log[v.name] = function (fmtstring, arg1, ...)
+      if i < levels[log.level] then
+         return
+      end
+
+      local message
+      if _type(arg1) == "function" then
+         -- Arguments are retrieved by invoking the function
+         message = string_format(fmtstring, arg1())
+      else
+         message = string_format(fmtstring, arg1, ...)
+      end
+
+      local dinfo = debug_getinfo(2, "Sl")
+
+      log.output:write(string_format(msgformat,
+                                     log.usecolor and v.color or "",
+                                     name_upper,
+                                     os_date("%H:%M:%S"),
+                                     log.usecolor and "\27[0m" or "",
+                                     dinfo.short_src,
+                                     dinfo.currentline,
+                                     message))
+      log.output:flush()
+   end
+end
+
+return log

--- a/src/apps/lwaftr/lwdebug.lua
+++ b/src/apps/lwaftr/lwdebug.lua
@@ -49,3 +49,27 @@ end
 function selftest ()
    assert(format_ipv4(0xfffefdfc) == "255.254.253.252", "Bad conversion in format_ipv4")
 end
+
+
+local has_log, log = pcall(require, "apps.lwaftr.log")
+if has_log then
+   function log.format.packet (pkt)
+      local bytes = gen_hex_bytes(pkt.data, pkt.length)
+      return string.format("length: %i, data:\n%s", pkt.length, bytes)
+   end
+   function log.format.macaddr (addr)
+      local chunks = {}
+      for i = 0, 5 do
+         table.insert(chunks, string.format("%02x", addr[i]))
+      end
+      return table.concat(chunks, ":")
+   end
+   function log.format.ipv6 (addr)
+      local chunks = {}
+      for i = 0, 7 do
+         table.insert(chunks, string.format("%x%x", addr[2 * i], addr[2 * i + 1]))
+      end
+      return table.concat(chunks, ":")
+   end
+   log.format.ipv4 = format_ipv4
+end

--- a/src/apps/lwaftr/lwdebug.lua
+++ b/src/apps/lwaftr/lwdebug.lua
@@ -1,25 +1,7 @@
 module(..., package.seeall)
 
 local bit = require("bit")
-local band, bor, rshift = bit.band, bit.bor, bit.rshift
-
-function pp(t) for k,v in pairs(t) do print(k,v) end end
-
-function print_ethernet(addr)
-   chunks = {}
-   for i = 0,5 do
-      table.insert(chunks, string.format("%x", addr[i]))
-   end
-   print(table.concat(chunks, ':'))
-end
-
-function print_ipv6(addr)
-   chunks = {}
-   for i = 0,7 do
-      table.insert(chunks, string.format("%x%x", addr[2*i], addr[2*i+1]))
-   end
-   print(table.concat(chunks, ':'))
-end
+local band, rshift = bit.band, bit.rshift
 
 local function gen_hex_bytes(data, len)
    local fbytes = {}
@@ -27,15 +9,6 @@ local function gen_hex_bytes(data, len)
       table.insert(fbytes, string.format("0x%x", data[i]))
    end
    return fbytes
-end
-
-function print_hex(data, len)
-   print(table.concat(gen_hex_bytes(data, len), " "))
-end
-
-function print_pkt(pkt)
-   local fbytes = gen_hex_bytes(pkt.data, pkt.length)
-   print(string.format("Len: %i: ", pkt.length) .. table.concat(fbytes, " "))
 end
 
 function format_ipv4(uint32)
@@ -51,6 +24,16 @@ function selftest ()
 end
 
 
+-- TODO: Maybe it would be better to unconditioally import the "log" module,
+--       add the formatters to it, and return the log module itself, so client
+--       code both import the "log" module and install our custom formatters
+--       by doing:
+--
+--          local log = require("apps.lwaftr.lwdebug")
+--
+--       In that case, probably it'd be better to call the "lwdebug" module
+--       something else, like "apps.lwaftr.lwlog". Dunno.
+--
 local has_log, log = pcall(require, "apps.lwaftr.log")
 if has_log then
    function log.format.packet (pkt)

--- a/src/program/lwaftr/bench/README
+++ b/src/program/lwaftr/bench/README
@@ -2,6 +2,8 @@ Usage: bench CONF IPV4-IN.PCAP IPV6-IN.PCAP
 
   -h, --help
                              Print usage information.
+  --log-level <level>        Set logging amount (default: warn, available:
+                             trace, debug, info, warn, error, fatal).
 
 Run the lwAFTR with input from IPV4-IN.PCAP and IPV6-IN.PCAP. The bench
 command is used to get an idea of the raw speed of the lwaftr without

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -3,6 +3,7 @@ module(..., package.seeall)
 local app = require("core.app")
 local config = require("core.config")
 local lib = require("core.lib")
+local log = require("apps.lwaftr.log")
 local csv_stats  = require("program.lwaftr.csv_stats")
 local setup = require("program.lwaftr.setup")
 
@@ -19,7 +20,18 @@ function parse_args(args)
       assert(opts.duration >= 0, "duration can't be negative")
    end
    function handlers.h() show_usage(0) end
-   args = lib.dogetopt(args, handlers, "hD:", { help="h", duration="D" })
+   handlers["log-level"] = function (arg)
+      if not arg then
+         log.fatal("No parameter passed to '--log-level'")
+         main.exit(1)
+      end
+      if not log[arg] then
+         log.fatal("Invalid log level '${}'", arg)
+         main.exit(1)
+      end
+      log.level = arg
+   end
+   args = lib.dogetopt(args, handlers, "hD:", { help="h", duration="D", ["log-level"] = 1 })
    if #args ~= 3 then show_usage(1) end
    return opts, unpack(args)
 end

--- a/src/program/lwaftr/check/README
+++ b/src/program/lwaftr/check/README
@@ -2,6 +2,8 @@ Usage: check CONF IPV4-IN.PCAP IPV6-IN.PCAP IPV4-OUT.PCAP IPV6-OUT.PCAP
 
   -h, --help
                              Print usage information.
+  --log-level <level>        Set logging amount (default: warn, available:
+                             trace, debug, info, warn, error, fatal).
 
 Run the lwAFTR with input from IPV4-IN.PCAP and IPV6-IN.PCAP, and record
 output to IPV4-OUT.PCAP and IPV6-OUT.PCAP.  Exit when finished.  This

--- a/src/program/lwaftr/check/check.lua
+++ b/src/program/lwaftr/check/check.lua
@@ -3,6 +3,7 @@ module(..., package.seeall)
 local app = require("core.app")
 local config = require("core.config")
 local lib = require("core.lib")
+local log = require("apps.lwaftr.log")
 local setup = require("program.lwaftr.setup")
 
 function show_usage(code)
@@ -12,8 +13,19 @@ end
 
 function parse_args(args)
    local handlers = {}
+   handlers["log-level"] = function (arg)
+      if not arg then
+         log.fatal("No parameter passed to '--log-level'")
+         main.exit(1)
+      end
+      if not log[arg] then
+         log.fatal("Invalid log level '${}'", arg)
+         main.exit(1)
+      end
+      log.level = arg
+   end
    function handlers.h() show_usage(0) end
-   args = lib.dogetopt(args, handlers, "h", { help="h" })
+   args = lib.dogetopt(args, handlers, "h", { help="h", ["log-level"] = 1 })
    if #args ~= 5 then show_usage(1) end
    return unpack(args)
 end

--- a/src/program/lwaftr/run/README
+++ b/src/program/lwaftr/run/README
@@ -11,5 +11,7 @@ Optional arguments:
        --ring-buffer-size <size>  Set Intel 82599 receive buffer size
        --cpu    <cpu>           Bind the lwAFTR to the given CPU
        --real-time              Enable real-time SCHED_FIFO scheduler
+       --log-level <level>      Set logging amount (default: warn, available:
+                                trace, debug, info, warn, error, fatal).
        -D       <seconds>       Duration in seconds
        -v                       Verbose (repeat for more verbosity)

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -3,6 +3,7 @@ module(..., package.seeall)
 local S          = require("syscall")
 local config     = require("core.config")
 local csv_stats  = require("program.lwaftr.csv_stats")
+local log        = require("apps.lwaftr.log")
 local lib        = require("core.lib")
 local setup      = require("program.lwaftr.setup")
 
@@ -96,12 +97,17 @@ function parse_args(args)
          fatal("ring size is not a power of two: " .. arg)
       end
    end
+   handlers["log-level"] = function (arg)
+      if not arg then fatal("No argument passed to '--log-level'") end
+      if not log[arg] then fatal(("Invalid log level '%s'"):format(arg)) end
+      log.level = arg
+   end
    function handlers.h() show_usage(0) end
    lib.dogetopt(args, handlers, "b:c:n:m:vD:hir:",
       { conf = "c", ["v4-pci"] = "n", ["v6-pci"] = "m",
         verbose = "v", duration = "D", help = "h",
         virtio = "i", ["ring-buffer-size"] = "r", cpu = 1,
-        ["real-time"] = 0 })
+        ["real-time"] = 0, ["log-level"] = 1 })
    if ring_buffer_size ~= nil then
       if opts.virtio_net then
          fatal("setting --ring-buffer-size does not work with --virtio")


### PR DESCRIPTION
:warning: **Do not merge yet** — this is a RFC PR :warning: 

This imports a new `apps.lwaftr.log` module which provides a standarized logging infrastructure. The features are:

- Timestamps in `HH:MM:SS` format and the name of the log level are prepended to log messages automatically.
- Uses the Lua `debug` module to include the file name and line where calls to the log functions are done.
- Logs are sent to `io.stderr` by default. Set `log.output` to a file-like object to change the output:
```lua
local log = require("apps.lwaftr.log")
log.output = io.open("/var/foo.log", "a")
log.info("Log output file changed")
```
- Colourful output, with different colors for each log level. To disable colors, set `log.usercolor = false`.
- Support for advanced string formatting/interpolation: Replacements in format string are delimited by `${}`, and can take the following forms (the text is from commit log which adds this feature):
```
   The following formats are recognized:

      ${}    Pick current argument.
      ${.}   Pick current argument, and advance to the next argument.
      ${I}   Pick argument I (where I is a number).
      ${N}   Pick current argument as a table, and return field N.
      ${.N}  Pick current argument as a table, return field N, and advance
             to the next argument.

    All the above interpolation expansions accept an optional format conversion
    specification, after a percent sign, as in ${argument%format}. Available
    formats are:

      ${%}   No format: Use tostring().
      ${%N}  Where N is a field from the log.format table: apply function
             log.format[N] to the value which will be printed, and use the
             resulting value instead.
      ${%P}  Where P is a format specifier as used with string.format():
             uses string.format("%P", value).

```
- Support for custom formatters. This is used to print IPv4 addresses, IPv6 addresses, MAC addresses, and packet contents (see `lwdebug.lua` for the definitions of the formatters). Example:
```lua
local log = require("apps.lwaftr.log")
log.level = "info"
log.format.doge = function (value)
  return "much " .. tostring(value) .. ", such " tostring(value)" .. ", wow!"
end
-- Prints "much networking, such networking, wow!"
log.info("${%doge}", "networking")
```
- Support using a function a parameter, to do lazy evaluation of the arguments to the format string:
```lua
log.debug("table field: ${field}", function ()
  -- The function may use expensive calculations, which will be done only when
  -- the "debug" log level is enabled.
  return { field = 42 }
end)
```