### PR TITLE
Fix error on dumping binding table

### DIFF
--- a/src/apps/lwaftr/dump.lua
+++ b/src/apps/lwaftr/dump.lua
@@ -129,9 +129,9 @@ the binding table to /tmp.
 --]]
 function dump_binding_table (lwstate)
    local bt_txt = lwstate.conf.binding_table
-   local bt_o = bt_txt:gsub("%.txt$", "%.o")
+   local bt_o = bt_txt:gsub("%.txt$", "")..'.o'
    if not bt_is_fresh(bt_txt, bt_o) then
-      error("Binding table file is outdated: '%s'"):format(bt_txt)
+      error(("Binding table file is outdated: '%s'"):format(bt_txt))
       main.exit(1)
    end
    local dest = (BINDING_TABLE_FILE_DUMP):format(os.time())


### PR DESCRIPTION
The binding table dumping code expects to find a _.o_ file originated from the compilation of a text file which filename ends in  _.txt_.

If the filename doesn't end in _.txt_, the _.o_ file cannot be found, printing out an error. Example:

```
$ sudo ./snabb lwaftr run --conf lwaftr.conf --v4-pci 83:00.0 --v6-pci 83:00.1
loading compiled binding table from ./binding_table2.o
compiled binding table ./binding_table2.o is up to date.
Dump lwAFTR configuration: '/tmp/lwaftr-1463481294.conf'
apps/lwaftr/dump.lua:134: Binding table file is outdated: '%s'
stack traceback:
        core/main.lua:122: in function <core/main.lua:120>
...

The error message is not properly formatted either. Fixed on this PR too.
```
