### PR TITLE
Rate limit backport

### DIFF
--- a/src/apps/basic/basic_apps.lua
+++ b/src/apps/basic/basic_apps.lua
@@ -190,9 +190,9 @@ RateLimitedRepeater = {}
 function RateLimitedRepeater:new (arg)
    local conf = arg and config.parse_app_arg(arg) or {}
    --- By default, limit to 10 Mbps, just to have a default.
-   conf.rate = conf.rate or (10e6 / 8)
+   conf.rate = conf.rate or 10e6
    -- By default, allow for 255 standard packets in the queue.
-   conf.bucket_capacity = conf.bucket_capacity or (255 * 1500)
+   conf.bucket_capacity = conf.bucket_capacity or (255 * 1500 * 8)
    conf.initial_capacity = conf.initial_capacity or conf.bucket_capacity
    local o = {
       index = 1,
@@ -204,8 +204,8 @@ function RateLimitedRepeater:new (arg)
    return setmetatable(o, {__index=RateLimitedRepeater})
 end
 
-function RateLimitedRepeater:set_rate (byte_rate)
-   self.rate = math.max(byte_rate, 0)
+function RateLimitedRepeater:set_rate (bit_rate)
+   self.rate = math.max(bit_rate, 0)
 end
 
 function RateLimitedRepeater:push ()
@@ -225,12 +225,16 @@ function RateLimitedRepeater:push ()
       self.last_time = cur_now
    end
 
+   -- 7 bytes preamble, 1 start-of-frame, 4 CRC, 12 interpacket gap.
+   local overhead = 7 + 1 + 4 + 12
+
    local npackets = #self.packets
    if npackets > 0 and self.rate > 0 then
       for _ = 1, link.nwritable(o) do
          local p = self.packets[self.index]
-         if p.length > self.bucket_content then break end
-         self.bucket_content = self.bucket_content - p.length
+         local bits = (p.length + overhead) * 8
+         if bits > self.bucket_content then break end
+         self.bucket_content = self.bucket_content - bits
          transmit(o, clone(p))
          self.index = (self.index % npackets) + 1
       end

--- a/src/program/lwaftr/loadtest/loadtest.lua
+++ b/src/program/lwaftr/loadtest/loadtest.lua
@@ -117,10 +117,9 @@ function run(args)
    engine.configure(c)
 
    local function adjust_rates(bit_rate)
-      local byte_rate = bit_rate / 8
       for _,stream in ipairs(streams) do
          local app = engine.app_table[stream.repeater_id]
-         app:set_rate(byte_rate)
+         app:set_rate(bit_rate)
       end
    end
 

--- a/src/program/lwaftr/loadtest/loadtest.lua
+++ b/src/program/lwaftr/loadtest/loadtest.lua
@@ -151,6 +151,11 @@ function run(args)
    end
 
    local function print_counter_diff(before, after)
+      local function bitrate(diff)
+         -- 7 bytes preamble, 1 start-of-frame, 4 CRC, 12 interpacket gap.
+         local overhead = 7 + 1 + 4 + 12
+         return (diff.txbytes + diff.txpackets * overhead) * 8 / opts.duration
+      end
       for _, stream in ipairs(streams) do
          print(string.format('  %s:', stream.tx_name))
          local nic_id = stream.nic_tx_id
@@ -159,10 +164,10 @@ function run(args)
          local rx = diff_counters(nic_before.rx, nic_after.rx)
          print(string.format('    TX %d packets (%f MPPS), %d bytes (%f Gbps)',
                              tx.txpackets, tx.txpackets / opts.duration / 1e6,
-                             tx.txbytes, tx.txbytes / opts.duration / 1e9 * 8))
+                             tx.txbytes, bitrate(tx) / 1e9))
          print(string.format('    RX %d packets (%f MPPS), %d bytes (%f Gbps)',
                              rx.txpackets, rx.txpackets / opts.duration / 1e6,
-                             rx.txbytes, rx.txbytes / opts.duration / 1e9 * 8))
+                             rx.txbytes, bitrate(rx) / 1e9))
          print(string.format('    Loss: %d packets (%f%%)',
                              tx.txpackets - rx.txpackets,
                              (tx.txpackets - rx.txpackets) / tx.txpackets * 100))

--- a/src/program/lwaftr/loadtest/loadtest.lua
+++ b/src/program/lwaftr/loadtest/loadtest.lua
@@ -6,7 +6,6 @@ local config = require("core.config")
 local pci = require("lib.hardware.pci")
 local Intel82599 = require("apps.intel.intel_app").Intel82599
 local basic_apps = require("apps.basic.basic_apps")
-local rate_limiter = require("apps.rate_limiter.rate_limiter")
 local main = require("core.main")
 local PcapReader = require("apps.pcap.pcap").PcapReader
 local lib = require("core.lib")
@@ -101,20 +100,17 @@ function run(args)
    for _,stream in ipairs(streams) do
       stream.pcap_id = 'pcap_'..stream.tx_id
       stream.repeater_id = 'repeater_'..stream.tx_id
-      stream.rate_limiter_id = 'rate_limiter_'..stream.tx_id
       stream.nic_tx_id = 'nic_'..stream.tx_id
       stream.nic_rx_id = 'nic_'..stream.rx_id
       stream.rx_sink_id = 'rx_sink_'..stream.rx_id
 
       config.app(c, stream.pcap_id, PcapReader, stream.capture_file)
-      config.app(c, stream.repeater_id, basic_apps.Repeater, {})
-      config.app(c, stream.rate_limiter_id, rate_limiter.RateLimiter, { })
+      config.app(c, stream.repeater_id, basic_apps.RateLimitedRepeater, {})
       config.app(c, stream.nic_tx_id, Intel82599, { pciaddr = stream.pci_addr })
       config.app(c, stream.rx_sink_id, basic_apps.Sink)
 
       config.link(c, stream.pcap_id..".output -> "..stream.repeater_id..".input")
-      config.link(c, stream.repeater_id..".output -> "..stream.rate_limiter_id..".input")
-      config.link(c, stream.rate_limiter_id..".output -> "..stream.nic_tx_id..".rx")
+      config.link(c, stream.repeater_id..".output -> "..stream.nic_tx_id..".rx")
 
       config.link(c, stream.nic_rx_id..".tx -> "..stream.rx_sink_id..".input")
    end
@@ -123,7 +119,7 @@ function run(args)
    local function adjust_rates(bit_rate)
       local byte_rate = bit_rate / 8
       for _,stream in ipairs(streams) do
-         local app = engine.app_table[stream.rate_limiter_id]
+         local app = engine.app_table[stream.repeater_id]
          app:set_rate(byte_rate)
       end
    end

--- a/src/program/lwaftr/transient/transient.lua
+++ b/src/program/lwaftr/transient/transient.lua
@@ -8,7 +8,6 @@ local csv_stats = require("lib.csv_stats")
 local pci = require("lib.hardware.pci")
 local Intel82599 = require("apps.intel.intel_app").Intel82599
 local basic_apps = require("apps.basic.basic_apps")
-local rate_limiter = require("apps.rate_limiter.rate_limiter")
 local main = require("core.main")
 local PcapReader = require("apps.pcap.pcap").PcapReader
 local lib = require("core.lib")
@@ -91,7 +90,7 @@ function adjust_rate(opts, streams)
    return function()
       local byte_rate = (opts.bitrate - math.abs(count) * opts.step) / 8
       for _,stream in ipairs(streams) do
-         local app = engine.app_table[stream.rate_limiter_id]
+         local app = engine.app_table[stream.repeater_id]
          app:set_rate(byte_rate)
       end
       count = count - 1
@@ -104,19 +103,16 @@ function run(args)
    for _,stream in ipairs(streams) do
       stream.pcap_id = 'pcap_'..stream.id
       stream.repeater_id = 'repeater_'..stream.id
-      stream.rate_limiter_id = 'rate_limiter_'..stream.id
       stream.nic_id = 'nic_'..stream.id
       stream.rx_sink_id = 'rx_sink_'..stream.id
 
       config.app(c, stream.pcap_id, PcapReader, stream.capture_file)
-      config.app(c, stream.repeater_id, basic_apps.Repeater, {})
-      config.app(c, stream.rate_limiter_id, rate_limiter.RateLimiter, {})
+      config.app(c, stream.repeater_id, basic_apps.RateLimitedRepeater, {})
       config.app(c, stream.nic_id, Intel82599, { pciaddr = stream.pci_addr })
       config.app(c, stream.rx_sink_id, basic_apps.Sink)
 
       config.link(c, stream.pcap_id..".output -> "..stream.repeater_id..".input")
-      config.link(c, stream.repeater_id..".output -> "..stream.rate_limiter_id..".input")
-      config.link(c, stream.rate_limiter_id..".output -> "..stream.nic_id..".rx")
+      config.link(c, stream.repeater_id..".output -> "..stream.nic_id..".rx")
 
       config.link(c, stream.nic_id..".tx -> "..stream.rx_sink_id..".input")
    end

--- a/src/program/lwaftr/transient/transient.lua
+++ b/src/program/lwaftr/transient/transient.lua
@@ -88,10 +88,10 @@ end
 function adjust_rate(opts, streams)
    local count = math.ceil(opts.bitrate / opts.step)
    return function()
-      local byte_rate = (opts.bitrate - math.abs(count) * opts.step) / 8
+      local bitrate = opts.bitrate - math.abs(count) * opts.step
       for _,stream in ipairs(streams) do
          local app = engine.app_table[stream.repeater_id]
-         app:set_rate(byte_rate)
+         app:set_rate(bitrate)
       end
       count = count - 1
    end


### PR DESCRIPTION
Backport of #309.

Output:

```
$ make && sudo taskset -c 11 ./snabb-lwaftr loadtest 20K-1M-vlan-tests/from-inet-vlan-0550.pcap IPv4 IPv6 83:00.0 20K-1M-vlan-tests/from-b4-vlan-0550.pcap IPv6 IPv4 83:00.1
make: 'snabb-lwaftr' is up to date.
Warming up at 5.000000 Gb/s for 2 seconds.
hi
Applying 1.000000 Gbps of load.
  IPv4:
    TX 1088850 packets (0.217770 MPPS), 598867500 bytes (1.000000 Gbps)
    RX 1088850 packets (0.217770 MPPS), 642421500 bytes (1.069686 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 1088850 packets (0.217770 MPPS), 598867500 bytes (1.000000 Gbps)
    RX 1088850 packets (0.217770 MPPS), 555313500 bytes (0.930313 Gbps)
    Loss: 0 packets (0.000000%)
Applying 2.000000 Gbps of load.
  IPv4:
    TX 2177700 packets (0.435540 MPPS), 1197735000 bytes (2.000000 Gbps)
    RX 2177700 packets (0.435540 MPPS), 1284843000 bytes (2.139372 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 2177700 packets (0.435540 MPPS), 1197735000 bytes (2.000000 Gbps)
    RX 2177700 packets (0.435540 MPPS), 1110627000 bytes (1.860627 Gbps)
    Loss: 0 packets (0.000000%)
Applying 3.000000 Gbps of load.
  IPv4:
    TX 3266550 packets (0.653310 MPPS), 1796602500 bytes (3.000000 Gbps)
    RX 3266550 packets (0.653310 MPPS), 1927264500 bytes (3.209059 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 3266550 packets (0.653310 MPPS), 1796602500 bytes (3.000000 Gbps)
    RX 3266550 packets (0.653310 MPPS), 1665940500 bytes (2.790940 Gbps)
    Loss: 0 packets (0.000000%)
Applying 4.000000 Gbps of load.
  IPv4:
    TX 4355397 packets (0.871079 MPPS), 2395468350 bytes (3.999997 Gbps)
    RX 4355397 packets (0.871079 MPPS), 2569684230 bytes (4.278742 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 4355397 packets (0.871079 MPPS), 2395468350 bytes (3.999997 Gbps)
    RX 4355397 packets (0.871079 MPPS), 2221252470 bytes (3.721251 Gbps)
    Loss: 0 packets (0.000000%)
Applying 5.000000 Gbps of load.
  IPv4:
    TX 5444245 packets (1.088849 MPPS), 2994334750 bytes (4.999995 Gbps)
    RX 5444245 packets (1.088849 MPPS), 3212104550 bytes (5.348426 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 5444245 packets (1.088849 MPPS), 2994334750 bytes (4.999995 Gbps)
    RX 5444245 packets (1.088849 MPPS), 2776564950 bytes (4.651563 Gbps)
    Loss: 0 packets (0.000000%)
Applying 6.000000 Gbps of load.
  IPv4:
    TX 6533098 packets (1.306620 MPPS), 3593203900 bytes (5.999997 Gbps)
    RX 6533098 packets (1.306620 MPPS), 3854527820 bytes (6.418115 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 6533098 packets (1.306620 MPPS), 3593203900 bytes (5.999997 Gbps)
    RX 6533098 packets (1.306620 MPPS), 3331879980 bytes (5.581879 Gbps)
    Loss: 0 packets (0.000000%)
Applying 7.000000 Gbps of load.
  IPv4:
    TX 7621945 packets (1.524389 MPPS), 4192069750 bytes (6.999994 Gbps)
    RX 7621945 packets (1.524389 MPPS), 4496947550 bytes (7.487799 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 7621945 packets (1.524389 MPPS), 4192069750 bytes (6.999994 Gbps)
    RX 7621945 packets (1.524389 MPPS), 3887191950 bytes (6.512190 Gbps)
    Loss: 0 packets (0.000000%)
Applying 8.000000 Gbps of load.
  IPv4:
    TX 8710775 packets (1.742155 MPPS), 4790926250 bytes (7.999976 Gbps)
    RX 8710775 packets (1.742155 MPPS), 5139357250 bytes (8.557465 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 8710775 packets (1.742155 MPPS), 4790926250 bytes (7.999976 Gbps)
    RX 8710775 packets (1.742155 MPPS), 4442495250 bytes (7.442486 Gbps)
    Loss: 0 packets (0.000000%)
Applying 9.000000 Gbps of load.
  IPv4:
    TX 9799619 packets (1.959924 MPPS), 5389790450 bytes (8.999970 Gbps)
    RX 9799619 packets (1.959924 MPPS), 5781775210 bytes (9.627146 Gbps)
    Loss: 0 packets (0.000000%)
  IPv6:
    TX 9799619 packets (1.959924 MPPS), 5389790450 bytes (8.999970 Gbps)
    RX 9799619 packets (1.959924 MPPS), 4997805690 bytes (8.372794 Gbps)
    Loss: 0 packets (0.000000%)
Applying 10.000000 Gbps of load.
  IPv4:
    TX 10888488 packets (2.177698 MPPS), 5988668400 bytes (9.999987 Gbps)
    RX 10179189 packets (2.035838 MPPS), 6005721510 bytes (10.000035 Gbps)
    Loss: 709299 packets (6.514210%)
  IPv6:
    TX 10888496 packets (2.177699 MPPS), 5988672800 bytes (9.999995 Gbps)
    RX 10254382 packets (2.050876 MPPS), 5229734820 bytes (8.761344 Gbps)
    Loss: 634114 packets (5.823706%)
```
