### PR TITLE
Fix ingress egress parsing

### DIFF
--- a/src/apps/lwaftr/conf.lua
+++ b/src/apps/lwaftr/conf.lua
@@ -58,10 +58,10 @@ local lwaftr_conf_spec = {
       v4_vlan_tag=Parser.parse_vlan_tag,
       v6_vlan_tag=Parser.parse_vlan_tag,
       vlan_tagging=Parser.parse_boolean,
-      ipv4_ingress_filter=Parser.parse_string_or_file,
-      ipv4_egress_filter=Parser.parse_string_or_file,
-      ipv6_ingress_filter=Parser.parse_string_or_file,
-      ipv6_egress_filter=Parser.parse_string_or_file,
+      ipv4_ingress_filter=Parser.parse_text_or_file,
+      ipv4_egress_filter=Parser.parse_text_or_file,
+      ipv6_ingress_filter=Parser.parse_text_or_file,
+      ipv6_egress_filter=Parser.parse_text_or_file,
    },
    defaults={
       aftr_ipv4_ip=required('aftr_ipv4_ip'),
@@ -135,6 +135,7 @@ function selftest()
             v4_vlan_tag = 1092 # 0x444
             v6_vlan_tag = 1638 # 0x666
             vlan_tagging = true
+            ipv4_ingress_filter = not dst host 8.8.8.8
         ]],
       {
          aftr_ipv4_ip = ipv4:pton('1.2.3.4'),
@@ -155,7 +156,8 @@ function selftest()
          policy_icmpv6_outgoing = policies['ALLOW'],
          v4_vlan_tag = 0x444,
          v6_vlan_tag = 0x666,
-         vlan_tagging = true
+         vlan_tagging = true,
+         ipv4_ingress_filter = "not dst host 8.8.8.8",
       }
    )
    local function test_loading_filter_conf_from_file()

--- a/src/apps/lwaftr/conf_parser.lua
+++ b/src/apps/lwaftr/conf_parser.lua
@@ -231,32 +231,32 @@ function Parser:parse_string()
    return str
 end
 
+function Parser:make_path(orig_path)
+   if orig_path == '' then self:error('file name is empty') end
+   if not orig_path:match('^/') and self.name then
+      -- Relative paths in conf files are relative to the location of the
+      -- conf file, not the current working directory.
+      return lib.dirname(self.name)..'/'..orig_path
+   end
+   return orig_path
+end
+
+function Parser:parse_file_name()
+   return self:make_path(self:parse_string())
+end
+
 function Parser:parse_string_or_file()
    local str = self:parse_string()
    if not str:match('^<') then
       return str
    end
-   -- Relative pathname, remove the angle bracket.
-   path = str:sub(2)
-   if self.name then
-      path = lib.dirname(self.name)..path
-   end
+   -- Remove the angle bracket.
+   path = self:make_path(str:sub(2))
    local filter, err = lib.readfile(path, "*a")
    if filter == nil then
       self:error('cannot read filter conf file "%s": %s', path, err)
    end
    return filter
-end
-
-function Parser:parse_file_name()
-   local str = self:parse_string()
-   if str == '' then self:error('file name is empty') end
-   -- Relative paths in conf files are relative to the location of the
-   -- conf file, not the current working directory.
-   if not str:match('^/') and self.name then
-      str = lib.dirname(self.name)..'/'..str
-   end
-   return str
 end
 
 function Parser:parse_boolean()

--- a/src/apps/lwaftr/conf_parser.lua
+++ b/src/apps/lwaftr/conf_parser.lua
@@ -245,8 +245,8 @@ function Parser:parse_file_name()
    return self:make_path(self:parse_string())
 end
 
-function Parser:parse_string_or_file()
-   local str = self:parse_string()
+function Parser:parse_text_or_file()
+   local str = self:parse_text()
    if not str:match('^<') then
       return str
    end
@@ -257,6 +257,14 @@ function Parser:parse_string_or_file()
       self:error('cannot read filter conf file "%s": %s', path, err)
    end
    return filter
+end
+
+function Parser:parse_text()
+   local str
+   if self:check("'") then str = self:parse_quoted_string("'")
+   elseif self:check('"') then str = self:parse_quoted_string('"')
+   else str = self:take_while('[^\n,]') end
+   return str
 end
 
 function Parser:parse_boolean()


### PR DESCRIPTION
Allows parsing non quoted pflang filters in ingress/egress attributes in lwAFTR conf file.
