### PR TITLE
Backport lwaftr_starfruit v2.9 changes to lwaftr

### DIFF
--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -133,7 +133,7 @@ function Intel82599:pull ()
    if l == nil then return end
    self.dev:sync_receive()
    for i=1,128 do
-      if full(l) or not self.dev:can_receive() then break end
+      if not self.dev:can_receive() then break end
       transmit(l, self.dev:receive())
    end
    self:add_receive_buffers()

--- a/src/apps/lwaftr/fragmentv6.lua
+++ b/src/apps/lwaftr/fragmentv6.lua
@@ -73,7 +73,7 @@ local function _reassemble_validated(fragments, fragment_offsets, fragment_lengt
  
    -- Copy the original headers; this automatically does the right thing in the face of vlans.
    local fixed_headers_size = l2_size + constants.ipv6_fixed_header_size
-   ffi.copy(repkt.data, first_fragment, l2_size + constants.ipv6_fixed_header_size)
+   ffi.copy(repkt.data, first_fragment.data, l2_size + constants.ipv6_fixed_header_size)
    -- Update the next header; it's not a fragment anymore
    repkt.data[l2_size + constants.o_ipv6_next_header] = ipv6_next_header
 

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -380,7 +380,10 @@ local function encapsulate_and_transmit(lwstate, pkt, ipv6_dst, ipv6_src)
    local payload_length = get_ethernet_payload_length(pkt)
    local l3_header = get_ethernet_payload(pkt)
    local dscp_and_ecn = get_ipv4_dscp_and_ecn(l3_header)
+   -- Note that this may invalidate any pointer into pkt.data.  Be warned!
    packet.shiftright(pkt, ipv6_fixed_header_size)
+   -- Fetch possibly-moved L3 header location.
+   l3_header = get_ethernet_payload(pkt)
    write_eth_header(pkt.data, ether_src, ether_dst, n_ethertype_ipv6)
    write_ipv6_header(l3_header, ipv6_src, ipv6_dst,
                      dscp_and_ecn, next_hdr_type, payload_length)
@@ -563,6 +566,7 @@ local function flush_decapsulation(lwstate)
           and ipv6_equals(get_ipv6_src_address(ipv6_header), b4_addr)
           and ipv6_equals(get_ipv6_dst_address(ipv6_header), br_addr)) then
          -- Source softwire is valid; decapsulate and forward.
+         -- Note that this may invalidate any pointer into pkt.data.  Be warned!
          packet.shiftleft(pkt, ipv6_fixed_header_size)
          write_eth_header(pkt.data, lwstate.aftr_mac_inet_side, lwstate.inet_mac,
                           n_ethertype_ipv4)

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -3,7 +3,7 @@
 enum {
     // A few bytes of headroom if needed by a low-level transport like
     // virtio.
-    PACKET_HEADROOM_SIZE = 54,
+    PACKET_HEADROOM_SIZE = 48,
     // The maximum amount of payload in any given packet.
     PACKET_PAYLOAD_SIZE = 10*1024
 };
@@ -12,7 +12,8 @@ enum {
 struct packet {
     unsigned char *data;
     uint16_t length;           // data payload length
-    unsigned char headroom[PACKET_HEADROOM_SIZE];
+    uint16_t headroom;
+    uint32_t padding;
     unsigned char data_[PACKET_PAYLOAD_SIZE];
 };
 

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -1,18 +1,13 @@
 /* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
 
-enum {
-    // A few bytes of headroom if needed by a low-level transport like
-    // virtio.
-    PACKET_HEADROOM_SIZE = 64,
-    // The maximum amount of payload in any given packet.
-    PACKET_PAYLOAD_SIZE = 10*1024
-};
+// The maximum amount of payload in any given packet.
+enum { PACKET_PAYLOAD_SIZE = 10*1024 };
 
 // Packet of network data, with associated metadata.
 struct packet {
     unsigned char *data;
     uint16_t length;           // data payload length
-    uint16_t headroom;
+    uint16_t headroom;         // payload starts this many bytes into data_
     uint32_t padding;
     unsigned char data_[PACKET_PAYLOAD_SIZE];
 };

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -3,15 +3,16 @@
 enum {
     // A few bytes of headroom if needed by a low-level transport like
     // virtio.
-    PACKET_HEADROOM_SIZE = 32,
+    PACKET_HEADROOM_SIZE = 56,
     // The maximum amount of payload in any given packet.
     PACKET_PAYLOAD_SIZE = 10*1024
 };
 
 // Packet of network data, with associated metadata.
 struct packet {
+    unsigned char *data;
     unsigned char headroom[PACKET_HEADROOM_SIZE];
-    unsigned char data[PACKET_PAYLOAD_SIZE];
+    unsigned char data_[PACKET_PAYLOAD_SIZE];
     uint16_t length;           // data payload length
 };
 

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -3,7 +3,7 @@
 enum {
     // A few bytes of headroom if needed by a low-level transport like
     // virtio.
-    PACKET_HEADROOM_SIZE = 48,
+    PACKET_HEADROOM_SIZE = 64,
     // The maximum amount of payload in any given packet.
     PACKET_PAYLOAD_SIZE = 10*1024
 };

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -1,10 +1,16 @@
 /* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
 
-// The maximum amount of payload in any given packet.
-enum { PACKET_PAYLOAD_SIZE = 10*1024 };
+enum {
+    // A few bytes of headroom if needed by a low-level transport like
+    // virtio.
+    PACKET_HEADROOM_SIZE = 32,
+    // The maximum amount of payload in any given packet.
+    PACKET_PAYLOAD_SIZE = 10*1024
+};
 
 // Packet of network data, with associated metadata.
 struct packet {
+    unsigned char headroom[PACKET_HEADROOM_SIZE];
     unsigned char data[PACKET_PAYLOAD_SIZE];
     uint16_t length;           // data payload length
 };

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -3,7 +3,7 @@
 enum {
     // A few bytes of headroom if needed by a low-level transport like
     // virtio.
-    PACKET_HEADROOM_SIZE = 56,
+    PACKET_HEADROOM_SIZE = 54,
     // The maximum amount of payload in any given packet.
     PACKET_PAYLOAD_SIZE = 10*1024
 };
@@ -11,8 +11,8 @@ enum {
 // Packet of network data, with associated metadata.
 struct packet {
     unsigned char *data;
+    uint16_t length;           // data payload length
     unsigned char headroom[PACKET_HEADROOM_SIZE];
     unsigned char data_[PACKET_PAYLOAD_SIZE];
-    uint16_t length;           // data payload length
 };
 

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -74,7 +74,7 @@ end
 -- Create an exact copy of a packet.
 function clone (p)
    local p2 = allocate()
-   ffi.copy(p2, p, p.length)
+   ffi.copy(p2.data, p.data, p.length)
    p2.length = p.length
    return p2
 end

--- a/src/lib/ipsec/esp.lua
+++ b/src/lib/ipsec/esp.lua
@@ -188,7 +188,7 @@ ABCDEFGHIJKLMNOPQRSTUVWXYZ
    local p2 = packet.clone(p_enc)
    assert(dec:decapsulate(p2), "decapsulation failed")
    print("decrypted", lib.hexdump(ffi.string(p2.data, p2.length)))
-   assert(p2.length == p.length and C.memcmp(p, p2, p.length) == 0,
+   assert(p2.length == p.length and C.memcmp(p.data, p2.data, p.length) == 0,
           "integrity check failed")
    -- Check invalid packets.
    local p_invalid = packet.from_string("invalid")
@@ -209,7 +209,7 @@ ABCDEFGHIJKLMNOPQRSTUVWXYZ
    print("decrypted", lib.hexdump(ffi.string(packet.data(e_min), packet.length(e_min))))
    assert(packet.length(e_min) == PAYLOAD_OFFSET)
    assert(packet.length(p_min) == packet.length(e_min)
-          and C.memcmp(p_min, e_min, packet.length(p_min)) == 0,
+          and C.memcmp(p_min.data, e_min.data, packet.length(p_min)) == 0,
           "integrity check failed")
    -- Check transmitted Sequence Number wrap around
    enc.seq:low(0)

--- a/src/lib/virtio/net_driver.lua
+++ b/src/lib/virtio/net_driver.lua
@@ -33,10 +33,10 @@ local ETHERTYPE_OFF = 12
 local ETHERLEN = 14 -- DST MAC | SRC MAC | ethertype
 local VIRTIO_NET_HDR_F_NEEDS_CSUM = 1
 
-local min_features =   C.VIRTIO_RING_F_INDIRECT_DESC + C.VIRTIO_NET_F_CSUM
-local want_features =  C.VIRTIO_F_ANY_LAYOUT +
-                       C.VIRTIO_RING_F_INDIRECT_DESC +
-                       C.VIRTIO_NET_F_MAC
+local min_features = C.VIRTIO_NET_F_CSUM +
+   C.VIRTIO_F_ANY_LAYOUT +
+   C.VIRTIO_NET_F_CTRL_VQ
+local want_features =  min_features
 
 local RXQ = 0
 local TXQ = 1
@@ -53,7 +53,6 @@ function VirtioNetDriver:new(args)
 
    if args.use_checksum then
       self.transmit = self._transmit_checksum
-      self.want_features = self.want_features + C.VIRTIO_NET_F_CSUM
    else
       self.transmit = self._transmit
    end

--- a/src/lib/virtio/net_driver.lua
+++ b/src/lib/virtio/net_driver.lua
@@ -21,7 +21,6 @@ local bit       = require('bit')
 local virtq     = require('lib.virtio.virtq_driver')
 local VirtioPci = require('lib.virtio.virtio_pci').VirtioPci
 local checksum  = require('lib.checksum')
-require('lib.virtio.virtio_h')
 
 local band, bor, rshift, lshift = bit.band, bit.bor, bit.rshift, bit.lshift
 local prepare_packet4, prepare_packet6 = checksum.prepare_packet4, checksum.prepare_packet6

--- a/src/lib/virtio/virtq_driver.lua
+++ b/src/lib/virtio/virtq_driver.lua
@@ -21,8 +21,13 @@ local physical = memory.virtual_to_physical
 local VirtioVirtq = {}
 VirtioVirtq.__index = VirtioVirtq
 
+local PACKET_HEADROOM_SIZE = C.PACKET_HEADROOM_SIZE
+local VRING_F_NO_INTERRUPT = C.VRING_F_NO_INTERRUPT
+local VRING_F_NO_NOTIFY = C.VRING_F_NO_NOTIFY
+
 local pk_header_t = ffi.typeof("struct virtio_net_hdr")
 local pk_header_size = ffi.sizeof(pk_header_t)
+assert(pk_header_size < PACKET_HEADROOM_SIZE)
 local vring_desc_t = ffi.typeof("struct vring_desc")
 
 local ringtypes = {}
@@ -54,10 +59,8 @@ local function vring_type(n)
          $ *vring;
          uint64_t vring_physaddr;
          struct packet *packets[$];
-         struct virtio_net_hdr *headers[$];
-         struct vring_desc *desc_tables[$];
       }
-   ]], rng, n, n, n)
+   ]], rng, n)
    ffi.metatype(t, VirtioVirtq)
    ringtypes[n] = t
    return t
@@ -70,43 +73,16 @@ local function allocate_virtq(n)
    local ptr, phys = memory.dma_alloc(ffi.sizeof(vr.vring[0]))
    vr.vring = ffi.cast(ring_t, ptr)
    vr.vring_physaddr = phys
-
-   for i = 0, n-1 do
-      local desc = vr.vring.desc[i]
-      local len = 2 * ffi.sizeof(vring_desc_t)
-      ptr, phys = memory.dma_alloc(len)
-      vr.desc_tables[i] = ffi.cast("struct vring_desc *", ptr)
-
-      desc.addr = phys
-      desc.len = len
-      -- fixme
-      desc.flags = C.VIRTIO_DESC_F_INDIRECT
-      desc.next = i + 1
+   -- Initialize free list.
+   vr.free_head = -1
+   vr.num_free = 0
+   for i = n-1, 0, -1 do
+      vr.vring.desc[i].next = vr.free_head
+      vr.free_head = i
+      vr.num_free = vr.num_free + 1
    end
-
-   for i = 0, n-1 do
-      local desc_table = vr.desc_tables[i]
-
-      -- Packet header descriptor
-      local desc = desc_table[0]
-      ptr, phys = memory.dma_alloc(pk_header_size)
-      vr.headers[i] = ffi.cast("struct virtio_net_hdr *", ptr)
-      desc.addr = phys
-      desc.len = pk_header_size
-      desc.flags = C.VIRTIO_DESC_F_NEXT
-      desc.next = 1
-
-      -- Packet data descriptor
-      desc = desc_table[1]
-      desc.addr = 0
-      desc.len = 0
-      desc.flags = 0
-      desc.next = -1
-   end
-   vr.num_free = n
-
    -- Disable the interrupts forever, we don't need them
-   vr.vring.avail.flags = C.VRING_F_NO_INTERRUPT
+   vr.vring.avail.flags = VRING_F_NO_INTERRUPT
    return vr
 end
 
@@ -115,24 +91,20 @@ function VirtioVirtq:can_add()
 end
 
 function VirtioVirtq:add(p, len, flags, csum_start, csum_offset)
-
    local idx = self.free_head
    local desc = self.vring.desc[idx]
-   local desc_table = self.desc_tables[idx]
    self.free_head = desc.next
    self.num_free = self.num_free -1
    desc.next = -1
 
-   -- Header
-   local header = self.headers[idx]
-   header[0].flags = flags
-   header[0].csum_start = csum_start
-   header[0].csum_offset = csum_offset
-
-   -- Packet
-   desc = desc_table[1]
-   desc.addr = physical(p.data)
-   desc.len = len
+   local header_addr = p.data - pk_header_size
+   local header = ffi.cast("struct virtio_net_hdr *", header_addr)
+   ffi.fill(header_addr, pk_header_size, 0)
+   --header.flags = flags
+   --header.csum_start = csum_start
+   --header.csum_offset = csum_offset
+   desc.addr = physical(header_addr)
+   desc.len = len + pk_header_size
    desc.flags = 0
    desc.next = -1
 
@@ -142,28 +114,7 @@ function VirtioVirtq:add(p, len, flags, csum_start, csum_offset)
 end
 
 function VirtioVirtq:add_empty_header(p, len)
-   local idx = self.free_head
-   local desc = self.vring.desc[idx]
-   local desc_table = self.desc_tables[idx]
-   self.free_head = desc.next
-   self.num_free = self.num_free -1
-   desc.next = -1
-
-   -- Header
-   local header = self.headers[idx]
-   header[0].flags = 0
-
-   -- Packet
-   desc = desc_table[1]
-   desc.addr = physical(p.data)
-
-   desc.len = len
-   desc.flags = 0
-   desc.next = -1
-
-   self.vring.avail.ring[band(self.last_avail_idx, self.num-1)] = idx
-   self.last_avail_idx = self.last_avail_idx + 1
-   self.packets[idx] = p
+   self:add(p, len, 0, 0, 0)
 end
 
 function VirtioVirtq:update_avail_idx()
@@ -183,16 +134,18 @@ function VirtioVirtq:can_get()
 end
 
 function VirtioVirtq:get()
-
    local last_used_idx = band(self.last_used_idx, self.num-1)
    local used = self.vring.used.ring[last_used_idx]
    local idx = used.id
    local desc = self.vring.desc[idx]
 
+   -- FIXME: we should allow the NEXT flag or something, though with worse perf
+   if debug then assert(desc.flags == 0) end
    local p = self.packets[idx]
+   self.packets[idx] = nil
    if debug then assert(p ~= nil) end
    p.length = used.len - pk_header_size
-   if debug then assert(physical(p.data) == self.desc_tables[idx][1].addr) end
+   if debug then assert(physical(p.data) == desc.addr + pk_header_size) end
 
    self.last_used_idx = self.last_used_idx + 1
    desc.next = self.free_head
@@ -204,7 +157,7 @@ end
 
 function VirtioVirtq:should_notify()
    -- Notify only if the used ring lacks the "no notify" flag
-   return band(self.vring.used.flags, C.VRING_F_NO_NOTIFY) == 0
+   return band(self.vring.used.flags, VRING_F_NO_NOTIFY) == 0
 end
 
 return {

--- a/src/program/lwaftr/doc/CHANGELOG.md
+++ b/src/program/lwaftr/doc/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Change Log
 
+## [2.9] - 2016-06-09
+
+A performance release, speeding up both the core lwaftr operations as
+well as the support for running Snabb on virtualized interfaces.
+
+ * Change Snabb representation of packets to have "headroom".
+   Prepending a header to a packet, as when encapsulating a packet in a
+   lightweight 4-over-6 softwire, can use this headroom instead of
+   shifting the packet's payload around in memory.  Taking off a header,
+   as in decapsulation, can likewise just adjust the amount of headroom.
+   Likewise when sending packets to a host Snabb NFV the virtio system
+   can place these headers in the headroom as well, instead of needing
+   multiple virtio scatter-gather buffers.
+
+ * Fix a bug in Snabb NFV by which it would mistakenly cache the Virtio
+   features that it used when negotiating with QEMU at startup for the
+   Snabb process.
+
+ * Remove backpressure on the intel driver.  This means that if Snabb
+   NFV is dropping packets at ingress, it is because Snabb NFV is too
+   slow.  If it is dropping them on the NIC -> Virtio link, it is
+   because the guest is too slow.
+
+Note: this version of the lwaftr *needs* a fixed version of Snabb NFV to
+run virtualized.  The patches are headed upstream, but for now, use the
+Snabb NFV from this release instead of the ones from upstream.
+
 ## [2.8] - 2016-06-03
 
 A bug-fix and documentation release.

--- a/src/program/lwaftr/virt/lwaftrctl
+++ b/src/program/lwaftr/virt/lwaftrctl
@@ -35,7 +35,7 @@ qemu_start_vm() {
     cd $VM_DIR
     sudo numactl -m ${NUMA_NODE} taskset -c ${QEMU_CORE} qemu-system-x86_64 \
         --enable-kvm -name ${NAME} -drive file=${DISK},if=virtio \
-        -m ${MEM} -cpu host -smp 2 \
+        -m ${MEM} -cpu host \
         -fsdev local,security_model=passthrough,id=fsdev0,path=${SHARED_LOCATION} \
             -device virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=share \
         -object memory-backend-file,id=mem,size=${MEM},mem-path=${HUGEPAGESTLB_FS},share=on \
@@ -57,10 +57,6 @@ vm_pid() {
 
 start_vm() {
     qemu_start_vm
-
-    pid=$(vm_pid "${NAME}")
-    for each in `ls /proc/$pid/task`; do sudo taskset -cp $QEMU_CORE $each; done
-    echo "Pinned QEMU to core $QEMU_CORE"
 }
 
 stop_vm() {


### PR DESCRIPTION
lwAFTR v2.8 log:

``` bash
$ git log --no-merges --pretty=format:"%h %s" v2.8..v2.9
```

_b7f876e_ v2.9 changelog
_38f6a74_ Default headroom in Lua, not C
_8d91975_ Bump packet headroom to 64 bytes.
_b4c0fb9_ Adapt virtio to use packet.shift for its headers
_8d8f245_ Add assertions in packet.lua
_08df8af_ Refactor packet headroom mechanism
_a58c4d2_ lwaftr is resilient to changes in p.data
_cbc8882_ Bring length back to beginning of struct packet
_1927541_ Indirect access to packet data
_fe12a0e_ Fix assumptions that packet == packet.data
_69a29ad_ virtio-net driver: Use direct descriptors
_45e346d_ Disable backpressure on intel driver
_df8e83c_ vhost-user: Support operation without MRG_RXBUF.
_10901b8_ vhost_user: Fix & comment "feature cache"
_d3939dc_ Add some headroom before a packet's data.
_ea865e9_ virtio-net driver: Use C header files
_c784e19_ Cleanup of lwaftrctl script

None commits were present in the `lwaftr` branch, except two:

_df8e83c_ vhost-user: Support operation without MRG_RXBUF.
_10901b8_ vhost_user: Fix & comment "feature cache"

All the rest need to be backported. This PR includes the commits present in #371 and #372.
