### PR TITLE
Backport lwaftr_starfruit v2.8 changes to lwaftr

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -117,8 +117,7 @@ function ingress_drop_monitor:jit_flush_if_needed()
    self.last_flush = now()
    self.last_value[0] = self.current_value[0]
    jit.flush()
-   local now_str = tonumber(now())/1e9
-   print(now_str..": warning: Dropped more than "..self.threshold.." packets; flushing JIT to try to recover.")
+   print(now()..": warning: Dropped more than "..self.threshold.." packets; flushing JIT to try to recover.")
    if print_tuning_tip then
       print("See https://github.com/Igalia/snabb/blob/lwaftr_starfruit/src/program/lwaftr/doc/README.performance.md for performance tuning tips.")
       print_tuning_tip = false

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -110,13 +110,19 @@ function ingress_drop_monitor:sample()
    end
 end
 
+local print_tuning_tip = true
 function ingress_drop_monitor:jit_flush_if_needed()
    if self.current_value[0] - self.last_value[0] < self.threshold then return end
    if now() - self.last_flush < self.wait then return end
    self.last_flush = now()
    self.last_value[0] = self.current_value[0]
    jit.flush()
-   print("jit.flush")
+   local now_str = tonumber(now())/1e9
+   print(now_str..": warning: Dropped more than "..self.threshold.." packets; flushing JIT to try to recover.")
+   if print_tuning_tip then
+      print("See https://github.com/Igalia/snabb/blob/lwaftr_starfruit/src/program/lwaftr/doc/README.performance.md for performance tuning tips.")
+      print_tuning_tip = false
+   end
    --- TODO: Change last_flush, last_value and current_value fields to be counters.
 end
 

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -110,18 +110,16 @@ function ingress_drop_monitor:sample()
    end
 end
 
-local print_tuning_tip = true
 function ingress_drop_monitor:jit_flush_if_needed()
    if self.current_value[0] - self.last_value[0] < self.threshold then return end
    if now() - self.last_flush < self.wait then return end
    self.last_flush = now()
    self.last_value[0] = self.current_value[0]
    jit.flush()
-   print(now()..": warning: Dropped more than "..self.threshold.." packets; flushing JIT to try to recover.")
-   if print_tuning_tip then
-      print("See https://github.com/Igalia/snabb/blob/lwaftr_starfruit/src/program/lwaftr/doc/README.performance.md for performance tuning tips.")
-      print_tuning_tip = false
-   end
+   print(now()..": warning: Dropped more than "..self.threshold.." packets;"
+            .." flushing JIT to try to recover.  See"
+            .." https://github.com/Igalia/snabb/blob/lwaftr_starfruit/src/program/lwaftr/doc/README.performance.md"
+            .." for performance tuning tips.")
    --- TODO: Change last_flush, last_value and current_value fields to be counters.
 end
 

--- a/src/program/lwaftr/doc/CHANGELOG.md
+++ b/src/program/lwaftr/doc/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Change Log
 
+## [2.8] - 2016-06-03
+
+A bug-fix and documentation release.
+
+ * Fix ability to load in ingress and egress filters from a file.  This
+   feature was originally developed on our main branch and backported in
+   v2.5, but the backport was missing a necessary fix from the main
+   branch.
+
+ * Update documentation on ingress and egress filtering, giving several
+   examples.
+
+ * Added performance analysis of the overhead of ingress and egress
+   filtering.  See
+   https://github.com/Igalia/snabb/blob/lwaftr_starfruit/src/program/lwaftr/doc/README.filters-performance.md.
+
+ * Updated documentation for performance tuning.  See
+   https://github.com/Igalia/snabb/blob/lwaftr_starfruit/src/program/lwaftr/doc/README.performance.md
+
+ * Add a time-stamp for the JIT self-healing behavior, and adapt the
+   message to be more helpful.
+
+ * The "loadtest" command now separates reporting of drops that were
+   because the load generator was not able to service its receive queue
+   in time, and drops which originate in the remote tested process.
+
 ## [2.7] - 2016-05-19
 
 A performance, feature, and bug-fix release.

--- a/src/program/lwaftr/doc/README.benchmarking.md
+++ b/src/program/lwaftr/doc/README.benchmarking.md
@@ -13,10 +13,13 @@ See [README.running.md](README.running.md).
 In one server, start the lwAFTR:
 
 ```
-$ sudo ./src/snabb lwaftr run --cpu 1 -v \
+$ sudo numactl -m 0 taskset -c 1 ./src/snabb lwaftr run -v \
     --conf program/lwaftr/tests/data/icmp_on_fail.conf \
     --v4 0000:02:00.0 --v6 0000:02:00.1
 ```
+
+See [README.performance.md](README.performance.md) for a discussion of `numactl`,
+`taskset`, and NUMA settings.
 
 The `-v` flag enables periodic printouts reporting MPPS and Gbps statistics per
 NIC.
@@ -24,7 +27,7 @@ NIC.
 In the other server, run the `loadtest` command:
 
 ```
-$ sudo ./snabb lwaftr loadtest --cpu 1 -D 1 -b 10e9 -s 0.2e9 \
+$ sudo numactl -m 0 taskset -c 1 ./snabb lwaftr loadtest -D 1 -b 10e9 -s 0.2e9 \
     program/lwaftr/tests/benchdata/ipv4-0550.pcap "NIC 0" "NIC 1" 02:00.0 \
     program/lwaftr/tests/benchdata/ipv6-0550.pcap "NIC 1" "NIC 0" 02:00.1
 ```


### PR DESCRIPTION
lwAFTR v2.8 log:

``` bash
$ git log --no-merges --pretty=format:"%h %s" v2.7..v2.8
```

_4bdab44_ v2.8 release notes
_25ba3ec_ Print troubleshooting link at every jit.flush.
_411aac3_ Added documentation of filter performance
_562fb0f_ Change --cpu mentions to taskset/numactl
_35fe940_ Fix time printout.
_3fa98f1_ More helpful jit.flush message
_3fa98f1_ More performance documentation updates
_b5c38fb_ Update documentation
_8bd2f99_ Disable JIT flush/drop monitor on loadtest; print ingress drops.
_4564d8a_ Unify pathname logic

Commits not present in `lwaftr` branch:

_4bdab44_ v2.8 release notes
_25ba3ec_ Print troubleshooting link at every jit.flush.
_562fb0f_ Change --cpu mentions to taskset/numactl
_35fe940_ Fix time printout.
_3fa98f1_ More helpful jit.flush message
_4564d8a_ Unify pathname logic

_4564d8a_ (_Unify pathname logic_) is a backport of #317, so the change was already preset in`lwaftr` branch.This PR includes #371.
