### PR TITLE
Backport lwaftr_starfruit v2.10 changes to lwaftr

### DIFF
--- a/src/lib/timers/ingress_drop_monitor.lua
+++ b/src/lib/timers/ingress_drop_monitor.lua
@@ -5,45 +5,59 @@ module(...,package.seeall)
 local ffi = require("ffi")
 
 -- Every 100 milliseconds.
-local interval = 1e8
+local default_interval = 1e8
 
-local with_restart = core.app.with_restart
 local now = core.app.now
 
-ingress_drop_monitor = {
-   threshold = 100000,
-   wait = 20,
-   last_flush = 0,
-   last_value = ffi.new('uint64_t[1]'),
-   current_value = ffi.new('uint64_t[1]'),
-}
+local IngressDropMonitor = {}
 
-function ingress_drop_monitor:sample ()
+function new(args)
+   local ret = {
+      threshold = args.threshold or 100000,
+      wait = args.wait or 20,
+      action = args.action or 'flush',
+      last_flush = 0,
+      last_value = ffi.new('uint64_t[1]'),
+      current_value = ffi.new('uint64_t[1]')
+   }
+   return setmetatable(ret, {__index=IngressDropMonitor})
+end
+
+function IngressDropMonitor:sample ()
    local app_array = engine.app_array
    local sum = self.current_value
    sum[0] = 0
    for i = 1, #app_array do
       local app = app_array[i]
       if app.ingress_packet_drops and not app.dead then
-         local status, value = with_restart(app, app.ingress_packet_drops)
-         if status then sum[0] = sum[0] + value end
+         sum[0] = sum[0] + app:ingress_packet_drops()
       end
    end
 end
 
-function ingress_drop_monitor:jit_flush_if_needed ()
+local tips_url = "https://github.com/Igalia/snabb/blob/lwaftr/src/program/lwaftr/doc/README.performance.md"
+
+function IngressDropMonitor:jit_flush_if_needed ()
    if self.current_value[0] - self.last_value[0] < self.threshold then return end
    if now() - self.last_flush < self.wait then return end
    self.last_flush = now()
    self.last_value[0] = self.current_value[0]
-   jit.flush()
-   print("jit.flush")
    --- TODO: Change last_flush, last_value and current_value fields to be counters.
+   local msg = now()..": warning: Dropped more than "..self.threshold.." packets"
+   if self.action == 'flush' then
+      msg = msg.."; flushing JIT to try to recover"
+   end
+   msg = msg..". See "..tips_url.." for performance tuning tips."
+   print(msg)
+   if self.action == 'flush' then jit.flush() end
 end
 
-local function fn ()
-   ingress_drop_monitor:sample()
-   ingress_drop_monitor:jit_flush_if_needed()
+function IngressDropMonitor:timer(interval)
+   return timer.new("ingress drop monitor",
+                    function ()
+                       self:sample()
+                       self:jit_flush_if_needed()
+                    end,
+                    interval or default_interval,
+                    "repeating")
 end
-
-return timer.new("ingress drop monitor", fn, interval, "repeating")

--- a/src/program/lwaftr/doc/CHANGELOG.md
+++ b/src/program/lwaftr/doc/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [2.10] - 2016-06-17
+
+A Snabb NFV performance fix, which results in more reliable performance
+when running any virtualized workload, including the lwAFTR.
+
+ * Fix a situation in the NFV which caused runtime behavior that the JIT
+   compiler did not handle well.  This fixes the situation where
+   sometimes Snabb NFV would wedge itself into a very low-throughput
+   state.
+
+ * Disable jit.flush() mechanism in Snabb NFV, to remove a source of
+   divergence with upstream Snabb NFV.  Ingress drops in the NFV are
+   still detected and printed to the console, but as warnings.
+
+ * Remove remaining sources of backpressure in the lwAFTR.
+
 ## [2.9] - 2016-06-09
 
 A performance release, speeding up both the core lwaftr operations as

--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -81,20 +81,23 @@ function long_usage () return usage end
 function traffic (pciaddr, confpath, sockpath)
    engine.log = true
    local mtime = 0
-   if C.stat_mtime(confpath) == 0 then
-      print(("WARNING: File '%s' does not exist."):format(confpath))
+   local needs_reconfigure = true
+   function check_for_reconfigure()
+      needs_reconfigure = C.stat_mtime(confpath) ~= mtime
    end
    timer.activate(ingress_drop_monitor.new({action='warn'}):timer())
+   timer.activate(timer.new("reconf", check_for_reconfigure, 1e9, 'repeating'))
+   -- Flush logs every second.
+   timer.activate(timer.new("flush", io.flush, 1e9, 'repeating'))
    while true do
-      local mtime2 = C.stat_mtime(confpath)
-      if mtime2 ~= mtime then
-         print("Loading " .. confpath)
-         engine.configure(nfvconfig.load(confpath, pciaddr, sockpath))
-         mtime = mtime2
+      needs_reconfigure = false
+      print("Loading " .. confpath)
+      mtime = C.stat_mtime(confpath)
+      if mtime == 0 then
+         print(("WARNING: File '%s' does not exist."):format(confpath))
       end
-      engine.main({duration=1, no_report=true})
-      -- Flush buffered log messages every 1s
-      io.flush()
+      engine.configure(nfvconfig.load(confpath, pciaddr, sockpath))
+      engine.main({done=function() return needs_reconfigure end})
    end
 end
 

--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -9,6 +9,7 @@ local ffi = require("ffi")
 local C = ffi.C
 local timer = require("core.timer")
 local pci = require("lib.hardware.pci")
+local ingress_drop_monitor = require("lib.timers.ingress_drop_monitor")
 local counter = require("core.counter")
 
 local long_opts = {
@@ -83,6 +84,7 @@ function traffic (pciaddr, confpath, sockpath)
    if C.stat_mtime(confpath) == 0 then
       print(("WARNING: File '%s' does not exist."):format(confpath))
    end
+   timer.activate(ingress_drop_monitor.new({action='warn'}):timer())
    while true do
       local mtime2 = C.stat_mtime(confpath)
       if mtime2 ~= mtime then


### PR DESCRIPTION
lwAFTR v2.10 log:

``` bash
$ git log --no-merges --pretty=format:"%h %s" v2.9..v2.1
```

_4b5cf2e_ Add v2.10 changelog.
_a9c5576_ snabbnfv traffic: Only re-start engine when configuration changes
_c317ddc_ Remove all backpressure
_9f6e7e9_ Enable warning ingress drop monitor on the NFV
_2cfbecc_ Refactor ingress drop monitor to have configurable actions
_2ab306b_ Make ingress drop monitor a timer and enable it only in lwAFTR

Only 2ab306b was present in lwaftr branch, all the other commits need to be backported. This PR includes #371, #372 and #373.
