### PR TITLE
Clear out Flags in ICMPv4 echo-reply

### DIFF
--- a/src/apps/lwaftr/ipv4_apps.lua
+++ b/src/apps/lwaftr/ipv4_apps.lua
@@ -183,6 +183,9 @@ function ICMPEcho:push()
             local ihl = get_ihl_from_offset(pkt, o_ipv4_ver_and_ihl)
             pkt.data[o_icmpv4_msg_type_sans_ihl + ihl] = icmpv4_echo_reply
 
+            -- Clear out flags
+            pkt_ipv4:flags(0)
+
             -- Recalculate checksums
             wr16(pkt.data + o_icmpv4_checksum_sans_ihl + ihl, 0)
             local icmp_offset = ethernet_header_size + ihl


### PR DESCRIPTION
It's a common practice in ping packets to set the Flags field of the IPv4 header with value DF (Don't Fragment). The reason for that is implementation of Path MTU discovery [1]

Echo-reply packets are generated by copying an echo-request payload and swapping IP addresses plus changing message type. The Flags field should be cleared out in the echo-reply packet.

[1] https://en.wikipedia.org/wiki/Path_MTU_Discovery