### PR TITLE
Unify pathname logic

### DIFF
--- a/src/apps/lwaftr/conf_parser.lua
+++ b/src/apps/lwaftr/conf_parser.lua
@@ -231,32 +231,32 @@ function Parser:parse_string()
    return str
 end
 
+function Parser:make_path(orig_path)
+   if orig_path == '' then self:error('file name is empty') end
+   if not orig_path:match('^/') and self.name then
+      -- Relative paths in conf files are relative to the location of the
+      -- conf file, not the current working directory.
+      return lib.dirname(self.name)..'/'..orig_path
+   end
+   return orig_path
+end
+
+function Parser:parse_file_name()
+   return self:make_path(self:parse_string())
+end
+
 function Parser:parse_string_or_file()
    local str = self:parse_string()
    if not str:match('^<') then
       return str
    end
-   -- Relative pathname, remove the angle bracket.
-   path = str:sub(2)
-   if self.name then
-      path = lib.dirname(self.name)..path
-   end
+   -- Remove the angle bracket.
+   path = self:make_path(str:sub(2))
    local filter, err = lib.readfile(path, "*a")
    if filter == nil then
       self:error('cannot read filter conf file "%s": %s', path, err)
    end
    return filter
-end
-
-function Parser:parse_file_name()
-   local str = self:parse_string()
-   if str == '' then self:error('file name is empty') end
-   -- Relative paths in conf files are relative to the location of the
-   -- conf file, not the current working directory.
-   if not str:match('^/') and self.name then
-      str = lib.dirname(self.name)..'/'..str
-   end
-   return str
 end
 
 function Parser:parse_boolean()


### PR DESCRIPTION
Missing commit from #317. Backport to lwaftr_starfruit.
