### PR TITLE
Remove 'ingress_drop_monitor' dead code

### DIFF
--- a/src/program/lwaftr/loadtest/loadtest.lua
+++ b/src/program/lwaftr/loadtest/loadtest.lua
@@ -246,7 +246,7 @@ function run(args)
 
       local function done() return is_done end
       head:resolve()
-      engine.main({done=done, ingress_drop_monitor=false})
+      engine.main({done=done})
    end
 
    engine.busywait = true


### PR DESCRIPTION
This PR removes dead code related with 'ingress_drop_monitor':
- `src/core/app.lua`: Remove duplicated code. Current implementation of 'ingress_drop_monitor' is at `lib/timers/ingress_drop_monitor.lua`.
- `src/program/lwaftr/loadtest/loadtest.lua`: Remove obsolete flag.

This code should have been removed when merging `lwaftr_starfruit` onto `lwaftr` and latest `master` onto `lwaftr`.

Some background about the ingress_drop_monitor feature. Initially it was implemented in `core/app.lua` and merged in master.  The feature was activated all the time by default, unless a flag was passed to the engine. 

When benchmarking the lwAFTR virtualized, we realized jit flushes triggered by the monitor had a bad impact when running SnabbNFV.  Then we decided to move this feature out of `core` and put it in a timer.  Applications that want to monitorize ingress packet drops import this timer and activate it. The timer can perform two actions (_flush_ or _warn_) when the threshold is reached.  Action _flush_  actually runs `jit.flush()`. OTOH, action _warn_ simply informs the threshold has been reached but it doesn't run `jit.flush()`.
