### PR TITLE
Do load testing at line rates, including overhead

### DIFF
--- a/src/apps/lwaftr/loadgen.lua
+++ b/src/apps/lwaftr/loadgen.lua
@@ -13,9 +13,9 @@ RateLimitedRepeater = {}
 function RateLimitedRepeater:new (arg)
    local conf = arg and config.parse_app_arg(arg) or {}
    --- By default, limit to 10 Mbps, just to have a default.
-   conf.rate = conf.rate or (10e6 / 8)
+   conf.rate = conf.rate or 10e6
    -- By default, allow for 255 standard packets in the queue.
-   conf.bucket_capacity = conf.bucket_capacity or (255 * 1500)
+   conf.bucket_capacity = conf.bucket_capacity or (255 * 1500 * 8)
    conf.initial_capacity = conf.initial_capacity or conf.bucket_capacity
    local o = {
       index = 1,
@@ -27,8 +27,8 @@ function RateLimitedRepeater:new (arg)
    return setmetatable(o, {__index=RateLimitedRepeater})
 end
 
-function RateLimitedRepeater:set_rate (byte_rate)
-   self.rate = math.max(byte_rate, 0)
+function RateLimitedRepeater:set_rate (bit_rate)
+   self.rate = math.max(bit_rate, 0)
 end
 
 function RateLimitedRepeater:push ()
@@ -48,12 +48,16 @@ function RateLimitedRepeater:push ()
       self.last_time = cur_now
    end
 
+   -- 7 bytes preamble, 1 start-of-frame, 4 CRC, 12 interpacket gap.
+   local overhead = 7 + 1 + 4 + 12
+
    local npackets = #self.packets
    if npackets > 0 and self.rate > 0 then
       for _ = 1, link.nwritable(o) do
          local p = self.packets[self.index]
-         if p.length > self.bucket_content then break end
-         self.bucket_content = self.bucket_content - p.length
+         local bits = (p.length + overhead) * 8
+         if bits > self.bucket_content then break end
+         self.bucket_content = self.bucket_content - bits
          transmit(o, clone(p))
          self.index = (self.index % npackets) + 1
       end

--- a/src/program/lwaftr/loadtest/loadtest.lua
+++ b/src/program/lwaftr/loadtest/loadtest.lua
@@ -118,10 +118,9 @@ function run(args)
    engine.configure(c)
 
    local function adjust_rates(bit_rate)
-      local byte_rate = bit_rate / 8
       for _,stream in ipairs(streams) do
          local app = engine.app_table[stream.repeater_id]
-         app:set_rate(byte_rate)
+         app:set_rate(bit_rate)
       end
    end
 

--- a/src/program/lwaftr/loadtest/loadtest.lua
+++ b/src/program/lwaftr/loadtest/loadtest.lua
@@ -152,6 +152,11 @@ function run(args)
    end
 
    local function print_counter_diff(before, after)
+      local function bitrate(diff)
+         -- 7 bytes preamble, 1 start-of-frame, 4 CRC, 12 interpacket gap.
+         local overhead = 7 + 1 + 4 + 12
+         return (diff.txbytes + diff.txpackets * overhead) * 8 / opts.duration
+      end
       for _, stream in ipairs(streams) do
          print(string.format('  %s:', stream.tx_name))
          local nic_id = stream.nic_tx_id
@@ -160,10 +165,10 @@ function run(args)
          local rx = diff_counters(nic_before.rx, nic_after.rx)
          print(string.format('    TX %d packets (%f MPPS), %d bytes (%f Gbps)',
                              tx.txpackets, tx.txpackets / opts.duration / 1e6,
-                             tx.txbytes, tx.txbytes / opts.duration / 1e9 * 8))
+                             tx.txbytes, bitrate(tx) / 1e9))
          print(string.format('    RX %d packets (%f MPPS), %d bytes (%f Gbps)',
                              rx.txpackets, rx.txpackets / opts.duration / 1e6,
-                             rx.txbytes, rx.txbytes / opts.duration / 1e9 * 8))
+                             rx.txbytes, bitrate(rx) / 1e9))
          print(string.format('    Loss: %d packets (%f%%)',
                              tx.txpackets - rx.txpackets,
                              (tx.txpackets - rx.txpackets) / tx.txpackets * 100))

--- a/src/program/lwaftr/transient/transient.lua
+++ b/src/program/lwaftr/transient/transient.lua
@@ -89,10 +89,10 @@ end
 function adjust_rate(opts, streams)
    local count = math.ceil(opts.bitrate / opts.step)
    return function()
-      local byte_rate = (opts.bitrate - math.abs(count) * opts.step) / 8
+      local bitrate = opts.bitrate - math.abs(count) * opts.step
       for _,stream in ipairs(streams) do
          local app = engine.app_table[stream.repeater_id]
-         app:set_rate(byte_rate)
+         app:set_rate(bitrate)
       end
       count = count - 1
    end


### PR DESCRIPTION
The rate limiter now takes its rate as a bit rate, not a byte rate. Also, it now factors in ethernet overhead when limiting bitrate.  Similarly, loadtest prints out bitrates with overhead.
