### PR TITLE
Fix test ipv6 packet not found lwaftr

### DIFF
--- a/src/apps/lwaftr/conf_parser.lua
+++ b/src/apps/lwaftr/conf_parser.lua
@@ -11,7 +11,9 @@ Parser = {}
 function Parser.new(file)
    local name = file.name
    if type(file) == 'string' then
-      name, file = file, io.open(file)
+      name = file
+      file, err = io.open(file)
+      if not file then error(err) end
    end
    local ret = { column=0, line=1, name=name }
    function ret.read_char() return file:read(1) end

--- a/src/program/lwaftr/tests/data/counters/drop-misplaced-not-ipv4.lua
+++ b/src/program/lwaftr/tests/data/counters/drop-misplaced-not-ipv4.lua
@@ -1,7 +1,0 @@
-return {
-   ["drop-misplaced-not-ipv4-bytes"] = 106,
-   ["drop-misplaced-not-ipv4-packets"] = 1,
-
-   ["drop-all-ipv4-iface-bytes"] = 106,
-   ["drop-all-ipv4-iface-packets"] = 1,
-}

--- a/src/program/lwaftr/tests/data/counters/drop-no-source-softwire-ipv6.lua
+++ b/src/program/lwaftr/tests/data/counters/drop-no-source-softwire-ipv6.lua
@@ -1,0 +1,9 @@
+return {
+   ["drop-all-ipv6-iface-bytes"] = 106,
+   ["drop-all-ipv6-iface-packets"] = 1,
+   ["drop-no-source-softwire-ipv6-bytes"] = 106,
+   ["drop-no-source-softwire-ipv6-packets"] = 1,
+   ["drop-out-by-policy-icmpv6-packets"] = 1,
+   ["in-ipv6-bytes"] = 106,
+   ["in-ipv6-packets"] = 1,
+}

--- a/src/program/lwaftr/tests/data/counters/non-ipv4-traffic-to-ipv4-interface.lua
+++ b/src/program/lwaftr/tests/data/counters/non-ipv4-traffic-to-ipv4-interface.lua
@@ -1,0 +1,6 @@
+return {
+   ["drop-misplaced-not-ipv6-bytes"] = 66,
+   ["drop-all-ipv6-iface-packets"] = 1,
+   ["drop-all-ipv6-iface-bytes"] = 66,
+   ["drop-misplaced-not-ipv6-packets"] = 1,
+}

--- a/src/program/lwaftr/tests/data/counters/non-ipv6-traffic-to-ipv6-interface.lua
+++ b/src/program/lwaftr/tests/data/counters/non-ipv6-traffic-to-ipv6-interface.lua
@@ -1,0 +1,6 @@
+return {
+   ["drop-all-ipv4-iface-bytes"] = 106,
+   ["drop-all-ipv4-iface-packets"] = 1,
+   ["drop-misplaced-not-ipv4-bytes"] = 106,
+   ["drop-misplaced-not-ipv4-packets"] = 1,
+}

--- a/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
@@ -289,6 +289,12 @@ snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
    ${EMPTY} ${TEST_DATA}/recap-customBR-IPs-ipv6.pcap \
    ${COUNTERS}/from-to-b4-ipv6-hairpin.lua
 
+echo "Testing sending non-IPv6 traffic to the IPv6 interface."
+snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
+   ${TEST_DATA}/tcp-afteraftr-ipv6.pcap ${EMPTY} \
+   ${EMPTY} ${EMPTY} \
+   ${COUNTERS}/empty.lua
+
 # Test UDP packets
 
 echo "Testing: from-internet bound IPv4 UDP packet"

--- a/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
@@ -295,6 +295,12 @@ snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
    ${EMPTY} ${EMPTY} \
    ${COUNTERS}/empty.lua
 
+echo "Testing: sending non-IPv4 traffic to the IPv4 interface"
+snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
+   ${EMPTY} ${TEST_DATA}/tcp-frominet-bound.pcap \
+   ${EMPTY} ${EMPTY} \
+   ${COUNTERS}/empty.lua
+
 # Test UDP packets
 
 echo "Testing: from-internet bound IPv4 UDP packet"

--- a/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
@@ -25,21 +25,21 @@ function scmp {
 }
 
 function snabb_run_and_cmp {
-   rm -f ${TEST_OUT}/endoutv4.pcap ${TEST_OUT}/endoutv6.pcap
    if [ -z $6 ]; then
       echo "not enough arguments to snabb_run_and_cmp"
       exit 1
    fi
+   conf=$1; v4_in=$2; v6_in=$3; v4_out=$4; v6_out=$5; counters_path=$6;
+   endoutv4="${TEST_OUT}/endoutv4.pcap"; endoutv6="${TEST_OUT}/endoutv6.pcap";
+   rm -f $endoutv4 $endoutv6
    ${SNABB_LWAFTR} check \
-      $1 $2 $3 \
-      ${TEST_OUT}/endoutv4.pcap ${TEST_OUT}/endoutv6.pcap $6 || quit_with_msg \
-         "Failure: ${SNABB_LWAFTR} check \
-         $1 $2 $3 \
-         ${TEST_OUT}/endoutv4.pcap ${TEST_OUT}/endoutv6.pcap $6"
-   scmp $4 ${TEST_OUT}/endoutv4.pcap \
-      "Failure: ${SNABB_LWAFTR} check $1 $2 $3 $4 $5 $6"
-   scmp $5 ${TEST_OUT}/endoutv6.pcap \
-      "Failure: ${SNABB_LWAFTR} check $1 $2 $3 $4 $5 $6"
+      $conf $v4_in $v6_in \
+      $endoutv4 $endoutv6 $counters_path || quit_with_msg \
+         "Failure: ${SNABB_LWAFTR} check $*"
+   scmp $v4_out $endoutv4 \
+      "Failure: ${SNABB_LWAFTR} check $*"
+   scmp $v6_out $endoutv6 \
+      "Failure: ${SNABB_LWAFTR} check $*"
    echo "Test passed"
 }
 

--- a/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
@@ -182,9 +182,9 @@ snabb_run_and_cmp ${TEST_CONF}/icmp_on_fail_vlan.conf \
 
 echo "Testing: from-to-b4 IPv6 packet NOT found in the binding table, no ICMP."
 snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \
-   ${TEST_DATA}/tcp-afteraftr-ipv6.pcap ${EMPTY} \
+   ${EMPTY} ${TEST_DATA}/tcp-afteraftr-ipv6.pcap \
    ${EMPTY} ${EMPTY} \
-   ${COUNTERS}/empty.lua
+   ${COUNTERS}/drop-no-source-softwire-ipv6.lua
 
 echo "Testing: from-b4 to-internet IPv6 packet found in the binding table."
 snabb_run_and_cmp ${TEST_CONF}/no_icmp_vlan.conf \

--- a/src/program/lwaftr/tests/end-to-end/end-to-end.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end.sh
@@ -318,6 +318,12 @@ snabb_run_and_cmp ${TEST_BASE}/no_icmp.conf \
    ${EMPTY} ${EMPTY} \
    ${COUNTERS}/non-ipv6-traffic-to-ipv6-interface.lua
 
+echo "Testing: sending non-IPv4 traffic to the IPv4 interface"
+snabb_run_and_cmp ${TEST_BASE}/no_icmp.conf \
+   ${EMPTY} ${TEST_BASE}/tcp-frominet-bound.pcap \
+   ${EMPTY} ${EMPTY} \
+   ${COUNTERS}/non-ipv4-traffic-to-ipv4-interface.lua
+
 # Test UDP packets
 
 echo "Testing: from-internet bound IPv4 UDP packet"

--- a/src/program/lwaftr/tests/end-to-end/end-to-end.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end.sh
@@ -193,9 +193,9 @@ snabb_run_and_cmp ${TEST_BASE}/icmp_on_fail.conf \
 
 echo "Testing: from-to-b4 IPv6 packet NOT found in the binding table, no ICMP."
 snabb_run_and_cmp ${TEST_BASE}/no_icmp.conf \
-   ${TEST_BASE}/tcp-afteraftr-ipv6.pcap ${EMPTY} \
+   ${EMPTY} ${TEST_BASE}/tcp-afteraftr-ipv6.pcap \
    ${EMPTY} ${EMPTY} \
-   ${COUNTERS}/drop-misplaced-not-ipv4.lua
+   ${COUNTERS}/drop-no-source-softwire-ipv6.lua
 
 echo "Testing: from-b4 to-internet IPv6 packet found in the binding table."
 snabb_run_and_cmp ${TEST_BASE}/no_icmp.conf \

--- a/src/program/lwaftr/tests/end-to-end/end-to-end.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end.sh
@@ -312,6 +312,12 @@ snabb_run_and_cmp ${TEST_BASE}/no_icmp.conf \
    ${EMPTY} ${TEST_BASE}/recap-customBR-IPs-ipv6.pcap \
    ${COUNTERS}/from-to-b4-ipv6-hairpin.lua
 
+echo "Testing: sending non-IPv6 traffic to the IPv6 interface"
+snabb_run_and_cmp ${TEST_BASE}/no_icmp.conf \
+   ${TEST_BASE}/tcp-afteraftr-ipv6.pcap ${EMPTY} \
+   ${EMPTY} ${EMPTY} \
+   ${COUNTERS}/non-ipv6-traffic-to-ipv6-interface.lua
+
 # Test UDP packets
 
 echo "Testing: from-internet bound IPv4 UDP packet"

--- a/src/program/lwaftr/tests/end-to-end/end-to-end.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end.sh
@@ -24,21 +24,21 @@ function scmp {
 }
 
 function snabb_run_and_cmp {
-   rm -f ${TEST_OUT}/endoutv4.pcap ${TEST_OUT}/endoutv6.pcap
    if [ -z $6 ]; then
       echo "not enough arguments to snabb_run_and_cmp"
       exit 1
    fi
-   (${SNABB_LWAFTR} check \
-      $1 $2 $3 \
-      ${TEST_OUT}/endoutv4.pcap ${TEST_OUT}/endoutv6.pcap $6) || quit_with_msg \
-         "Failure: ${SNABB_LWAFTR} check \
-         $1 $2 $3 \
-         ${TEST_OUT}/endoutv4.pcap ${TEST_OUT}/endoutv6.pcap $6"
-   scmp $4 ${TEST_OUT}/endoutv4.pcap \
-      "Failure: ${SNABB_LWAFTR} check $1 $2 $3 $4 $5 $6"
-   scmp $5 ${TEST_OUT}/endoutv6.pcap \
-      "Failure: ${SNABB_LWAFTR} check $1 $2 $3 $4 $5 $6"
+   conf=$1; v4_in=$2; v6_in=$3; v4_out=$4; v6_out=$5; counters_path=$6;
+   endoutv4="${TEST_OUT}/endoutv4.pcap"; endoutv6="${TEST_OUT}/endoutv6.pcap";
+   rm -f $endoutv4 $endoutv6
+   ${SNABB_LWAFTR} check \
+      $conf $v4_in $v6_in \
+      $endoutv4 $endoutv6 $counters_path || quit_with_msg \
+         "Failure: ${SNABB_LWAFTR} check $*"
+   scmp $v4_out $endoutv4 \
+      "Failure: ${SNABB_LWAFTR} check $*"
+   scmp $v6_out $endoutv6 \
+      "Failure: ${SNABB_LWAFTR} check $*"
    echo "Test passed"
 }
 


### PR DESCRIPTION
Supersedes #380. 

The reason for creating a new PR is that github doesn't allow to change the target branch of a PR and #380 had "counters-lwaftr" as target, because it was dependent on it. Now that "counters-lwaftr" is merged the target of #380 should change to "lwaftr", but that's not possible without creating a new PR :/
