### PR TITLE
Monitor QPRDC and run jit flush if threshold exceeded

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -187,6 +187,10 @@ do
    end
 end
 
+function M_sf:ingress_packet_drops ()
+   return self.qs.QPRDC[0]()
+end
+
 function M_sf:init_snmp ()
    -- Rudimentary population of a row in the ifTable MIB.  Allocation
    -- of the ifIndex is delegated to the SNMP agent via the name of
@@ -717,6 +721,7 @@ M_pf.set_promiscuous_mode = M_sf.set_promiscuous_mode
 M_pf.init_receive = M_sf.init_receive
 M_pf.init_transmit = M_sf.init_transmit
 M_pf.wait_linkup = M_sf.wait_linkup
+M_pf.ingress_packet_drops = M_sf.ingress_packet_drops
 
 function M_pf:set_vmdq_mode ()
    self.r.RTTDCS(bits{VMPAC=1,ARBDIS=6,BDPM=22})       -- clear TDPAC,TDRM=4, BPBFSM
@@ -1171,6 +1176,9 @@ function M_vf:set_tx_rate (limit, priority)
    return self
 end
 
+function M_vf:ingress_packet_drops ()
+   return self.pf:ingress_packet_drops()
+end
 
 rxdesc_t = ffi.typeof [[
    union {

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -97,6 +97,10 @@ function Intel82599:pull ()
    self:add_receive_buffers()
 end
 
+function Intel82599:ingress_packet_drops ()
+   return self.dev:ingress_packet_drops()
+end
+
 function Intel82599:add_receive_buffers ()
    -- Generic buffers
    while self.dev:can_add_receive_buffer() do

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -41,7 +41,7 @@ function ingress_drop_monitor:sample()
    sum[0] = 0
    for i = 1, #app_array do
       local app = app_array[i]
-      if app.pull and not app.dead then
+      if app.ingress_packet_drops and not app.dead then
          sum[0] = sum[0] + app:ingress_packet_drops()
       end
    end
@@ -53,6 +53,7 @@ function ingress_drop_monitor:jit_flush_if_needed()
    self.last_flush = app.now()
    self.last_value[0] = self.current_value[0]
    jit.flush()
+   print("jit.flush")
    --- TODO: Change last_flush, last_value and current_value fields to be counters.
 end
 
@@ -275,8 +276,8 @@ function main (options)
       breathe = latency:wrap_thunk(breathe, now)
    end
 
-   if options.ingress_drop_monitor then
-      local interval = 1e9 / 1e2   -- Every 100 milliseconds.
+   if options.ingress_drop_monitor or options.ingress_drop_monitor == nil then
+      local interval = 1e8   -- Every 100 milliseconds.
       local function fn()
          ingress_drop_monitor:sample()
          ingress_drop_monitor:jit_flush_if_needed()

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -20,18 +20,41 @@ local use_restart = false
 
 test_skipped_code = 43
 
-ingress_packet_drops = {
-   threshold = 100000,
-   wait = 20,
-   last_value = 0,
-}
-
 -- The set of all active apps and links in the system.
 -- Indexed both by name (in a table) and by number (in an array).
 app_table,  app_array  = {}, {}
 link_table, link_array = {}, {}
 
 configuration = config.new()
+
+-- Ingress packet drop monitor.
+ingress_drop_monitor = {
+   threshold = 100000,
+   wait = 20,
+   last_flush = 0,
+   last_value = ffi.new('uint64_t[1]'),
+   current_value = ffi.new('uint64_t[1]')
+}
+
+function ingress_drop_monitor:sample()
+   local sum = self.current_value
+   sum[0] = 0
+   for i = 1, #app_array do
+      local app = app_array[i]
+      if app.pull and not app.dead then
+         sum[0] = sum[0] + app:ingress_packet_drops()
+      end
+   end
+end
+
+function ingress_drop_monitor:jit_flush_if_needed()
+   if self.current_value[0] - self.last_value[0] < self.threshold then return end
+   if app.now() - self.last_flush < self.wait then return end
+   self.last_flush = app.now()
+   self.last_value[0] = self.current_value[0]
+   jit.flush()
+   --- TODO: Change last_flush, last_value and current_value fields to be counters.
+end
 
 -- Counters for statistics.
 breaths   = counter.open("engine/breaths")   -- Total breaths taken
@@ -252,6 +275,16 @@ function main (options)
       breathe = latency:wrap_thunk(breathe, now)
    end
 
+   if options.ingress_drop_monitor then
+      local interval = 1e9 / 1e2   -- Every 100 milliseconds.
+      local function fn()
+         ingress_drop_monitor:sample()
+         ingress_drop_monitor:jit_flush_if_needed()
+      end
+      local t = timer.new("ingress drop monitor", fn, interval, "repeating")
+      timer.activate(t)
+   end
+
    monotonic_now = C.get_monotonic_time()
    repeat
       breathe()
@@ -289,24 +322,6 @@ function pace_breathing ()
    end
 end
 
-local jit_flush_if_needed = (function ()
-   local last_trigger = 0
-   return function (app)
-      local now = now()
-      if now < last_trigger then return end
-      if app.ingress_packet_drops then
-         local threshold = ingress_packet_drops.last_value + ingress_packet_drops.threshold
-         local current = app:ingress_packet_drops()
-         local exceeded = current > threshold
-         if exceeded then
-            ingress_packet_drops.last_value = current
-            last_trigger = now + ingress_packet_drops.wait
-            jit.flush()
-         end
-      end
-   end
-end)()
-
 function breathe ()
    monotonic_now = C.get_monotonic_time()
    -- Restart: restart dead apps
@@ -317,7 +332,6 @@ function breathe ()
       if app.pull and not app.dead then
          zone(app.zone)
          with_restart(app, app.pull)
-         jit_flush_if_needed(app)
          zone()
       end
    end

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -20,6 +20,12 @@ local use_restart = false
 
 test_skipped_code = 43
 
+ingress_packet_drops = {
+   threshold = 100000,
+   wait = 20,
+   last_value = 0,
+}
+
 -- The set of all active apps and links in the system.
 -- Indexed both by name (in a table) and by number (in an array).
 app_table,  app_array  = {}, {}
@@ -283,6 +289,28 @@ function pace_breathing ()
    end
 end
 
+local function exceeded_ingress_packet_drops (app)
+   if app.ingress_packet_drops then
+      local threshold = ingress_packet_drops.last_value + ingress_packet_drops.threshold
+      local current = app:ingress_packet_drops()
+      local exceeded = current > threshold
+      if exceeded then
+         ingress_packet_drops.last_value = current
+      end
+      return exceeded
+   end
+end
+
+local jit_flush = (function ()
+   local last_trigger = 0
+   return function (app)
+      local now = now()
+      if now < last_trigger then return end
+      jit.flush()
+      last_trigger = now + ingress_packet_drops.wait
+   end
+end)()
+
 function breathe ()
    monotonic_now = C.get_monotonic_time()
    -- Restart: restart dead apps
@@ -290,11 +318,12 @@ function breathe ()
    -- Inhale: pull work into the app network
    for i = 1, #app_array do
       local app = app_array[i]
---      if app.pull then
---         zone(app.zone) app:pull() zone()
       if app.pull and not app.dead then
          zone(app.zone)
          with_restart(app, app.pull)
+         if exceeded_ingress_packet_drops(app) then
+            jit_flush()
+         end
          zone()
       end
    end


### PR DESCRIPTION
Monitors QPRDC register (Queue Packet Received Drop Counter), and calls `jit.flush()` if packet drop threshold is exceeded.

Original code by Marcel Wiget. Back ported from [1].

[1] https://github.com/mwiget/snabbswitch/commit/89cec535790f8d5762d31824e55582169a2bcfe7
