### PR TITLE
Manage Neighbor Advertisement without Target link-layer address

### DIFF
--- a/src/apps/lwaftr/lwdebug.lua
+++ b/src/apps/lwaftr/lwdebug.lua
@@ -33,9 +33,38 @@ function print_hex(data, len)
    print(table.concat(gen_hex_bytes(data, len), " "))
 end
 
+-- Formats packet in 'od' format:
+--
+--    000000 00 0e b6 00 00 02 00 0e b6 00 00 01 08 00 45 00
+--    000010 00 28 00 00 00 00 ff 01 37 d1 c0 00 02 01 c0 00
+--    000020 02 02 08 00 a6 2f 00 01 00 01 48 65 6c 6c 6f 20
+--    000030 57 6f 72 6c 64 21
+--
+-- A packet text dump in 'od' format can be easily converted into a pcap file:
+--
+--    $ text2pcap pkt.txt pkt.pcap
+---
+local function od_dump(pkt)
+   local function column_index(i)
+      return ("%.6x"):format(i)
+   end
+   local function column_value(val)
+      return ("%.2x"):format(val)
+   end
+   local ret = {}
+   for i=0, pkt.length-1 do
+      if i == 0 then
+         table.insert(ret, column_index(i))
+      elseif i % 16 == 0 then
+         table.insert(ret, "\n"..column_index(i))
+      end
+      table.insert(ret, column_value(pkt.data[i]))
+   end
+   return table.concat(ret, " ")
+end
+
 function print_pkt(pkt)
-   local fbytes = gen_hex_bytes(pkt.data, pkt.length)
-   print(string.format("Len: %i: ", pkt.length) .. table.concat(fbytes, " "))
+   print(("Len: %i, data:\n%s"):format(pkt.length, od_dump(pkt)))
 end
 
 function format_ipv4(uint32)

--- a/src/apps/lwaftr/ndp.lua
+++ b/src/apps/lwaftr/ndp.lua
@@ -401,7 +401,8 @@ function selftest()
    set_dst_ethernet(nsp, lmac) -- Not a meaningful thing to do, just a test
    
    local sol_na = form_nsolicitation_reply(lmac, lip, nsp)
-   get_dst_ethernet(sol_na, {rip})
+   local dst_eth = get_dst_ethernet(sol_na, {rip})
+   assert(ethernet:ntop(dst_eth) == "01:02:03:04:05:06")
    assert(sol_na, "an na packet should have been formed")
    assert(is_ndp(sol_na), "sol_na must be ndp!")
    assert(is_solicited_neighbor_advertisement(sol_na), "sol_na must be sna!")

--- a/src/apps/lwaftr/ndp.lua
+++ b/src/apps/lwaftr/ndp.lua
@@ -391,7 +391,24 @@ function form_nsolicitation_reply(local_eth, local_ipv6, ns_pkt)
    return form_sna(local_eth, local_ipv6, true, ns_pkt)
 end
 
+local function test_ndp_without_target_link()
+   local lib = require("core.lib")
+   -- Neighbor Advertisement packet.
+   local na_pkt = lib.hexundump([[
+      02:aa:aa:aa:aa:aa 90:e2:ba:a9:89:2d 86 dd 60 00 
+      00 00 00 18 3a ff fe 80 00 00 00 00 00 00 92 e2 
+      ba ff fe a9 89 2d fc 00 00 00 00 00 00 00 00 00 
+      00 00 00 00 01 00 88 00 92 36 40 00 00 00 fe 80 
+      00 00 00 00 00 00 92 e2 ba ff fe a9 89 2d
+   ]], 78)
+   local dst_eth = get_dst_ethernet(packet.from_string(na_pkt),
+      {ipv6:pton("fe80::92e2:baff:fea9:892d")})
+   assert(ethernet:ntop(dst_eth) == "90:e2:ba:a9:89:2d")
+end
+
 function selftest()
+   print("selftest: ndp")
+
    local lmac = ethernet:pton("01:02:03:04:05:06")
    local lip = ipv6:pton("1:2:3:4:5:6:7:8")
    local rip = ipv6:pton("9:a:b:c:d:e:f:0")
@@ -406,4 +423,8 @@ function selftest()
    assert(sol_na, "an na packet should have been formed")
    assert(is_ndp(sol_na), "sol_na must be ndp!")
    assert(is_solicited_neighbor_advertisement(sol_na), "sol_na must be sna!")
+
+   test_ndp_without_target_link()
+
+   print("selftest: ok")
 end


### PR DESCRIPTION
Backport of #291 to `lwaftr_starfruit` branch.
