### PR TITLE
Rename v4-pci and v6-pci args

### DIFF
--- a/src/program/lwaftr/doc/README.benchmarking.md
+++ b/src/program/lwaftr/doc/README.benchmarking.md
@@ -15,7 +15,7 @@ In one server, start the lwAFTR:
 ```
 $ sudo taskset -c 1 ./src/snabb lwaftr run -v \
     --conf program/lwaftr/tests/data/icmp_on_fail.conf \
-    --v4-pci 0000:02:00.0 --v6-pci 0000:02:00.1
+    --v4 0000:02:00.0 --v6 0000:02:00.1
 ```
 
 The `-v` flag enables periodic printouts reporting MPPS and Gbps statistics per

--- a/src/program/lwaftr/doc/README.running.md
+++ b/src/program/lwaftr/doc/README.running.md
@@ -45,7 +45,7 @@ First, start the lwAFTR:
 ```
 $ sudo ./snabb lwaftr run \
     --conf program/lwaftr/tests/data/icmp_on_fail.conf \
-    --v4-pci 0000:01:00.1 --v6-pci 0000:02:00.1
+    --v4 0000:01:00.1 --v6 0000:02:00.1
 ```
 
 Then run a load generator:

--- a/src/program/lwaftr/doc/README.troubleshooting.md
+++ b/src/program/lwaftr/doc/README.troubleshooting.md
@@ -16,7 +16,7 @@ Time (s),IPv4 RX MPPS,IPv4 RX Gbps,IPv4 TX MPPS,IPv4 TX Gbps,IPv6 RX MPPS,IPv6 R
 The lwaftr is running, but not receiving packets from the load generator.
 Check that the load generator is running, and that the physical wiring is
 between the interfaces the load generator is running on and the interfaces
-that the lwaftr is running on, and that the `--v4-pci` and `--v6-pci` arguments
+that the lwaftr is running on, and that the `--v4` and `--v6` arguments
 reflect the physical wiring, rather than being swapped.  If you have VLANs configured
 and you are using Intel NICs, make sure the VLAN IDs are correct.
 

--- a/src/program/lwaftr/doc/benchmarks-v1.0/Makefile
+++ b/src/program/lwaftr/doc/benchmarks-v1.0/Makefile
@@ -27,7 +27,7 @@ transient-self-test.csv: $(LWAFTR)
 
 lwaftr-%.csv:: $(LWAFTR)
 	( set -m; set -o pipefail; \
-	  taskset -c 6 ./snabb lwaftr run -D 170 --conf $(LWAFTR_CONF) --v4-pci $(LWAFTR_IPV4_PCIADDR) --v6-pci $(LWAFTR_IPV6_PCIADDR) & \
+	  taskset -c 6 ./snabb lwaftr run -D 170 --conf $(LWAFTR_CONF) --v4 $(LWAFTR_IPV4_PCIADDR) --v6 $(LWAFTR_IPV6_PCIADDR) & \
 	  taskset -c 7 ./snabb lwaftr transient -s 0.25e9 -D 2 $(IPV4_PCAP) IPv4 $(TRANSIENT_IPV4_PCIADDR) $(IPV6_PCAP) IPv6 $(TRANSIENT_IPV6_PCIADDR) | tee $@.tmp && \
 	  mv $@.tmp $@ && \
 	  wait )

--- a/src/program/lwaftr/run/README
+++ b/src/program/lwaftr/run/README
@@ -1,10 +1,10 @@
 Usage: run --help
-       run --conf <conf-file> --v4-pci <pci-addr> --v6-pci <pci-addr> [OPTION...]
+       run --conf <conf-file> --v4 <pci-addr> --v4 <pci-addr> [OPTION...]
 
 Required arguments:
        --conf   <conf-file>     Sets configuration policy table
-       --v4-pci <pci-addr>      PCI device number for the INET-side NIC
-       --v6-pci <pci-addr>      PCI device number for the B4-side NIC
+       --v4 <pci-addr>          PCI device number for the INET-side NIC
+       --v6 <pci-addr>          PCI device number for the B4-side NIC
 
 Optional arguments:
        --virtio                 Use virtio-net interfaces instead of Intel 82599

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -35,7 +35,7 @@ end
 
 function parse_args(args)
    if #args == 0 then show_usage(1) end
-   local conf_file, v4_pci, v6_pci
+   local conf_file, v4, v6
    local ring_buffer_size
    local opts = { verbosity = 0 }
    local handlers = {}
@@ -69,21 +69,21 @@ function parse_args(args)
       end
    end
    function handlers.n(arg)
-      v4_pci = arg
+      v4 = arg
       if not arg then
-         fatal("Argument '--v4-pci' was not set")
+         fatal("Argument '--v4' was not set")
       end
-      if not nic_exists(v4_pci) then
-         fatal(("Couldn't locate NIC with PCI address '%s'"):format(v4_pci))
+      if not nic_exists(v4) then
+         fatal(("Couldn't locate NIC with PCI address '%s'"):format(v4))
       end
    end
    function handlers.m(arg)
-      v6_pci = arg
-      if not v6_pci then
-         fatal("Argument '--v6-pci' was not set")
+      v6 = arg
+      if not v6 then
+         fatal("Argument '--v6' was not set")
       end
-      if not nic_exists(v6_pci) then
-         fatal(("Couldn't locate NIC with PCI address '%s'"):format(v6_pci))
+      if not nic_exists(v6) then
+         fatal(("Couldn't locate NIC with PCI address '%s'"):format(v6))
       end
    end
    function handlers.r (arg)
@@ -98,7 +98,7 @@ function parse_args(args)
    end
    function handlers.h() show_usage(0) end
    lib.dogetopt(args, handlers, "b:c:n:m:vD:hir:",
-      { conf = "c", ["v4-pci"] = "n", ["v6-pci"] = "m",
+      { conf = "c", ["v4"] = "n", ["v6"] = "m",
         verbose = "v", duration = "D", help = "h",
         virtio = "i", ["ring-buffer-size"] = "r", cpu = 1,
         ["real-time"] = 0 })
@@ -109,20 +109,20 @@ function parse_args(args)
       require('apps.intel.intel10g').num_descriptors = ring_buffer_size
    end
    if not conf_file then fatal("Missing required --conf argument.") end
-   if not v4_pci then fatal("Missing required --v4-pci argument.") end
-   if not v6_pci then fatal("Missing required --v6-pci argument.") end
-   return opts, conf_file, v4_pci, v6_pci
+   if not v4 then fatal("Missing required --v4 argument.") end
+   if not v6 then fatal("Missing required --v6 argument.") end
+   return opts, conf_file, v4, v6
 end
 
 function run(args)
-   local opts, conf_file, v4_pci, v6_pci = parse_args(args)
+   local opts, conf_file, v4, v6 = parse_args(args)
    local conf = require('apps.lwaftr.conf').load_lwaftr_config(conf_file)
 
    local c = config.new()
    if opts.virtio_net then
-      setup.load_virt(c, conf, 'inetNic', v4_pci, 'b4sideNic', v6_pci)
+      setup.load_virt(c, conf, 'inetNic', v4, 'b4sideNic', v6)
    else
-      setup.load_phy(c, conf, 'inetNic', v4_pci, 'b4sideNic', v6_pci)
+      setup.load_phy(c, conf, 'inetNic', v4, 'b4sideNic', v6)
    end
    engine.configure(c)
 

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -77,6 +77,7 @@ function parse_args(args)
          fatal(("Couldn't locate NIC with PCI address '%s'"):format(v4))
       end
    end
+   handlers["v4-pci"] = handlers.v4
    function handlers.v6(arg)
       v6 = arg
       if not v6 then
@@ -86,6 +87,7 @@ function parse_args(args)
          fatal(("Couldn't locate NIC with PCI address '%s'"):format(v6))
       end
    end
+   handlers["v6-pci"] = handlers.v6
    function handlers.r (arg)
       ring_buffer_size = tonumber(arg)
       if not ring_buffer_size then fatal("bad ring size: " .. arg) end
@@ -98,7 +100,7 @@ function parse_args(args)
    end
    function handlers.h() show_usage(0) end
    lib.dogetopt(args, handlers, "b:c:vD:hir:",
-      { conf = "c", v4 = 1, v6 = 1,
+      { conf = "c", v4 = 1, v6 = 1, ["v4-pci"] = 1, ["v6-pci"] = 1,
         verbose = "v", duration = "D", help = "h",
         virtio = "i", ["ring-buffer-size"] = "r", cpu = 1,
         ["real-time"] = 0 })

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -68,7 +68,7 @@ function parse_args(args)
          fatal('Failed to enable real-time scheduling.  Try running as root.')
       end
    end
-   function handlers.n(arg)
+   function handlers.v4(arg)
       v4 = arg
       if not arg then
          fatal("Argument '--v4' was not set")
@@ -77,7 +77,7 @@ function parse_args(args)
          fatal(("Couldn't locate NIC with PCI address '%s'"):format(v4))
       end
    end
-   function handlers.m(arg)
+   function handlers.v6(arg)
       v6 = arg
       if not v6 then
          fatal("Argument '--v6' was not set")
@@ -97,8 +97,8 @@ function parse_args(args)
       end
    end
    function handlers.h() show_usage(0) end
-   lib.dogetopt(args, handlers, "b:c:n:m:vD:hir:",
-      { conf = "c", ["v4"] = "n", ["v6"] = "m",
+   lib.dogetopt(args, handlers, "b:c:vD:hir:",
+      { conf = "c", v4 = 1, v6 = 1,
         verbose = "v", duration = "D", help = "h",
         virtio = "i", ["ring-buffer-size"] = "r", cpu = 1,
         ["real-time"] = 0 })

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -77,7 +77,10 @@ function parse_args(args)
          fatal(("Couldn't locate NIC with PCI address '%s'"):format(v4))
       end
    end
-   handlers["v4-pci"] = handlers.v4
+   handlers["v4-pci"] = function(arg)
+      print("WARNING: Deprecated argument '--v4-pci'. Use '--v4' instead.")
+      handlers.v4(arg)
+   end
    function handlers.v6(arg)
       v6 = arg
       if not v6 then
@@ -87,7 +90,10 @@ function parse_args(args)
          fatal(("Couldn't locate NIC with PCI address '%s'"):format(v6))
       end
    end
-   handlers["v6-pci"] = handlers.v6
+   handlers["v6-pci"] = function(arg)
+      print("WARNING: Deprecated argument '--v6-pci'. Use '--v6' instead.")
+      handlers.v6(arg)
+   end
    function handlers.r (arg)
       ring_buffer_size = tonumber(arg)
       if not ring_buffer_size then fatal("bad ring size: " .. arg) end

--- a/src/program/lwaftr/virt/run_lwaftr.sh.example
+++ b/src/program/lwaftr/virt/run_lwaftr.sh.example
@@ -6,4 +6,4 @@ V6_PCI=0000:00:09.0
 LWAFTR_CONF=program/lwaftr/tests/data/icmp_on_fail.conf
 OUTPUT=/tmp/lwaftr.csv
 
-screen -dmS lwaftr bash -c "cd ${SNABB_GUEST};sudo taskset -c 1 ./snabb snsh -p lwaftr run -v -i --conf $LWAFTR_CONF --v4-pci ${V4_PCI} --v6-pci ${V6_PCI} | tee $OUTPUT"
+screen -dmS lwaftr bash -c "cd ${SNABB_GUEST};sudo taskset -c 1 ./snabb snsh -p lwaftr run -v -i --conf $LWAFTR_CONF --v4 ${V4_PCI} --v6 ${V6_PCI} | tee $OUTPUT"


### PR DESCRIPTION
Rename v4-pci and v6-pci arguments to v4 and v6.

While https://github.com/Igalia/snabb/pull/298 doesn't land yet, I've renamed the v4-pci and v6-pci arguments to v4 and v6. Documentation has been updated and the short options for these arguments ('n' and 'm' respectively) has been removed as they were never used.
