### PR TITLE
'lwaftr query' improvements

### DIFF
--- a/src/program/lwaftr/query/README
+++ b/src/program/lwaftr/query/README
@@ -1,5 +1,5 @@
 Usage:
-  query [OPTIONS] [<pid>]
+  query [OPTIONS] [<pid>] [<counter-name>]
 
   -h, --help
                              Print usage information.
@@ -7,6 +7,9 @@ Usage:
 Display current statistics from lwAftr counters for a running Snabb instance
 with <pid>. If <pid> is not supplied and there is only one Snabb instance,
 "query" will connect to that instance.
+
+If <counter-name> is set, only counters partially matching <counter-name> are
+listed.
 
 The values for the counters defined in <src/apps/lwaftr/lwaftr.lua> will be
 displayed, but only the ones that are not zero.

--- a/src/program/lwaftr/query/README
+++ b/src/program/lwaftr/query/README
@@ -1,8 +1,10 @@
 Usage:
   query [OPTIONS] [<pid>] [<counter-name>]
 
-  -h, --help
-                             Print usage information.
+Options:
+
+  -h, --help                    Print usage information.
+  -l, --list-all                List all available counter names.
 
 Display current statistics from lwAftr counters for a running Snabb instance
 with <pid>. If <pid> is not supplied and there is only one Snabb instance,

--- a/src/program/lwaftr/query/query.lua
+++ b/src/program/lwaftr/query/query.lua
@@ -30,7 +30,9 @@ function print_counters (tree, filter)
    print("lwAFTR operational counters (non-zero)")
    -- Open, read and print whatever counters are in that directory.
    local counters_path = "/" .. tree .. "/" .. counters_rel_dir
-   for _, name in ipairs(shm.children(counters_path)) do
+   local counters = shm.children(counters_path)
+   table.sort(counters)
+   for _, name in ipairs(counters) do
       cnt_path = counters_path .. name
       cnt = counter.open(cnt_path, 'readonly')
       value = tonumber(counter.read(cnt))

--- a/src/program/lwaftr/query/query.lua
+++ b/src/program/lwaftr/query/query.lua
@@ -36,7 +36,7 @@ function print_counters (tree)
       value = tonumber(counter.read(cnt))
       if value ~= 0 then
          name = name:gsub(".counter$", "")
-         print(name..": "..value)
+         print(name..": "..lib.comma_value(value))
       end
    end
 end

--- a/src/program/lwaftr/query/query.lua
+++ b/src/program/lwaftr/query/query.lua
@@ -17,10 +17,22 @@ function show_usage (code)
    main.exit(code)
 end
 
+local function sort (t)
+   table.sort(t)
+   return t
+end
+
 function parse_args (raw_args)
    local handlers = {}
    function handlers.h() show_usage(0) end
-   local args = lib.dogetopt(raw_args, handlers, "h", { help="h" })
+   function handlers.l ()
+      for _, name in ipairs(sort(lwaftr.counter_names)) do
+         print(name)
+      end
+      main.exit(0)
+   end
+   local args = lib.dogetopt(raw_args, handlers, "hl",
+                             { help="h", ["list-all"]="l" })
    if #args > 2 then show_usage(1) end
    return args
 end
@@ -42,11 +54,6 @@ local function read_counters (tree, filter)
       end
    end
    return ret, max_width
-end
-
-local function sort (t)
-   table.sort(t)
-   return t
 end
 
 local function keys (t)

--- a/src/program/lwaftr/query/query.lua
+++ b/src/program/lwaftr/query/query.lua
@@ -25,26 +25,55 @@ function parse_args (raw_args)
    return args
 end
 
-function print_counters (tree, filter)
+local function read_counters (tree, filter)
+   local ret = {}
    local cnt, cnt_path, value
-   print("lwAFTR operational counters (non-zero)")
-   -- Open, read and print whatever counters are in that directory.
+   local max_width = 0
    local counters_path = "/" .. tree .. "/" .. counters_rel_dir
    local counters = shm.children(counters_path)
-   table.sort(counters)
    for _, name in ipairs(counters) do
       cnt_path = counters_path .. name
       cnt = counter.open(cnt_path, 'readonly')
       value = tonumber(counter.read(cnt))
       if value ~= 0 then
          name = name:gsub(".counter$", "")
-         if filter then
-            if name:match(filter) then
-               print(name..": "..lib.comma_value(value))
-            end
-         else
-            print(name..": "..lib.comma_value(value))
-         end
+         if #name > max_width then max_width = #name end
+         ret[name] = value
+      end
+   end
+   return ret, max_width
+end
+
+local function sort (t)
+   table.sort(t)
+   return t
+end
+
+local function keys (t)
+   local ret = {}
+   for key, _ in pairs(t) do
+      table.insert(ret, key)
+   end
+   return ret
+end
+
+local function skip_counter (name, filter)
+   return filter and not name:match(filter)
+end
+
+local function print_counter (name, value, max_width)
+   local nspaces = max_width - #name
+   print(("%s: %s%s"):format(name, (" "):rep(nspaces), lib.comma_value(value)))
+end
+
+function print_counters (tree, filter)
+   print("lwAFTR operational counters (non-zero)")
+   -- Open, read and print whatever counters are in that directory.
+   local counters, max_width = read_counters(tree, filter)
+   for _, name in ipairs(sort(keys(counters))) do
+      if not skip_counter(name, filter) then
+         local value = counters[name]
+         print_counter(name, value, max_width)
       end
    end
 end


### PR DESCRIPTION
Implements several improvements in "lwaftr query" subcommand:
- Format integer values
- Filter out counters to print
- Sort counters by name
- Align counter values
- Add an option to print out all available counter names

Example:
- Print incoming packets:

```
$ sudo ./snabb lwaftr query 27723 in
lwAFTR operational counters (non-zero)
in-ipv4-bytes:    5,986,192,850
in-ipv4-packets:  10,883,987
in-ipv6-bytes:    5,997,666,950
in-ipv6-packets:  10,904,849
```
- Print available counters related with "softwires":

```
$ sudo ./snabb lwaftr query --list-all | grep softwire
drop-no-dest-softwire-ipv4-bytes
drop-no-dest-softwire-ipv4-packets
drop-no-source-softwire-ipv6-bytes
drop-no-source-softwire-ipv6-packets
```

Depends on #389 
