### PR TITLE
Add a flag to allow monitor all packets in on-a-stick mode

### DIFF
--- a/src/apps/lwaftr/V4V6.lua
+++ b/src/apps/lwaftr/V4V6.lua
@@ -16,6 +16,7 @@ local o_ipv4_src_addr = constants.o_ipv4_src_addr
 local ipv6_fixed_header_size = constants.ipv6_fixed_header_size
 
 local v4v6_mirror = shm.create("v4v6_mirror", "struct { uint32_t ipv4; }")
+local MIRROR_EVERYTHING = 0xffffffff
 
 local function is_ipv4 (pkt)
    local ethertype = rd16(pkt.data + o_ethernet_ethertype)
@@ -35,19 +36,27 @@ local function get_ipv6_payload (ptr)
 end
 
 local function mirror_ipv4 (pkt, output, ipv4_num)
-   local ipv4_hdr = get_ethernet_payload(pkt)
-   if get_ipv4_dst_num(ipv4_hdr) == ipv4_num or
-         get_ipv4_src_num(ipv4_hdr) == ipv4_num then
+   if ipv4_num == MIRROR_EVERYTHING then
       transmit(output, packet.clone(pkt))
+   else
+      local ipv4_hdr = get_ethernet_payload(pkt)
+      if get_ipv4_dst_num(ipv4_hdr) == ipv4_num or
+         get_ipv4_src_num(ipv4_hdr) == ipv4_num then
+         transmit(output, packet.clone(pkt))
+      end
    end
 end
 
 local function mirror_ipv6 (pkt, output, ipv4_num)
-   local ipv6_hdr = get_ethernet_payload(pkt)
-   local ipv4_hdr = get_ipv6_payload(ipv6_hdr)
-   if get_ipv4_dst_num(ipv4_hdr) == ipv4_num or
-         get_ipv4_src_num(ipv4_hdr) == ipv4_num then
+   if ipv4_num == MIRROR_EVERYTHING then
       transmit(output, packet.clone(pkt))
+   else
+      local ipv6_hdr = get_ethernet_payload(pkt)
+      local ipv4_hdr = get_ipv6_payload(ipv6_hdr)
+      if get_ipv4_dst_num(ipv4_hdr) == ipv4_num or
+         get_ipv4_src_num(ipv4_hdr) == ipv4_num then
+         transmit(output, packet.clone(pkt))
+      end
    end
 end
 

--- a/src/program/lwaftr/monitor/README
+++ b/src/program/lwaftr/monitor/README
@@ -1,18 +1,22 @@
 Usage:
-    monitor [IPV4_ADDRESS] [PID]
+    monitor ACTION|IPV4_ADDRESS [PID]
 
     -h, --help
                                 Print usage information.
 
-Optional arguments:
+Arguments:
 
-    IPV4_ADDRESS                IPv4 address to mirror. Default: 0.0.0.0.
+    ACTION                      Action to perform: 'none' or 'all'
+    IPV4_ADDRESS                IPv4 address to mirror
     PID                         PID value of Snabb process.
 
 Sets the value of 'v4v6_mirror' counter to IPV4_ADDRESS.  The 'v4v6_mirror'
 counter is defined for all lwAFTR instances running in mirroring mode.
 Matching packets will be mirrored to the tap interface set by the original
 lwAFTR process.
+
+When action is 'none' IPV4_ADDRESS is set to '0.0.0.0'. When ACTION is 'all'
+IPV4_ADDRESS is set to '255.255.255.255'.
 
 PID value is used to retrieve the lwAFTR instance.  If PID is not set, the
 most recent active lwAFTR instance for which 'v4v6_mirror' is defined is used.


### PR DESCRIPTION
I need this feature for implementing Snabbvmx test, so I can inspect any kind of packet returned by the VM.

Currently monitor only allows to set and IPv4 address and mirrors any IPv4 packet matching its source or destination address with the IPv4 address set by monitor. It also mirrors ipv4-in-ipv6 packets. It's mainly thought to debug packets going to the lwAFTR.

My use case is sending an IPv6 ping packet to the lwAFTR IPv6 interface. Mirroring all packets I can fetch the IPv6 echo-reply returned by the VM.
