### PR TITLE
lwAFTR query: Fetch PID by lwAFTR ID

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -469,6 +469,10 @@ If *readonly* is non-nil the shared object is mapped in read-only mode.
 *Readonly* defaults to nil. Fails if the shared object does not already exist.
 Returns a pointer to the mapped object.
 
+— Function **shm.exists** *name*
+
+Checks whether shared object *name* exists.
+
 — Function **shm.unmap** *pointer*
 
 Deletes the memory mapping for *pointer*.

--- a/src/apps/lwaftr/lwtypes.lua
+++ b/src/apps/lwaftr/lwtypes.lua
@@ -65,3 +65,9 @@ struct {
 ]]
 udp_header_ptr_type = ffi.typeof("$*", udp_header_t)
 udp_header_size = ffi.sizeof(udp_header_t)
+
+lwaftr_id_type = ffi.typeof[[
+struct {
+  char value[256];
+}
+]]

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -55,6 +55,12 @@ function open (name, type, readonly)
    return map(name, type, readonly, false)
 end
 
+function exists (name)
+   local path = resolve(name)
+   local fd = S.open(root..'/'..path, "rdonly")
+   return fd and fd:close()
+end
+
 function resolve (name)
    local q, p = name:match("^(/*)(.*)") -- split qualifier (/)
    local result = p
@@ -190,6 +196,14 @@ function selftest ()
    assert(unlink(name))
    unmap(p1)
    unmap(p2)
+
+   print("checking exists..")
+   assert(not exists(name))
+   local p1 = create(name, "struct { int x, y, z; }")
+   assert(exists(name))
+   assert(unlink(name))
+   unmap(p1)
+   assert(not exists(name))
 
    -- Test that we can open and cleanup many objects
    print("checking many objects..")

--- a/src/program/lwaftr/query/README
+++ b/src/program/lwaftr/query/README
@@ -1,14 +1,20 @@
 Usage:
-  query [OPTIONS] [<pid>] [<counter-name>]
+  query [OPTIONS] [<id>] [<counter-name>]
 
 Options:
 
   -h, --help                    Print usage information.
   -l, --list-all                List all available counter names.
 
-Display current statistics from lwAftr counters for a running Snabb instance
-with <pid>. If <pid> is not supplied and there is only one Snabb instance,
-"query" will connect to that instance.
+Display current statistics from lwAFTR counters for a running Snabb instance
+with <id>.  <id> can be either a PID or a string ID:
+
+   * If it is a PID, <id> should exists at /var/run/snabb/<id>.
+   * If it is a string ID, <id> should match the value defined
+     in /var/run/snabb/*/nic/id.
+
+If <pid> is not supplied and there is only one Snabb instance, "query" will
+connect to that instance.
 
 If <counter-name> is set, only counters partially matching <counter-name> are
 listed.

--- a/src/program/lwaftr/query/query.lua
+++ b/src/program/lwaftr/query/query.lua
@@ -22,6 +22,10 @@ local function sort (t)
    return t
 end
 
+local function is_counter_name (name)
+   return lwaftr.counter_names[name] ~= nil
+end
+
 function parse_args (raw_args)
    local handlers = {}
    function handlers.h() show_usage(0) end
@@ -34,7 +38,18 @@ function parse_args (raw_args)
    local args = lib.dogetopt(raw_args, handlers, "hl",
                              { help="h", ["list-all"]="l" })
    if #args > 2 then show_usage(1) end
-   return args
+   if #args == 2 then
+      return args[1], args[2]
+   end
+   if #args == 1 then
+      local arg = args[1]
+      if is_counter_name(arg) then
+         return nil, arg
+      else
+         return arg, nil
+      end
+   end
+   return nil, nil
 end
 
 local function read_counters (tree, filter)
@@ -86,19 +101,7 @@ function print_counters (tree, filter)
 end
 
 function run (raw_args)
-   local args = parse_args(raw_args) 
-
-   local target_pid, counter_name
-   if #args == 2 then
-      target_pid, counter_name = args[1], args[2]
-   elseif #args == 1 then
-      local maybe_pid = tonumber(args[1])
-      if maybe_pid then
-         target_pid = args[1]
-      else
-         counter_name = args[1]
-      end
-   end
+   local target_pid, counter_name = parse_args(raw_args)
 
    local instance_tree = select_snabb_instance(target_pid)
    print_counters(instance_tree, counter_name)

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -39,14 +39,20 @@ function select_snabb_instance (pid)
          if instance == pid then return pid end
       end
       print("No such Snabb instance: "..pid)
-   elseif #instances == 2 then
-      -- Two means one is us, so we pick the other.
-      local own_pid = tostring(S.getpid())
-      if instances[1] == own_pid then return instances[2]
-      else                            return instances[1] end
    elseif #instances == 1 then print("No Snabb instance found.")
-   else print("Multple Snabb instances found. Select one.") end
-   os.exit(1)
+   else
+      local own_pid = tostring(S.getpid())
+      if #instances == 2 then
+         -- Two means one is us, so we pick the other.
+         return instances[1] == own_pid and instances[2] or instances[1]
+      else
+         print("Multiple Snabb instances found. Select one:")
+         for _, instance in ipairs(instances) do
+            if instance ~= own_pid then print(instance) end
+         end
+      end
+   end
+   main.exit(1)
 end
 
 function list_shm (pid, object)


### PR DESCRIPTION
When there are many lwAFTR instances running in the same machine, it's hard to know what's the right PID for a lwAFTR process. It would be more convenient to be able to identify a lwAFTR process per ID.

When running Snabbvmx is possible to specify an ID:

``` bash
$ sudo ./snabb snabbvmx lwaftr -v --id A --conf snabbvmx.cfg --pci 81:00.0
```

Then doing `ps aux | grep <ID>` is possible to fetch the corresponding PID for an identifier. Still not very convenient because usually per Snabb program there are three processes with the same line arguments:

```
root     10966  0.0  0.0 133856  2908 pts/4    S+   10:45   0:00
sudo ./snabb snabbvmx lwaftr -v --id A --conf snabbvmx.cfg --pci 81:00.0
root     10967  0.0  0.0  19412  4168 pts/4    S+   10:45   0:00 ./snabb
snabbvmx lwaftr -v --id A --conf snabbvmx.cfg --pci 81:00.0
root     10968  1.0  0.5 836152 343092 pts/4   S+   10:45   0:00 ./snabb
snabbvmx lwaftr -v --id A --conf snabbvmx.cfg --pci 81:00.0
```

After discussing it with Marcel we agreed that a more convenient solution would be to store the lwAFTR ID value in shared memory. When lwAFTR query uses an ID, other than a PID, it searches in the available Snabb instances the one which has "nic/id" defined and compares its value to ID. If both matched it returns PID and runs as normal. Example:

```
$ sudo ./snabb lwaftr query A
lwAFTR operational counters (non-zero)
in-ipv4-bytes:    2,611,588,458,050
in-ipv4-packets:  4,748,342,651
out-ipv6-bytes:   2,801,522,164,090
out-ipv6-packets: 4,748,342,651
```

What happens with normal lwAFTR (not snabbvmx)? If we want "lwaftr query" to use a lwAFTR ID, we should do something similar to what snabbvmx does and add support for ID (via line arguments or lwAFTR.conf file and add store its value in shared memory). However, as we have proposed to add support for identifying Snabb processes per name [1], as part of our "snabb config" proposal, I wouldn't do anything for now and wait until identification of Snabb processes per name is implemented.

[1] https://github.com/snabbco/snabb/issues/987
