### PR TITLE
Virtio headroom

### DIFF
--- a/src/apps/lwaftr/fragmentv6.lua
+++ b/src/apps/lwaftr/fragmentv6.lua
@@ -73,7 +73,7 @@ local function _reassemble_validated(fragments, fragment_offsets, fragment_lengt
  
    -- Copy the original headers; this automatically does the right thing in the face of vlans.
    local fixed_headers_size = l2_size + constants.ipv6_fixed_header_size
-   ffi.copy(repkt.data, first_fragment, l2_size + constants.ipv6_fixed_header_size)
+   ffi.copy(repkt.data, first_fragment.data, l2_size + constants.ipv6_fixed_header_size)
    -- Update the next header; it's not a fragment anymore
    repkt.data[l2_size + constants.o_ipv6_next_header] = ipv6_next_header
 

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -1,8 +1,14 @@
-// The maximum amount of payload in any given packet.
-enum { PACKET_PAYLOAD_SIZE = 10*1024 };
+enum {
+    // A few bytes of headroom if needed by a low-level transport like
+    // virtio.
+    PACKET_HEADROOM_SIZE = 32,
+    // The maximum amount of payload in any given packet.
+    PACKET_PAYLOAD_SIZE = 10*1024
+};
 
 // Packet of network data, with associated metadata.
 struct packet {
+    unsigned char headroom[PACKET_HEADROOM_SIZE];
     unsigned char data[PACKET_PAYLOAD_SIZE];
     uint16_t length;           // data payload length
 };

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -43,7 +43,7 @@ end
 -- Create an exact copy of a packet.
 function clone (p)
    local p2 = allocate()
-   ffi.copy(p2, p, p.length)
+   ffi.copy(p2.data, p.data, p.length)
    p2.length = p.length
    return p2
 end

--- a/src/lib/virtio/net_driver.lua
+++ b/src/lib/virtio/net_driver.lua
@@ -19,7 +19,6 @@ local bit       = require('bit')
 local virtq     = require('lib.virtio.virtq_driver')
 local VirtioPci = require('lib.virtio.virtio_pci').VirtioPci
 local checksum  = require('lib.checksum')
-require('lib.virtio.virtio_h')
 
 local band, bor, rshift, lshift = bit.band, bit.bor, bit.rshift, bit.lshift
 local prepare_packet4, prepare_packet6 = checksum.prepare_packet4, checksum.prepare_packet6

--- a/src/lib/virtio/net_driver.lua
+++ b/src/lib/virtio/net_driver.lua
@@ -31,10 +31,10 @@ local ETHERTYPE_OFF = 12
 local ETHERLEN = 14 -- DST MAC | SRC MAC | ethertype
 local VIRTIO_NET_HDR_F_NEEDS_CSUM = 1
 
-local min_features =   C.VIRTIO_RING_F_INDIRECT_DESC + C.VIRTIO_NET_F_CSUM
-local want_features =  C.VIRTIO_F_ANY_LAYOUT +
-                       C.VIRTIO_RING_F_INDIRECT_DESC +
-                       C.VIRTIO_NET_F_MAC
+local min_features = C.VIRTIO_NET_F_CSUM +
+   C.VIRTIO_F_ANY_LAYOUT +
+   C.VIRTIO_NET_F_CTRL_VQ
+local want_features =  min_features
 
 local RXQ = 0
 local TXQ = 1
@@ -51,7 +51,6 @@ function VirtioNetDriver:new(args)
 
    if args.use_checksum then
       self.transmit = self._transmit_checksum
-      self.want_features = self.want_features + C.VIRTIO_NET_F_CSUM
    else
       self.transmit = self._transmit
    end

--- a/src/lib/virtio/virtq_driver.lua
+++ b/src/lib/virtio/virtq_driver.lua
@@ -14,51 +14,17 @@ local ffi    = require("ffi")
 local C      = ffi.C
 local memory = require('core.memory')
 local band   = require('bit').band
+require("lib.virtio.virtio.h")
+require("lib.virtio.virtio_vring.h")
 
 local physical = memory.virtual_to_physical
 
 local VirtioVirtq = {}
 VirtioVirtq.__index = VirtioVirtq
 
--- The Host uses this in used->flags to advise the Guest: don't kick me when you add a buffer.
-local VRING_USED_F_NO_NOTIFY = 1
--- The Guest uses this in avail->flags to advise the Host: don't interrupt me when you consume a buffer
-local VRING_AVAIL_F_NO_INTERRUPT = 1
-
--- This marks a buffer as continuing via the next field.
-local VRING_DESC_F_NEXT = 1
--- This marks a buffer as write-only (otherwise read-only).
-local VRING_DESC_F_WRITE = 2
--- This means the buffer contains a list of buffer descriptors.
-local VRING_DESC_F_INDIRECT = 4
-
-ffi.cdef([[
-struct pk_header {
-  uint8_t flags;
-  uint8_t gso_type;
-  uint16_t hdr_len;
-  uint16_t gso_size;
-  uint16_t csum_start;
-  uint16_t csum_offset;
-}  __attribute__((packed));
-]])
-local pk_header_t = ffi.typeof("struct pk_header")
+local pk_header_t = ffi.typeof("struct virtio_net_hdr")
 local pk_header_size = ffi.sizeof(pk_header_t)
-
-ffi.cdef([[
-  struct vring_desc { 
-    /* Address (guest-physical). */ 
-    uint64_t addr; 
-    /* Length. */ 
-    uint32_t len; 
-    /* The flags as indicated above. */ 
-    uint16_t flags; 
-    /* Next field if flags & NEXT */ 
-    uint16_t next;
-}  __attribute__((packed));
-]])
 local vring_desc_t = ffi.typeof("struct vring_desc")
-
 
 local ringtypes = {}
 local function vring_type(n)
@@ -89,7 +55,7 @@ local function vring_type(n)
          $ *vring;
          uint64_t vring_physaddr;
          struct packet *packets[$];
-         struct pk_header *headers[$];
+         struct virtio_net_hdr *headers[$];
          struct vring_desc *desc_tables[$];
       }
    ]], rng, n, n, n)
@@ -114,7 +80,8 @@ local function allocate_virtq(n)
 
       desc.addr = phys
       desc.len = len
-      desc.flags = VRING_DESC_F_INDIRECT
+      -- fixme
+      desc.flags = C.VIRTIO_DESC_F_INDIRECT
       desc.next = i + 1
    end
 
@@ -124,10 +91,10 @@ local function allocate_virtq(n)
       -- Packet header descriptor
       local desc = desc_table[0]
       ptr, phys = memory.dma_alloc(pk_header_size)
-      vr.headers[i] = ffi.cast("struct pk_header *", ptr)
+      vr.headers[i] = ffi.cast("struct virtio_net_hdr *", ptr)
       desc.addr = phys
       desc.len = pk_header_size
-      desc.flags = VRING_DESC_F_NEXT
+      desc.flags = C.VIRTIO_DESC_F_NEXT
       desc.next = 1
 
       -- Packet data descriptor
@@ -140,7 +107,7 @@ local function allocate_virtq(n)
    vr.num_free = n
 
    -- Disable the interrupts forever, we don't need them
-   vr.vring.avail.flags = VRING_AVAIL_F_NO_INTERRUPT
+   vr.vring.avail.flags = C.VRING_F_NO_INTERRUPT
    return vr
 end
 
@@ -238,7 +205,7 @@ end
 
 function VirtioVirtq:should_notify()
    -- Notify only if the used ring lacks the "no notify" flag
-   return band(self.vring.used.flags, VRING_USED_F_NO_NOTIFY) == 0
+   return band(self.vring.used.flags, C.VRING_F_NO_NOTIFY) == 0
 end
 
 return {

--- a/src/lib/virtio/virtq_driver.lua
+++ b/src/lib/virtio/virtq_driver.lua
@@ -22,8 +22,13 @@ local physical = memory.virtual_to_physical
 local VirtioVirtq = {}
 VirtioVirtq.__index = VirtioVirtq
 
+local PACKET_HEADROOM_SIZE = C.PACKET_HEADROOM_SIZE
+local VRING_F_NO_INTERRUPT = C.VRING_F_NO_INTERRUPT
+local VRING_F_NO_NOTIFY = C.VRING_F_NO_NOTIFY
+
 local pk_header_t = ffi.typeof("struct virtio_net_hdr")
 local pk_header_size = ffi.sizeof(pk_header_t)
+assert(pk_header_size < PACKET_HEADROOM_SIZE)
 local vring_desc_t = ffi.typeof("struct vring_desc")
 
 local ringtypes = {}
@@ -55,10 +60,8 @@ local function vring_type(n)
          $ *vring;
          uint64_t vring_physaddr;
          struct packet *packets[$];
-         struct virtio_net_hdr *headers[$];
-         struct vring_desc *desc_tables[$];
       }
-   ]], rng, n, n, n)
+   ]], rng, n)
    ffi.metatype(t, VirtioVirtq)
    ringtypes[n] = t
    return t
@@ -71,43 +74,16 @@ local function allocate_virtq(n)
    local ptr, phys = memory.dma_alloc(ffi.sizeof(vr.vring[0]))
    vr.vring = ffi.cast(ring_t, ptr)
    vr.vring_physaddr = phys
-
-   for i = 0, n-1 do
-      local desc = vr.vring.desc[i]
-      local len = 2 * ffi.sizeof(vring_desc_t)
-      ptr, phys = memory.dma_alloc(len)
-      vr.desc_tables[i] = ffi.cast("struct vring_desc *", ptr)
-
-      desc.addr = phys
-      desc.len = len
-      -- fixme
-      desc.flags = C.VIRTIO_DESC_F_INDIRECT
-      desc.next = i + 1
+   -- Initialize free list.
+   vr.free_head = -1
+   vr.num_free = 0
+   for i = n-1, 0, -1 do
+      vr.vring.desc[i].next = vr.free_head
+      vr.free_head = i
+      vr.num_free = vr.num_free + 1
    end
-
-   for i = 0, n-1 do
-      local desc_table = vr.desc_tables[i]
-
-      -- Packet header descriptor
-      local desc = desc_table[0]
-      ptr, phys = memory.dma_alloc(pk_header_size)
-      vr.headers[i] = ffi.cast("struct virtio_net_hdr *", ptr)
-      desc.addr = phys
-      desc.len = pk_header_size
-      desc.flags = C.VIRTIO_DESC_F_NEXT
-      desc.next = 1
-
-      -- Packet data descriptor
-      desc = desc_table[1]
-      desc.addr = 0
-      desc.len = 0
-      desc.flags = 0
-      desc.next = -1
-   end
-   vr.num_free = n
-
    -- Disable the interrupts forever, we don't need them
-   vr.vring.avail.flags = C.VRING_F_NO_INTERRUPT
+   vr.vring.avail.flags = VRING_F_NO_INTERRUPT
    return vr
 end
 
@@ -116,24 +92,20 @@ function VirtioVirtq:can_add()
 end
 
 function VirtioVirtq:add(p, len, flags, csum_start, csum_offset)
-
    local idx = self.free_head
    local desc = self.vring.desc[idx]
-   local desc_table = self.desc_tables[idx]
    self.free_head = desc.next
    self.num_free = self.num_free -1
    desc.next = -1
 
-   -- Header
-   local header = self.headers[idx]
-   header[0].flags = flags
-   header[0].csum_start = csum_start
-   header[0].csum_offset = csum_offset
-
-   -- Packet
-   desc = desc_table[1]
-   desc.addr = physical(p.data)
-   desc.len = len
+   local header_addr = p.data - pk_header_size
+   local header = ffi.cast("struct virtio_net_hdr *", header_addr)
+   ffi.fill(header_addr, pk_header_size, 0)
+   --header.flags = flags
+   --header.csum_start = csum_start
+   --header.csum_offset = csum_offset
+   desc.addr = physical(header_addr)
+   desc.len = len + pk_header_size
    desc.flags = 0
    desc.next = -1
 
@@ -143,28 +115,7 @@ function VirtioVirtq:add(p, len, flags, csum_start, csum_offset)
 end
 
 function VirtioVirtq:add_empty_header(p, len)
-   local idx = self.free_head
-   local desc = self.vring.desc[idx]
-   local desc_table = self.desc_tables[idx]
-   self.free_head = desc.next
-   self.num_free = self.num_free -1
-   desc.next = -1
-
-   -- Header
-   local header = self.headers[idx]
-   header[0].flags = 0
-
-   -- Packet
-   desc = desc_table[1]
-   desc.addr = physical(p.data)
-
-   desc.len = len
-   desc.flags = 0
-   desc.next = -1
-
-   self.vring.avail.ring[band(self.last_avail_idx, self.num-1)] = idx
-   self.last_avail_idx = self.last_avail_idx + 1
-   self.packets[idx] = p
+   self:add(p, len, 0, 0, 0)
 end
 
 function VirtioVirtq:update_avail_idx()
@@ -184,16 +135,18 @@ function VirtioVirtq:can_get()
 end
 
 function VirtioVirtq:get()
-
    local last_used_idx = band(self.last_used_idx, self.num-1)
    local used = self.vring.used.ring[last_used_idx]
    local idx = used.id
    local desc = self.vring.desc[idx]
 
+   -- FIXME: we should allow the NEXT flag or something, though with worse perf
+   if debug then assert(desc.flags == 0) end
    local p = self.packets[idx]
+   self.packets[idx] = nil
    if debug then assert(p ~= nil) end
    p.length = used.len - pk_header_size
-   if debug then assert(physical(p.data) == self.desc_tables[idx][1].addr) end
+   if debug then assert(physical(p.data) == desc.addr + pk_header_size) end
 
    self.last_used_idx = self.last_used_idx + 1
    desc.next = self.free_head
@@ -205,7 +158,7 @@ end
 
 function VirtioVirtq:should_notify()
    -- Notify only if the used ring lacks the "no notify" flag
-   return band(self.vring.used.flags, C.VRING_F_NO_NOTIFY) == 0
+   return band(self.vring.used.flags, VRING_F_NO_NOTIFY) == 0
 end
 
 return {


### PR DESCRIPTION
This patch needs testing :)  It adds 32 bytes onto the beginning of `struct packet'.  Virtio-net can scribble in these bytes, avoiding the need for two virtq buffers, effectively making our queue size 256 instead of 128.  This was done before via indirect buffers, which maybe was not as cheap.

I show around a 10% performance boost locally.  Needs #354 and #355 on the Snabb NFV side, to work well -- otherwise we run into various Snabb NFV bugs that prevent this branch from working at all.  Need to measure also on a bare-metal setup to see if the "struct packet" changes do anything bad.
