### PR TITLE
Backport better loadtest, docs from lwaftr

### DIFF
--- a/src/program/lwaftr/doc/README.benchmarking.md
+++ b/src/program/lwaftr/doc/README.benchmarking.md
@@ -13,10 +13,13 @@ See [README.running.md](README.running.md).
 In one server, start the lwAFTR:
 
 ```
-$ sudo ./src/snabb lwaftr run --cpu 1 -v \
+$ sudo numactl -m 0 taskset -c 1 ./src/snabb lwaftr run -v \
     --conf program/lwaftr/tests/data/icmp_on_fail.conf \
     --v4-pci 0000:02:00.0 --v6-pci 0000:02:00.1
 ```
+
+See [README.performance.md](README.performance.md) for a discussion of `numactl`,
+`taskset`, and NUMA settings.
 
 The `-v` flag enables periodic printouts reporting MPPS and Gbps statistics per
 NIC.
@@ -24,7 +27,7 @@ NIC.
 In the other server, run the `loadtest` command:
 
 ```
-$ sudo ./snabb lwaftr loadtest --cpu 1 -D 1 -b 10e9 -s 0.2e9 \
+$ sudo numactl -m 0 taskset -c 1 ./snabb lwaftr loadtest -D 1 -b 10e9 -s 0.2e9 \
     program/lwaftr/tests/benchdata/ipv4-0550.pcap "NIC 0" "NIC 1" 02:00.0 \
     program/lwaftr/tests/benchdata/ipv6-0550.pcap "NIC 1" "NIC 0" 02:00.1
 ```

--- a/src/program/lwaftr/doc/README.benchmarking.md
+++ b/src/program/lwaftr/doc/README.benchmarking.md
@@ -13,7 +13,7 @@ See [README.running.md](README.running.md).
 In one server, start the lwAFTR:
 
 ```
-$ sudo taskset -c 1 ./src/snabb lwaftr run -v \
+$ sudo ./src/snabb lwaftr run --cpu 1 -v \
     --conf program/lwaftr/tests/data/icmp_on_fail.conf \
     --v4-pci 0000:02:00.0 --v6-pci 0000:02:00.1
 ```
@@ -24,7 +24,7 @@ NIC.
 In the other server, run the `loadtest` command:
 
 ```
-$ sudo taskset -c 1 ./snabb lwaftr loadtest -D 1 -b 10e9 -s 0.2e9 \
+$ sudo ./snabb lwaftr loadtest --cpu 1 -D 1 -b 10e9 -s 0.2e9 \
     program/lwaftr/tests/benchdata/ipv4-0550.pcap "NIC 0" "NIC 1" 02:00.0 \
     program/lwaftr/tests/benchdata/ipv6-0550.pcap "NIC 1" "NIC 0" 02:00.1
 ```
@@ -83,48 +83,25 @@ them to CPUs in the NUMA node 0.
 
 ![Decapsulation Gbps](benchmarks-v1.0/lwaftr-decapsulation-gbps.png)
 
-## Version 2.0
+## Version 2.x
 
 Charts are not available at this moment.  
 
-Version 2.0 fixes packet loss for small binding tables, however there are 
-still packet loss reported for big binding tables.  
-
-The excerpts below show maximum peformance peak before packets start to lose
-for a small binding table and large binding table.  As it was mentioned, small
-binding tables reach linerate speed without reporting packet loss.
-
-Small binding table:
+The 2.x release series (up to version 2.7 at this writing) fixes packet
+loss for binding tables on the order of a million entries.  For example,
+on a binding table with one million entries:
 
 ```
-Applying 10.000000 Gbps of load.
-  NIC 0:
-    TX 2178555 packets (2.178555 MPPS), 1198205250 bytes (9.585642 Gbps)
-    RX 2037552 packets (2.037552 MPPS), 1202155680 bytes (9.617245 Gbps)
-    Loss: 141003 packets (6.472318%)
-  NIC 1:
-    TX 2178567 packets (2.178567 MPPS), 1198211850 bytes (9.585695 Gbps)
-    RX 2178567 packets (2.178567 MPPS), 1111069170 bytes (8.888553 Gbps)
-    Loss: 0 packets (0.000000%)
+Applying 9.800000 Gbps of load.
+  IPv4:
+    TX 2134131 packets (2.134131 MPPS), 1173772050 bytes (9.799930 Gbps)
+    RX 2037944 packets (2.037944 MPPS), 1202386960 bytes (10.010381 Gbps)
+    Loss: 12 ingress drop + 96175 packets lost (4.507080%)
+  IPv6:
+    TX 2134131 packets (2.134131 MPPS), 1173772050 bytes (9.799930 Gbps)
+    RX 2134131 packets (2.134131 MPPS), 1088406810 bytes (9.117008 Gbps)
+    Loss: 0 ingress drop + 0 packets lost (0.000000%)
 ```
-
-Large binding table:
-    
-```
-Applying 10.000000 Gbps of load.
-NIC 0:
-    TX 2178323 packets (2.178323 MPPS), 1198077650 bytes (9.584621 Gbps)
-    RX 1696703 packets (1.696703 MPPS), 1001054770 bytes (8.008438 Gbps)
-Loss: 481620 packets (22.109669%)
-    NIC 1:
-    TX 2178299 packets (2.178299 MPPS), 1198064450 bytes (9.584516 Gbps)
-    RX 1696739 packets (1.696739 MPPS), 865336890 bytes (6.922695 Gbps)
-Loss: 481560 packets (22.107158%)
-```
-
-See the [Large binding table loadtest](benchmarks-v2.0/loadtest.txt) and the
-[Small binding table loadtest](benchmarks-v2.0/loadtest-small.txt) reports for
-more information.
 
 ## Approximate benchmarking, without physical NICs
 
@@ -153,25 +130,9 @@ Time (s),Decapsulation MPPS,Decapsulation Gbps,Encapsulation MPPS,Encapsulation 
 8.999636,2.811551,11.471128,2.811551,13.270521
 9.999650,2.812866,11.476491,2.812866,13.276725
 ```
-### Large binding table
 
-A binding table of 10^6 entries testing 20K softwires.
-
-```bash
-$ sudo ./snabb lwaftr bench lwaftr.conf from-inet-0550.pcap from-b4-0550.pcap 
-loading compiled binding table from ./binding_table.o
-compiled binding table ./binding_table.o is up to date.
-Time (s),Decapsulation MPPS,Decapsulation Gbps,Encapsulation MPPS,Encapsulation Gbps
-0.985063,0.019933,0.081326,0.019933,0.094083
-1.999062,1.237028,5.047072,1.237028,5.838770
-2.998942,1.300146,5.304596,1.300146,6.136689
-3.999119,1.299760,5.303020,1.299760,6.134866
-4.999052,1.300077,5.304314,1.300077,6.136364
-5.999126,1.303208,5.317090,1.303208,6.151144
-6.999103,1.303081,5.316569,1.303081,6.150540
-7.999060,1.303106,5.316672,1.303106,6.150660
-8.999098,1.301215,5.308958,1.301215,6.141735
-9.999096,1.299993,5.303972,1.299993,6.135967
-```
-
-The processing is not limited to 10 Gbps, as no NIC hardware is involved.
+Note however that this approach is limited as it does not model the
+memory behavior of a real lwAFTR that is connected to hardware.  For
+serious performance testing, we recommend using `loadtest` on one
+machine, and running the lwAFTR on another machine that is directly
+cabled to the load-testing machine.

--- a/src/program/lwaftr/doc/README.configuration.md
+++ b/src/program/lwaftr/doc/README.configuration.md
@@ -22,10 +22,10 @@ policy_icmpv6_outgoing = ALLOW
 v4_vlan_tag = 1234
 v6_vlan_tag = 42
 vlan_tagging = true
-# ipv4_ingress_filter = ip
-# ipv4_egress_filter = ip
-# ipv6_ingress_filter = ip6
-# ipv6_egress_filter = ip6
+# ipv4_ingress_filter = "ip"
+# ipv4_egress_filter = "ip"
+# ipv6_ingress_filter = "ip6"
+# ipv6_egress_filter = "ip6"
 ```
 
 The lwAFTR is associated with two physical network cards. One of these cards
@@ -82,6 +82,10 @@ binding_table = path/to/binding-table.txt
 See [README.bindingtable.md](README.bindingtable.md) for binding table
 details.  Note that you can compile the binding table beforehand; again,
 see [README.bindingtable.md](README.bindingtable.md).
+
+If the path to the binding table is a relative path, it will be relative
+to the location of the configuration file.  Enclose the path in single
+or double quotes if the path contains spaces.
 
 ### Hairpinning
 
@@ -150,24 +154,64 @@ will be provided upon request.
 ### Ingress and egress filters
 
 ```
-# ipv4_ingress_filter = ip
-# ipv4_egress_filter = ip
-# ipv6_ingress_filter = ip6
-# ipv6_egress_filter = ip6
+# ipv4_ingress_filter = "ip"
+# ipv4_egress_filter = "ip"
+# ipv6_ingress_filter = "ip6"
+# ipv6_egress_filter = "ip6"
 ```
 
 In the example configuration these entries are commented out by the `#`
 character.  If uncommented, the right-hand-side should be a
 [pflang](https://github.com/Igalia/pflua/blob/master/doc/pflang.md)
 filter.  Pflang is the language of `tcpdump`, `libpcap`, and other
-tools.  If these options are given, the filters will run on the packets
-without vlan tags, if any.
+tools.
 
-Filter definitions may also be stored in separate config files, one per
-filter, and their relative paths go to the right-hand side of these entries.
-The relative paths should be prefixed by `<` and are based on the directory
-where the main config file is. Example:
+If an ingress or egress filter is specified in the configuration file,
+then only packets which match that filter will be allowed in or out of
+the lwAFTR.  It might help to think of the filter as being "whitelists"
+-- they pass only what matches and reject other things.  To make a
+"blacklist" filter, use the `not` pflang operator:
+
+```
+ipv4_ingress_filter = "not ip6"
+```
+
+You might need to use parentheses so that you are applying the `not` to
+the right subexpression.  Note also that if you have 802.1Q vlan tagging
+enabled, the ingress and egress filters run after the tags have been
+stripped.
+
+Here is a more complicated example:
+
+```
+ipv6_egress_filter = "
+  ip6 and not (
+    (icmp6 and
+     src net 3ffe:501:0:1001::2/128 and
+     dst net 3ffe:507:0:1:200:86ff:fe05:8000/116)
+    or
+    (ip6 and udp and
+     src net 3ffe:500::/28 and
+     dst net 3ffe:0501:4819::/64 and
+     src portrange 2397-2399 and
+     dst port 53)
+  )
+"
+```
+
+As filter definitions can be a bit unmanageable as part of the
+configuration, you can also load filters from a file.  To do this, start
+the filter configuration like with `<` and follow it immediately with a
+file name.
 
 ```
 ipv4_ingress_filter = <ingress4.pf
 ```
+
+As with the path to the binding table, if the path to the filter file is
+a relative path, it will be relative to the location of the
+configuration file.  If the path contains spaces, enclose the whole
+string, including the `<` character, in single or double quotes.
+
+Enabling ingress and egress filters currently has a performance cost.
+See [README.performance.md](README.performance.md).

--- a/src/program/lwaftr/doc/README.performance.md
+++ b/src/program/lwaftr/doc/README.performance.md
@@ -10,10 +10,16 @@ for CPUFREQ in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
    echo -n performance > $CPUFREQ;
 done
 ```
+
+You might need to also go into your BIOS and verify that you have not
+enabled aggressive power-saving modes that could downclock your
+processors.  A CPU in a power-saving mode typically takes some time to
+return to peak performance, and this latency can cause packet loss.
+
 ## Avoid fragmentation
 
-Make sure that MTUs are set such that fragmentation is rare.
-
+Fragment reassembly in particular is a costly operation.  Make sure that
+MTUs are set such that fragmentation is rare.
 
 ## NUMA
 
@@ -47,7 +53,9 @@ node 1 cpus: 6 7 8 9 10 11
 ```
 
 So for these we should run our binaries under `taskset -c CPU` to bind
-them to CPUs in the NUMA node 0.
+them to CPUs in the NUMA node 0.  You also need to run Snabb within
+`numactl --membind` to make sure only to use memory that is close to
+that NUMA node.
 
 ## Isolate CPUs
 
@@ -58,11 +66,29 @@ To isolate CPUs, boot your Linux kernel with the `isolcpus` parameter.
 Under NixOS, edit `/etc/nixos/configuration.nix` to add this parameter:
 
 ```
-boot.kernelParams = [ "hugepagesz=1G" "hugepages=10" "isolcpus=1-5,7-11" ];
+boot.kernelParams = [ "default_hugepagesz=2048K"  "hugepagesz=2048K"
+                      "hugepages=10000" "isolcpus=1-5,7-11" ];
 ```
 
-The line above prevents the kernel to schedule processes in CPUs ranging from
-1 to 5 and 7 to 11. That leaves CPUs 0 and 6 for the Linux kernel.
+The line above prevents the kernel to schedule processes in CPUs ranging
+from 1 to 5 and 7 to 11. That leaves CPUs 0 and 6 for the Linux kernel.
+By default, the kernel will arrange deliver interrupts to the first CPU
+on a socket, so this `isolcpus` setting should also isolate the
+dataplane from interrupt handling as well.
 
 After adding the `isolcpus` flag run `nixos-rebuild switch` and then reboot 
 your workstation to enable the changes.
+
+Note that if you are not running NixOS, you probably have `irqbalanced`
+running, and so you might need to stop that to prevent interrupts being
+delivered to your Snabb process.
+
+## Ingress and egress filtering
+
+Simply enabling ingress and/or egress filtering has a cost.  Enabling
+all filtes adds 4 apps to the Snabb graph, and there is a cost for every
+additional Snabb app.  In our tests, while a normal run can do 10 Gbps
+over two interfaces in full duplex, enabling filters drops that to 8.2
+Gbps before dropping packets.  However we have not found that the
+performance depends much on the size of the filter, as the filter's
+branches are well-biased.

--- a/src/program/lwaftr/doc/README.performance.md
+++ b/src/program/lwaftr/doc/README.performance.md
@@ -2,7 +2,8 @@
 
 ## Adjust CPU frequency governor
 
-Set the CPU frequency governor to _'performance'_:
+To avoid power-saving heuristics causing decreased throughput and higher
+latency, set the CPU frequency governor to `performance`:
 
 ```bash
 for CPUFREQ in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
@@ -21,14 +22,29 @@ return to peak performance, and this latency can cause packet loss.
 Fragment reassembly in particular is a costly operation.  Make sure that
 MTUs are set such that fragmentation is rare.
 
+## CPU affinity
+
+A Snabb dataplane works best when it is the only process running on a
+CPU.  Take a look at your resources and choose a CPU on which to run the
+lwAFTR, then invoke it like
+
+```
+numactl -m NODE taskset -c CPU ./snabb lwaftr run ...
+```
+
+That will ensure that Snabb is only running on the given CPU.  Read on
+for a discussion of `numactl`.
+
 ## NUMA
 
-Each NIC is associated with a NUMA node.  For systems with multiple NUMA
-nodes, usually if you have more than one socket, you will need to ensure
-that the processes that access NICs do so from the right NUMA node.
+In a machine with multiple sockets, you usually have Non-Uniform Memory
+Access, or NUMA.  On such a system, a PCI device or a range of memory
+might be "closer" to one node than another.
 
-For example if you are going to be working with NICs `0000:01:00.0`,
-`0000:01:00.1`, `0000:02:00.0`, and `0000:02:00.1`, check:
+To determine what PCI devices are local to what NUMA nodes, you need to
+grovel around in `/sys`.  For example if you are going to be working
+with NICs `0000:01:00.0`, `0000:01:00.1`, `0000:02:00.0`, and
+`0000:02:00.1`, check:
 
 ```bash
 $ for device in 0000:0{1,2}:00.{0,1}; do \
@@ -44,7 +60,7 @@ $ for device in 0000:0{1,2}:00.{0,1}; do \
 0
 ```
 
-So all of these are on NUMA node 0.  Then check your CPUs:
+So all of these are on NUMA node 0.  Then you can check your CPUs:
 
 ```
 $ numactl -H | grep cpus
@@ -52,22 +68,36 @@ node 0 cpus: 0 1 2 3 4 5
 node 1 cpus: 6 7 8 9 10 11
 ```
 
-So for these we should run our binaries under `taskset -c CPU` to bind
-them to CPUs in the NUMA node 0.  You also need to run Snabb within
-`numactl --membind` to make sure only to use memory that is close to
-that NUMA node.
+To arrange for Snabb to only use memory local to a given node, use
+`numactl -m NODE`:
+
+```
+numactl -m NODE taskset -c CPU ./snabb lwaftr run ...
+```
+
+Here the NODE indicates memory afffinity, and the CPU indicates compute
+affinity.  For best performance, this CPU should be on the same NUMA
+node as NODE, and any PCI devices used by `snabb lwaftr run` should also
+be on the same NUMA node.
+
+In our experience, not using the right `numactl` / `taskset` invocations
+is the most common reason for unexpectedly bad lwAFTR performance.  We
+have improved this situation in our development branch but for the 2.x
+series, operators need to use the `numactl` and `taskset` wrappers.
 
 ## Isolate CPUs
 
-Force the Linux kernel to use a limited amount of CPUs to schedule its
-processes, leaving all the other CPUs for running Snabb Switch.
+When running a Snabb dataplane, we don't want interference from the
+Linux kernel.  In normal operation, a Snabb dataplane won't even make
+any system calls at all.  You can prevent the Linux kernel from
+pre-empting your Snabb application to schedule other processes on its
+CPU by reserving CPUs via the `isolcpus` kernel boot setting.
 
 To isolate CPUs, boot your Linux kernel with the `isolcpus` parameter.
 Under NixOS, edit `/etc/nixos/configuration.nix` to add this parameter:
 
 ```
-boot.kernelParams = [ "default_hugepagesz=2048K"  "hugepagesz=2048K"
-                      "hugepages=10000" "isolcpus=1-5,7-11" ];
+boot.kernelParams = [ "isolcpus=1-5,7-11" ];
 ```
 
 The line above prevents the kernel to schedule processes in CPUs ranging
@@ -79,16 +109,123 @@ dataplane from interrupt handling as well.
 After adding the `isolcpus` flag run `nixos-rebuild switch` and then reboot 
 your workstation to enable the changes.
 
-Note that if you are not running NixOS, you probably have `irqbalanced`
-running, and so you might need to stop that to prevent interrupts being
-delivered to your Snabb process.
-
 ## Ingress and egress filtering
 
 Simply enabling ingress and/or egress filtering has a cost.  Enabling
-all filtes adds 4 apps to the Snabb graph, and there is a cost for every
-additional Snabb app.  In our tests, while a normal run can do 10 Gbps
-over two interfaces in full duplex, enabling filters drops that to 8.2
-Gbps before dropping packets.  However we have not found that the
+all filters adds 4 apps to the Snabb graph, and there is a cost for
+every additional Snabb app.  In our tests, while a normal run can do 10
+Gbps over two interfaces in full duplex, enabling filters drops that to
+8.2 Gbps before dropping packets.  However we have not found that the
 performance depends much on the size of the filter, as the filter's
 branches are well-biased.
+
+## Interrupts
+
+Normally Linux will handle hardware interrupts on the first core on a
+socket.  In our case above, that would be cores 0 and 6.  That works
+well with our `isolcpus` setting as well: interrupts like timers and so
+on will only get delivered to the cores which Linux is managing already,
+and won't interrupt the dataplanes.
+
+However, some distributions (notably Ubuntu) enable `irqbalanced`, a
+daemon whose job it is to configure the system to deliver interrupts to
+all cores.  This can increase interrupt-handling throughput, but that's
+not what we want in a Snabb scenario: we want low latency for the
+dataplane, and handling interrupts on dataplane CPUs is undesirable.
+When deploying on Ubuntu, be sure to disable irqbalanced.
+
+## Hyperthreads
+
+Hyperthreads are a way of maximizing resource utilization on a CPU core,
+driven by the observation that a CPU is often waiting on memory or some
+external event, and might as well be doing something else while it's
+waiting.  In such a situation, it can be advantageous to run a second
+thread on that CPU.  However for Snabb that's exactly what we don't
+want.  We do not want another thread competing for compute and cache
+resources on our CPU and increasing our latency.  For best results and
+lowest latency, disable hyperthreading via the BIOS settings.
+
+## Huge pages
+
+By default on a Xeon machine, the virtual memory system manages its
+allocations in 4096-byte "pages".  It has a "page table" which maps
+virtual page addresses to physical memory addresses.  Frequently-used
+parts of a page table are cached in the "translation lookaside buffer"
+(TLB) for fast access.  A virtual memory mapping that describes 500 MB
+of virtual memory would normally require 120000 entries for 4096-byte
+pages.  However, a TLB only has a limited amount of space and can't hold
+all those entries.  If it is missing an entry, that causes a "TLB miss",
+causing an additional trip out to memory to fetch the page table entry,
+slowing down memory access.
+
+To mitigate this problem, it's possible for a Xeon machine to have some
+"huge pages", which can be either 2 megabytes or 1 gigabyte in size.
+The same 500MB address space would then require only 250 entries for 2MB
+hugepages, or just 1 for 1GB hugepages.  That's a big win!  Also,
+memory within a huge page is physically contiguous, which is required to
+interact with some hardware devices, notably the Intel 82599 NICs.
+
+However because hugepages are bigger and need to be physically
+contiguous, it may be necessary to pre-allocate them at boot-time.  To
+do that, add the `default_hugepagesz`, `hugepagesz`, and `hugepages`
+parameters to your kernel boot.  In NixOS, we use the following, adding
+on to the `isolcpus` setting mentioned above:
+
+```
+boot.kernelParams = [ "default_hugepagesz=2048K" "hugepagesz=2048K"
+                      "hugepages=10000" "isolcpus=1-5,7-11" ];
+```
+
+## Ring buffer sizes
+
+The way that Snabb interfaces with a NIC is that it will configure the
+NIC to receive incoming packets into a /ring buffer/.  This ring buffer
+is allocated by Snabb (incidentally, to a huge page; see above) and will
+be filled by the NIC.  It has to be a power of 2 in size: so it can hold
+space for 64 packets, 128 packets, 256 packets, and so on.  The default
+size is 512 packets and the maximum is 65536.  The NIC will fill this
+buffer with packets as it receives them: first to slot 0, then to slot
+1, all the way up to slot 511 (for a ring buffer of the default size),
+then back to slot 0, then slot 1, and so on.  Snabb will periodically
+take some packets out of this read buffer (currently 128 at a time),
+process them, then come back and take some more: wash, rinse, repeat.
+
+The ring buffer size is configurable via the `--ring-buffer-size`
+argument to `snabb lwaftr run`.  What is the right size?  Well, there
+are a few trade-offs.  If the buffer is too big, it will take up a lot
+of memory and start to have too much of a cache footprint.  The ring
+buffer is mapped into Snabb's memory as well, and the NIC arranges for
+the ring buffer elements that it writes to be directly placed in L3
+cache.  This means that receiving packets can evict other entries in L3
+cache.  If your ring buffer is too big, it can evict other data resident
+in cache that you might want.
+
+Another down-side of having a big buffer is latency.  The bigger your
+buffer, the more the bloat.  Usually, Snabb applications always run
+faster than the incoming packets, so the buffer size isn't an issue when
+everything is going well; but in a traffic spike where packets come in
+faster than Snabb can process them, the buffer can remain full the whole
+time, which just adds latency for the packets that Snabb does manage to
+process.
+
+However, too small a buffer exposes the user to a higher risk of packet
+loss due to jitter in the Snabb breath time.  A "breath" is one cycle of
+processing a batch of packets, and as we mentioned it is currently up to
+128 packets at a time.  This processing doesn't always take the same
+amount of time: the contents of the packets can obviously be different,
+causing different control flow and different data flow.  Even well-tuned
+applications can exhibit jitter in their breath times due to differences
+between what data is in cache (and which cache) and what data has to be
+fetched from memory.  Infrequent events like reloading the binding table
+or dumping configuration can also cause one breath to take longer than
+another.  Poorly-tuned applications might have other sources of latency
+such as garbage collection, though this is not usually the case in the
+lwAFTR.
+
+So, a bigger ring buffer insulates packet processing from breath jitter.
+You want your ring buffer to be big enough to not drop packets due to
+jitter during normal operation, but not bigger than that.  In our
+testing we usually use the default ring buffer size.  In your operations
+you might want to increase this up to 2048 entries.  We have not found
+that bigger ring buffer sizes are beneficial, but it depends very much
+on the environment.


### PR DESCRIPTION
This back-ports the ability for loadtest to print ingress drops and to disable jit.flush in the loadtest, and also backports perf docs.  The doc backports were changed to mention numactl and taskset instead of --cpu.
