### PR TITLE
Backport lwaftr_starfruit v2.7 changes to lwaftr

### DIFF
--- a/src/program/lwaftr/doc/CHANGELOG.md
+++ b/src/program/lwaftr/doc/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## [2.7] - 2016-05-19
+
+A performance, feature, and bug-fix release.
+
+ * Fix a situation where the JIT self-healing behavior introduced in
+   v2.4 was not being triggered when VLANs were enabled.  Detecting when
+   to re-train the JIT depends on information from the network card, and
+   the Snabb Intel 82599 driver has two very different code paths
+   depending on whether VLAN tagging is enabled or not.  Our fix that we
+   introduced in v2.4 was only working if VLAN tagging was not enabled.
+   The end result was that performance was not as reliably good as it
+   should be.
+
+ * Add the ability for the "loadtest" command to produce different load
+   transient shapes.  See "snabb lwaftr loadtest --help" for more
+   details.
+
 ## [2.6] - 2016-05-18
 
 A bug fix release.


### PR DESCRIPTION
lwAFTR v2.7 log:

``` bash
$ git log --no-merges --pretty=format:"%h %s" v2.6..v2.7
```

_eee1ca7_ v2.7 changelog
_a37e453_ Fetch VF ingress packet drops from correct queue
_7895e89_ Intel VF interfaces default to statistics counter 0.
_8deca3d_ Loadtest supports different programs
_1f76033_ Fix promise bug with more than one argument.

The only commit missing is _eee1ca7_, all the other commits were already present in `lwaftr` branch.

The missing commit simply updates the lwAFTR Changelog with the changes from v2.7. No need to run a performance benchmark.
