### PR TITLE
Better NUMA behavior

### DIFF
--- a/lib/ljsyscall/syscall/linux/c.lua
+++ b/lib/ljsyscall/syscall/linux/c.lua
@@ -347,6 +347,13 @@ function C.sched_setparam(pid, param)
   return syscall(sys.sched_setparam, int(pid), void(param))
 end
 
+function C.get_mempolicy(mode, mask, maxnode, addr, flags)
+  return syscall(sys.get_mempolicy, void(mode), void(mask), ulong(maxnode), ulong(addr), ulong(flags))
+end
+function C.set_mempolicy(mode, mask, maxnode)
+  return syscall(sys.set_mempolicy, int(mode), void(mask), ulong(maxnode))
+end
+
 -- in librt for glibc but use syscalls instead of loading another library
 function C.clock_nanosleep(clk_id, flags, req, rem)
   return syscall(sys.clock_nanosleep, int(clk_id), int(flags), void(req), void(rem))

--- a/lib/ljsyscall/syscall/linux/c.lua
+++ b/lib/ljsyscall/syscall/linux/c.lua
@@ -354,6 +354,10 @@ function C.set_mempolicy(mode, mask, maxnode)
   return syscall(sys.set_mempolicy, int(mode), void(mask), ulong(maxnode))
 end
 
+function C.migrate_pages(pid, maxnode, from, to)
+  return syscall(sys.migrate_pages, int(pid), ulong(maxnode), void(from), void(to))
+end
+
 -- in librt for glibc but use syscalls instead of loading another library
 function C.clock_nanosleep(clk_id, flags, req, rem)
   return syscall(sys.clock_nanosleep, int(clk_id), int(flags), void(req), void(rem))

--- a/lib/ljsyscall/syscall/linux/c.lua
+++ b/lib/ljsyscall/syscall/linux/c.lua
@@ -691,7 +691,7 @@ C.gettimeofday = ffi.C.gettimeofday
 --function C.gettimeofday(tv, tz) return syscall(sys.gettimeofday, void(tv), void(tz)) end
 
 -- glibc does not provide getcpu; it is however VDSO
-function C.getcpu(cpu, node, tcache) return syscall(sys.getcpu, void(node), void(node), void(tcache)) end
+function C.getcpu(cpu, node, tcache) return syscall(sys.getcpu, void(cpu), void(node), void(tcache)) end
 -- time is VDSO but not really performance critical; does not exist for some architectures
 if sys.time then
   function C.time(t) return syscall(sys.time, void(t)) end

--- a/lib/ljsyscall/syscall/linux/constants.lua
+++ b/lib/ljsyscall/syscall/linux/constants.lua
@@ -3149,6 +3149,23 @@ c.IPT_SO_GET = strflag {
   REVISION_TARGET      = IPT_BASE_CTL + 3,
 }
 
+c.MPOL_MODE = multiflags {
+  DEFAULT = 0,
+  PREFERRED = 1,
+  BIND = 2,
+  INTERLEAVE = 3,
+  LOCAL = 4,
+  -- TODO: Only the following two flags can be ORed.
+  STATIC_NODES     = 0x80000000,
+  RELATIVE_NODES   = 0x40000000,
+}
+
+c.MPOL_FLAG = multiflags {
+  NODE	           = 1,
+  ADDR	           = 2,
+  MEMS_ALLOWED     = 4
+}
+
 c.SCHED = multiflags {
   NORMAL           = 0,
   OTHER            = 0,

--- a/lib/ljsyscall/syscall/linux/syscalls.lua
+++ b/lib/ljsyscall/syscall/linux/syscalls.lua
@@ -457,6 +457,18 @@ function S.sched_setaffinity(pid, mask, len) -- note len last as rarely used
   return retbool(C.sched_setaffinity(pid or 0, len or s.cpu_set, mktype(t.cpu_set, mask)))
 end
 
+function S.get_mempolicy(mode, mask, addr, flags)
+  mode = mode or t.int1()
+  mask = mktype(t.bitmask, mask)
+  local ret, err = C.get_mempolicy(mode, mask.mask, mask.size, addr or 0, c.MPOL_FLAG[flags])
+  if ret == -1 then return nil, t.error(err or errno()) end
+  return { mode=mode[0], mask=mask }
+end
+function S.set_mempolicy(mode, mask)
+  mask = mktype(t.bitmask, mask)
+  return retbool(C.set_mempolicy(c.MPOL_MODE[mode], mask.mask, mask.size))
+end
+
 function S.sched_get_priority_max(policy) return retnum(C.sched_get_priority_max(c.SCHED[policy])) end
 function S.sched_get_priority_min(policy) return retnum(C.sched_get_priority_min(c.SCHED[policy])) end
 

--- a/lib/ljsyscall/syscall/linux/syscalls.lua
+++ b/lib/ljsyscall/syscall/linux/syscalls.lua
@@ -469,6 +469,13 @@ function S.set_mempolicy(mode, mask)
   return retbool(C.set_mempolicy(c.MPOL_MODE[mode], mask.mask, mask.size))
 end
 
+function S.migrate_pages(pid, from, to)
+  from = mktype(t.bitmask, from)
+  to = mktype(t.bitmask, to)
+  assert(from.size == to.size, "incompatible nodemask sizes")
+  return retbool(C.migrate_pages(pid or 0, from.size, from.mask, to.mask))
+end
+
 function S.sched_get_priority_max(policy) return retnum(C.sched_get_priority_max(c.SCHED[policy])) end
 function S.sched_get_priority_min(policy) return retnum(C.sched_get_priority_min(c.SCHED[policy])) end
 

--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -2,6 +2,19 @@ module(..., package.seeall)
 
 local S = require("syscall")
 
+function cpu_get_numa_node (cpu)
+   local node = 0
+   while true do
+      local node_dir = S.open('/sys/devices/system/node/node'..node,
+                              'rdonly, directory')
+      if not node_dir then return end
+      local found = S.readlinkat(node_dir, 'cpu'..cpu)
+      node_dir:close()
+      if found then return node end
+      node = node + 1
+   end
+end
+
 function set_cpu (cpu)
    local cpu_set = S.sched_getaffinity()
    cpu_set:zero()
@@ -18,6 +31,7 @@ function set_cpu (cpu)
 end
 
 function selftest ()
+   print(cpu_get_numa_node(0))
    print(S.sched_getaffinity())
    print(S.get_mempolicy().mask)
 end

--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -2,6 +2,9 @@ module(..., package.seeall)
 
 local S = require("syscall")
 
+local bound_cpu
+local bound_numa_node
+
 function cpu_get_numa_node (cpu)
    local node = 0
    while true do
@@ -15,23 +18,67 @@ function cpu_get_numa_node (cpu)
    end
 end
 
-function set_cpu (cpu)
+function pci_get_numa_node (addr)
+   local file = assert(io.open('/sys/bus/pci/devices/'..addr..'/numa_node'))
+   local node = tonumber(file)
+   -- node can be -1.
+   if node >= 0 then return node end
+end
+
+function unbind_cpu ()
    local cpu_set = S.sched_getaffinity()
    cpu_set:zero()
-   cpu_set:set(cpu)
-   S.sched_setaffinity(0, cpu_set)
+   for i = 0, 1023 do cpu_set:set(i) end
+   assert(S.sched_setaffinity(0, cpu_set))
+   bound_cpu = nil
+end
 
-   local policy = S.get_mempolicy()
-   mask:zero()
-   mask:set(cpu) -- fixme should be numa node
-   S.set_mempolicy(policy.mode, policy.mask)
-   if not S.sched_setscheduler(0, "fifo", 1) then
+function bind_to_cpu (cpu)
+   if cpu == bound_cpu then return end
+   if not cpu then return unbind_cpu() end
+   assert(not bound_cpu, "already bound")
+
+   assert(S.sched_setaffinity(0, cpu))
+   local cpu_and_node = S.getcpu()
+   assert(cpu_and_node.cpu == cpu)
+   bound_cpu = cpu
+
+   bind_to_numa_node (cpu_and_node.node)
+end
+
+function unbind_numa_node ()
+   assert(S.set_mempolicy('default'))
+   bound_numa_node = nil
+end
+
+function bind_to_numa_node (node)
+   if node == bound_numa_node then return end
+   if not node then return unbind_numa_node() end
+   assert(not bound_numa_node, "already bound")
+
+   assert(S.set_mempolicy('bind', node))
+   bound_numa_node = node
+end
+
+function prevent_preemption(priority)
+   if not S.sched_setscheduler(0, "fifo", priority or 1) then
       fatal('Failed to enable real-time scheduling.  Try running as root.')
    end
 end
 
 function selftest ()
-   print(cpu_get_numa_node(0))
-   print(S.sched_getaffinity())
-   print(S.get_mempolicy().mask)
+   print('selftest: numa')
+   bind_to_cpu(0)
+   assert(bound_cpu == 0)
+   assert(bound_numa_node == 0)
+   assert(S.getcpu().cpu == 0)
+   assert(S.getcpu().node == 0)
+   bind_to_cpu(nil)
+   assert(bound_cpu == nil)
+   assert(bound_numa_node == 0)
+   assert(S.getcpu().node == 0)
+   bind_to_numa_node(nil)
+   assert(bound_cpu == nil)
+   assert(bound_numa_node == nil)
+   print('selftest: numa: ok')
 end

--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -1,6 +1,7 @@
 module(..., package.seeall)
 
 local S = require("syscall")
+local pci = require("lib.hardware.pci")
 
 local bound_cpu
 local bound_numa_node
@@ -19,6 +20,7 @@ function cpu_get_numa_node (cpu)
 end
 
 function pci_get_numa_node (addr)
+   addr = pci.qualified(addr)
    local file = assert(io.open('/sys/bus/pci/devices/'..addr..'/numa_node'))
    local node = assert(tonumber(file:read()))
    -- node can be -1.

--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -1,5 +1,6 @@
 module(..., package.seeall)
 
+local ffi = require("ffi")
 local S = require("syscall")
 local pci = require("lib.hardware.pci")
 
@@ -17,6 +18,16 @@ function cpu_get_numa_node (cpu)
       if found then return node end
       node = node + 1
    end
+end
+
+-- Sadly, ljsyscall's `getcpu' call doesn't appear to work for some
+-- reason: https://github.com/justincormack/ljsyscall/issues/194.  Until
+-- then, here's a shim.
+ffi.cdef("int sched_getcpu(void);")
+function getcpu()
+   local ret = { cpu = ffi.C.sched_getcpu() }
+   ret.node = cpu_get_numa_node(ret.cpu)
+   return ret
 end
 
 function has_numa ()
@@ -63,7 +74,7 @@ function check_affinity_for_pci_addresses (addrs)
    elseif policy.mode ~= S.c.MPOL_MODE['bind'] then
       print("Warning: NUMA memory policy already in effect, but it's not --membind.")
    else
-      local node = S.getcpu().node
+      local node = getcpu().node
       local node_for_pci = choose_numa_node_for_pci_addresses(addrs)
       if node_for_pci and node ~= node_for_pci then
          print("Warning: Bound NUMA node does not have affinity with PCI devices.")
@@ -85,7 +96,7 @@ function bind_to_cpu (cpu)
    assert(not bound_cpu, "already bound")
 
    assert(S.sched_setaffinity(0, cpu))
-   local cpu_and_node = S.getcpu()
+   local cpu_and_node = getcpu()
    assert(cpu_and_node.cpu == cpu)
    bound_cpu = cpu
 
@@ -117,12 +128,12 @@ function selftest ()
    bind_to_cpu(0)
    assert(bound_cpu == 0)
    assert(bound_numa_node == 0)
-   assert(S.getcpu().cpu == 0)
-   assert(S.getcpu().node == 0)
+   assert(getcpu().cpu == 0)
+   assert(getcpu().node == 0)
    bind_to_cpu(nil)
    assert(bound_cpu == nil)
    assert(bound_numa_node == 0)
-   assert(S.getcpu().node == 0)
+   assert(getcpu().node == 0)
    bind_to_numa_node(nil)
    assert(bound_cpu == nil)
    assert(bound_numa_node == nil)

--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -1,0 +1,23 @@
+module(..., package.seeall)
+
+local S = require("syscall")
+
+function set_cpu (cpu)
+   local cpu_set = S.sched_getaffinity()
+   cpu_set:zero()
+   cpu_set:set(cpu)
+   S.sched_setaffinity(0, cpu_set)
+
+   local policy = S.get_mempolicy()
+   mask:zero()
+   mask:set(cpu) -- fixme should be numa node
+   S.set_mempolicy(policy.mode, policy.mask)
+   if not S.sched_setscheduler(0, "fifo", 1) then
+      fatal('Failed to enable real-time scheduling.  Try running as root.')
+   end
+end
+
+function selftest ()
+   print(S.sched_getaffinity())
+   print(S.get_mempolicy().mask)
+end

--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -104,6 +104,11 @@ function bind_to_numa_node (node)
    assert(not bound_numa_node, "already bound")
 
    assert(S.set_mempolicy('bind', node))
+
+   -- Migrate any pages that might have the wrong affinity.
+   local from_mask = assert(S.get_mempolicy(nil, nil, nil, 'mems_allowed')).mask
+   assert(S.migrate_pages(0, from_mask, node))
+
    bound_numa_node = node
 end
 

--- a/src/program/lwaftr/loadtest/README
+++ b/src/program/lwaftr/loadtest/README
@@ -8,6 +8,8 @@ Usage: loadtest [OPTIONS] <PCAP-FILE> <TX-NAME> <RX-NAME> <PCI> [<PCAP-FILE> <TX
                              Linger on each step for DURATION seconds.
   -p PROGRAM, --program PROGRAM
                              Use workload PROGRAM.
+  --cpu CPU
+                             Bind to the given CPU.
   -h, --help
                              Print usage information.
 


### PR DESCRIPTION
This branch makes it so that the --cpu argument also binds memory to a NUMA node.  It also checks that the PCI cards being used are on the same NUMA node as the CPU, as well as troubleshooting some other NUMA-related issues.

It mostly makes it unnecessary to use taskset/numactl.  The exception is that pages that are already allocated when the program starts aren't migrated to the new NUMA node, if they were allocated on the "wrong" NUMA node.  Not sure what to do about this yet.
