### PR TITLE
Remove obsolete l2_size approach

### DIFF
--- a/src/apps/lwaftr/icmp.lua
+++ b/src/apps/lwaftr/icmp.lua
@@ -31,17 +31,18 @@ local o_icmpv4_msg_code_sans_ihl = constants.ethernet_header_size + constants.o_
 local o_ipv6_next_header = constants.ethernet_header_size + constants.o_ipv6_next_header
 local o_icmpv6_msg_type = constants.ethernet_header_size + constants.ipv6_fixed_header_size + constants.o_icmpv6_msg_type
 local o_icmpv6_msg_code = constants.ethernet_header_size + constants.ipv6_fixed_header_size + constants.o_icmpv6_msg_code
+local ehs = constants.ethernet_header_size
 
-local function calculate_payload_size(dst_pkt, initial_pkt, l2_size, max_size, config)
-   local original_bytes_to_skip = l2_size
+local function calculate_payload_size(dst_pkt, initial_pkt, max_size, config)
+   local original_bytes_to_skip = ehs
    if config.extra_payload_offset then
       original_bytes_to_skip = original_bytes_to_skip + config.extra_payload_offset
    end
    local payload_size = initial_pkt.length - original_bytes_to_skip
    local non_payload_bytes = dst_pkt.length + constants.icmp_base_size
    local full_pkt_size = payload_size + non_payload_bytes
-   if full_pkt_size > max_size + l2_size then
-      full_pkt_size = max_size + l2_size
+   if full_pkt_size > max_size + ehs then
+      full_pkt_size = max_size + ehs
       payload_size = full_pkt_size - non_payload_bytes
    end
    return payload_size, original_bytes_to_skip, non_payload_bytes
@@ -51,9 +52,9 @@ end
 -- Config must contain code and type
 -- Config may contain a 'next_hop_mtu' setting.
 
-local function write_icmp(dst_pkt, initial_pkt, l2_size, max_size, base_checksum, config)
+local function write_icmp(dst_pkt, initial_pkt, max_size, base_checksum, config)
    local payload_size, original_bytes_to_skip, non_payload_bytes =
-      calculate_payload_size(dst_pkt, initial_pkt, l2_size, max_size, config)
+      calculate_payload_size(dst_pkt, initial_pkt, max_size, config)
    local off = dst_pkt.length
    dst_pkt.data[off] = config.type
    dst_pkt.data[off + 1] = config.code
@@ -78,7 +79,7 @@ local function to_datagram(pkt)
 end
 
 -- initial_pkt is the one to embed (a subset of) in the ICMP payload
-function new_icmpv4_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, l2_size, config)
+function new_icmpv4_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, config)
    local new_pkt = packet.allocate()
    local dgram = to_datagram(new_pkt)
    local ipv4_header = ipv4:new({ttl = constants.default_ttl,
@@ -86,20 +87,20 @@ function new_icmpv4_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, l2_siz
                                  src = from_ip, dst = to_ip})
    dgram:push(ipv4_header)
    ipv4_header:free()
-   packet.shiftright(new_pkt, l2_size)
+   packet.shiftright(new_pkt, ehs)
    write_eth_header(new_pkt.data, from_eth, to_eth, constants.n_ethertype_ipv4, config.vlan_tag)
 
    -- Generate RFC 1812 ICMPv4 packets, which carry as much payload as they can,
    -- rather than RFC 792 packets, which only carry the original IPv4 header + 8 octets
-   write_icmp(new_pkt, initial_pkt, l2_size, constants.max_icmpv4_packet_size, 0, config)
+   write_icmp(new_pkt, initial_pkt, constants.max_icmpv4_packet_size, 0, config)
 
    -- Fix up the IPv4 total length and checksum
-   local new_ipv4_len = new_pkt.length - l2_size
-   local ip_tl_p = new_pkt.data + l2_size + constants.o_ipv4_total_length
+   local new_ipv4_len = new_pkt.length - ehs
+   local ip_tl_p = new_pkt.data + ehs + constants.o_ipv4_total_length
    wr16(ip_tl_p, ntohs(new_ipv4_len))
-   local ip_checksum_p = new_pkt.data + l2_size + constants.o_ipv4_checksum
+   local ip_checksum_p = new_pkt.data + ehs + constants.o_ipv4_checksum
    wr16(ip_checksum_p,  0) -- zero out the checksum before recomputing
-   local csum = checksum.ipsum(new_pkt.data + l2_size, new_ipv4_len, 0)
+   local csum = checksum.ipsum(new_pkt.data + ehs, new_ipv4_len, 0)
    wr16(ip_checksum_p, htons(csum))
 
    return new_pkt
@@ -119,25 +120,25 @@ function is_icmpv4_message(pkt, msg_type, msg_code)
    end
 end
 
-function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, l2_size, config)
+function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, config)
    local new_pkt = packet.allocate()
    local dgram = to_datagram(new_pkt)
    local ipv6_header = ipv6:new({hop_limit = constants.default_ttl,
                                  next_header = constants.proto_icmpv6,
                                  src = from_ip, dst = to_ip})
    dgram:push(ipv6_header)
-   packet.shiftright(new_pkt, l2_size)
-   write_eth_header(new_pkt.data, from_eth, to_eth, constants.n_ethertype_ipv6, config.vlan_tag)
+   packet.shiftright(new_pkt, ehs)
+   write_eth_header(new_pkt.data, from_eth, to_eth, constants.n_ethertype_ipv6)
 
    local max_size = constants.max_icmpv6_packet_size
-   local ph_len = calculate_payload_size(new_pkt, initial_pkt, l2_size, max_size, config) + constants.icmp_base_size
+   local ph_len = calculate_payload_size(new_pkt, initial_pkt, max_size, config) + constants.icmp_base_size
    local ph = ipv6_header:pseudo_header(ph_len, constants.proto_icmpv6)
    local ph_csum = checksum.ipsum(ffi.cast("uint8_t*", ph), ffi.sizeof(ph), 0)
    local ph_csum = band(bnot(ph_csum), 0xffff)
-   write_icmp(new_pkt, initial_pkt, l2_size, max_size, ph_csum, config)
+   write_icmp(new_pkt, initial_pkt, max_size, ph_csum, config)
 
-   local new_ipv6_len = new_pkt.length - (constants.ipv6_fixed_header_size + l2_size)
-   local ip_pl_p = new_pkt.data + l2_size + constants.o_ipv6_payload_len
+   local new_ipv6_len = new_pkt.length - (constants.ipv6_fixed_header_size + ehs)
+   local ip_pl_p = new_pkt.data + ehs + constants.o_ipv6_payload_len
    wr16(ip_pl_p, ntohs(new_ipv6_len))
 
    ipv6_header:free()

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -507,7 +507,7 @@ local function drop_ipv4_packet_to_unreachable_host(lwstate, pkt, pkt_src_link)
    }
    local icmp_dis = icmp.new_icmpv4_packet(
       lwstate.aftr_mac_inet_side, lwstate.inet_mac, lwstate.aftr_ipv4_ip,
-      to_ip, pkt, ethernet_header_size, icmp_config)
+      to_ip, pkt, icmp_config)
 
    drop_ipv4(lwstate, pkt, pkt_src_link)
    return transmit_icmpv4_reply(lwstate, icmp_dis, pkt)
@@ -530,7 +530,7 @@ local function drop_ipv6_packet_from_bad_softwire(lwstate, pkt)
                        }
    local b4fail_icmp = icmp.new_icmpv6_packet(
       lwstate.aftr_mac_b4_side, lwstate.next_hop6_mac, lwstate.aftr_ipv6_ip,
-      ipv6_src_addr, pkt, ethernet_header_size, icmp_config)
+      ipv6_src_addr, pkt, icmp_config)
    drop(pkt)
    transmit_icmpv6_reply(lwstate.o6, b4fail_icmp)
 end
@@ -560,8 +560,7 @@ local function cannot_fragment_df_packet_error(lwstate, pkt)
       next_hop_mtu = lwstate.ipv6_mtu - constants.ipv6_fixed_header_size,
    }
    return icmp.new_icmpv4_packet(lwstate.aftr_mac_inet_side, lwstate.inet_mac,
-                                 lwstate.aftr_ipv4_ip, dst_ip, pkt,
-                                 ethernet_header_size, icmp_config)
+                                 lwstate.aftr_ipv4_ip, dst_ip, pkt, icmp_config)
 end
 
 local function encapsulate_and_transmit(lwstate, pkt, ipv6_dst, ipv6_src, pkt_src_link)
@@ -582,7 +581,7 @@ local function encapsulate_and_transmit(lwstate, pkt, ipv6_dst, ipv6_src, pkt_sr
                            }
       local reply = icmp.new_icmpv4_packet(
          lwstate.aftr_mac_inet_side, lwstate.inet_mac, lwstate.aftr_ipv4_ip,
-         dst_ip, pkt, ethernet_header_size, icmp_config)
+         dst_ip, pkt, icmp_config)
 
       drop_ipv4(lwstate, pkt, pkt_src_link)
       return transmit_icmpv4_reply(lwstate, reply, pkt)
@@ -777,7 +776,7 @@ local function tunnel_unreachable(lwstate, pkt, code, next_hop_mtu)
    local dst_ip = get_ipv4_src_address_ptr(embedded_ipv4_header)
    local icmp_reply = icmp.new_icmpv4_packet(lwstate.aftr_mac_inet_side, lwstate.inet_mac,
                                              lwstate.aftr_ipv4_ip, dst_ip, pkt,
-                                             ethernet_header_size, icmp_config)
+                                             icmp_config)
    return icmp_reply
 end
 

--- a/src/apps/lwaftr/lwheader.lua
+++ b/src/apps/lwaftr/lwheader.lua
@@ -23,16 +23,11 @@ local ntohs, ntohl = htons, htonl
 -- payload lengths should be in host byte order.
 -- next_hdr_type and dscp_and_ecn are <= 1 byte, so byte order is irrelevant.
 
-function write_eth_header(dst_ptr, ether_src, ether_dst, eth_type, vlan_tag)
+function write_eth_header(dst_ptr, ether_src, ether_dst, eth_type)
    local eth_hdr = cast(ethernet_header_ptr_type, dst_ptr)
    eth_hdr.ether_shost = ether_src
    eth_hdr.ether_dhost = ether_dst
-   if vlan_tag then -- TODO: don't have bare constant offsets here
-      wr32(dst_ptr + 12, vlan_tag)
-      wr16(dst_ptr + 16, eth_type)
-   else
-      eth_hdr.ether_type = eth_type
-   end
+   eth_hdr.ether_type = eth_type
 end
 
 function write_ipv6_header(dst_ptr, ipv6_src, ipv6_dst, dscp_and_ecn, next_hdr_type, payload_length)


### PR DESCRIPTION
Our codebase now relies on vlan tags being stripped/inserted nearer the edges
of the app network.
