### PR TITLE
snabbnfv traffic: Only re-start engine when configuration changes

### DIFF
--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -79,20 +79,23 @@ function long_usage () return usage end
 function traffic (pciaddr, confpath, sockpath)
    engine.log = true
    local mtime = 0
-   if C.stat_mtime(confpath) == 0 then
-      print(("WARNING: File '%s' does not exist."):format(confpath))
+   local needs_reconfigure = true
+   function check_for_reconfigure()
+      needs_reconfigure = C.stat_mtime(confpath) ~= mtime
    end
    timer.activate(ingress_drop_monitor.new({action='warn'}):timer())
+   timer.activate(timer.new("reconf", check_for_reconfigure, 1e9, 'repeating'))
+   -- Flush logs every second.
+   timer.activate(timer.new("flush", io.flush, 1e9, 'repeating'))
    while true do
-      local mtime2 = C.stat_mtime(confpath)
-      if mtime2 ~= mtime then
-         print("Loading " .. confpath)
-         engine.configure(nfvconfig.load(confpath, pciaddr, sockpath))
-         mtime = mtime2
+      needs_reconfigure = false
+      print("Loading " .. confpath)
+      mtime = C.stat_mtime(confpath)
+      if mtime == 0 then
+         print(("WARNING: File '%s' does not exist."):format(confpath))
       end
-      engine.main({duration=1, no_report=true})
-      -- Flush buffered log messages every 1s
-      io.flush()
+      engine.configure(nfvconfig.load(confpath, pciaddr, sockpath))
+      engine.main({done=function() return needs_reconfigure end})
    end
 end
 


### PR DESCRIPTION
Before, snabbnfv would run the engine for one-second intervals, checking
for restart every second and restarting the engine.  However this
interacts poorly with the latency-tracking mechanism, which expects to
be able to call non-performant functions like ffi.typeof() at setup,
because it's just setup.  With this fix we have less trace creation and
interpreter bailout at run-time.

/cc @lukego
