### PR TITLE
Fix intel1g selftest

### DIFF
--- a/src/apps/intel/intel1g.lua
+++ b/src/apps/intel/intel1g.lua
@@ -633,7 +633,7 @@ end  -- function Intel1g:new()
 function selftest ()
    print("selftest: Intel1g")
    local pciaddr = os.getenv("SNABB_PCI_INTEL1G0")
-   if not pciaddr then
+   if not pciaddr or pciaddr == "" then
       print("SNABB_PCI_INTEL1G0 not set")
       os.exit(engine.test_skipped_code)
    end

--- a/src/apps/intel/intel1g.lua
+++ b/src/apps/intel/intel1g.lua
@@ -632,8 +632,8 @@ end  -- function Intel1g:new()
 
 function selftest ()
    print("selftest: Intel1g")
-   local pciaddr = os.getenv("SNABB_PCI_INTEL1G0")
-   if not pciaddr or pciaddr == "" then
+   local pciaddr = lib.getenv("SNABB_PCI_INTEL1G0")
+   if not pciaddr then
       print("SNABB_PCI_INTEL1G0 not set")
       os.exit(engine.test_skipped_code)
    end


### PR DESCRIPTION
Skip selftest if SNABB_PCI_INTEL1G0 is empty.

Snabb-bot CI tests are failing because the CI process is attempting to run the intel1g selftest when it should skip it. Details here: https://github.com/snabbco/snabb/pull/975
