### PR TITLE
Linux network interface support via RawSocket for snabbvmx

### DIFF
--- a/src/program/snabbvmx/lwaftr/README
+++ b/src/program/snabbvmx/lwaftr/README
@@ -7,7 +7,7 @@ Arguments:
 
   --conf    <config-file>   configuration file for lwaftr service
   --id      <port-id>       port_id for virtio socket
-  --pci     <pci-addr>      PCI device number for NIC
+  --pci     <pci-addr>      PCI device number for NIC (or Linux interface name)
   --mac     <mac address>   Ethernet address of virtio interface
   --sock    <socket-path>   Socket path for virtio-user interfaces
 
@@ -18,9 +18,9 @@ Optional:
 
 Example config file:
 
-# cat snabbvmx-lwaftr-em3-em4.cfg
+# cat snabbvmx-lwaftr-xe0.cfg
 return {
-   lwaftr = "snabbvmx-lwaftr-em3-em4.conf",
+   lwaftr = "snabbvmx-lwaftr-xe0.conf",
    ipv6_interface = {
       ipv6_address = "fc00::100",
       mtu = 9500,


### PR DESCRIPTION
This pull request depends on [https://github.com/Igalia/snabb/pull/391](https://github.com/Igalia/snabb/pull/391). Actual change is in src/program/snabbvmx/lwaftr/setup.lua and src/program/snabbvmx/lwaftr/README (where I also cleaned up the config file name. em2-em3 was misleading). 

Adding basic support to use Linux network interfaces instead of Intel 82599 ports. Instead of a PCI address, an interface name can be passed to 'snabb snabbvmx lwaftr --pci <ethX>'. 
This will load apps.socket.raw instead of apps.intel.intel10g.

Main use case is functionality testing in a Docker virtual network environment without physical interfaces. Docker supports attaching multiple networks to a container and they appear as additional ethX interfaces within the container. It is even possible to attach new virtual networks at runtime.
See https://docs.docker.com/engine/userguide/networking/ for details. Many Containers can be connected to these virtual networks, and in case of an overlay docker network plugin, even across compute nodes. Great way to build more complex lab topologies, completely isolated from the underlay and deployable on cloud only servers.

BTW only one network can be specified to a container with 'run', so the creation and instantiation must be separated, with networks connected to the container after it has been created. A simple example illustrates this:

```
#!/bin/sh
NAME="vmxlwaftr1"
docker create --name $NAME -ti --privileged -v $PWD:/u:ro $CONTAINER -I $IDENTITY -l $LICENSE -c $CFG $1 $VMX $INTERFACES
docker network create net1 
docker network create net2 
docker network connect net1 $NAME
docker network connect net2 $NAME
docker start -a -i $NAME
```

Within the running container, there are now 3 network interfaces:

```
root@36d8a94aea3f:/# ifconfig |grep eth
eth0      Link encap:Ethernet  HWaddr 02:42:ac:11:00:02
eth1      Link encap:Ethernet  HWaddr 02:42:ac:13:00:02
eth2      Link encap:Ethernet  HWaddr 02:42:ac:14:00:02
```

Snabbvmx can then be launched on eth1 and eth2 (eth0 is typically connected to docker0):

```
root@36d8a94aea3f:/# ps ax|grep lwaftr|grep pci
  381 ?        S      0:00 /usr/local/bin/snabb snabbvmx lwaftr --conf snabbvmx-lwaftr-xe0.cfg --id xe0 --pci eth1 --mac 02:cf:69:15:00:00 --sock %s.socket
  382 ?        R     30:37 /usr/local/bin/snabb snabbvmx lwaftr --conf snabbvmx-lwaftr-xe0.cfg --id xe0 --pci eth1 --mac 02:cf:69:15:00:00 --sock %s.socket
  383 ?        S      0:00 /usr/local/bin/snabb snabbvmx lwaftr --conf snabbvmx-lwaftr-xe1.cfg --id xe1 --pci eth2 --mac 02:cf:69:15:00:01 --sock %s.socket
  384 ?        R     30:36 /usr/local/bin/snabb snabbvmx lwaftr --conf snabbvmx-lwaftr-xe1.cfg --id xe1 --pci eth2 --mac 02:cf:69:15:00:01 --sock %s.socket
```

Also allows for easy troubleshooting within the container shell:

```
docker exec -ti vmxlwaftr1 bash
root@36d8a94aea3f:/# tcpdump -n -i eth1 -v
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth1, link-type EN10MB (Ethernet), capture size 65535 bytes
tcpdump: listening on eth1, link-type EN10MB (Ethernet), capture size 65535 bytes
16:10:00.253397 LLDP, length 260
        Chassis ID TLV (1), length 7
          Subtype MAC address (4): 00:05:86:f4:d6:c0
        Port ID TLV (2), length 4
          Subtype Local (7): 517
        Time to Live TLV (3), length 2: TTL 120s
        System Name TLV (5), length 7: lwaftr1
        System Description TLV (6), length 156
          Juniper Networks, Inc. vmx internet router, kernel JUNOS 16.1-20160807.0, Build date: 2016-08-07 03:08:33 UTC Copyright (c) 1996-2016 Juniper Networks, Inc.
        System Capabilities TLV (7), length 4
          System  Capabilities [Bridge, Router] (0x0014)
          Enabled Capabilities [Bridge, Router] (0x0014)
        Management Address TLV (8), length 24
          Management Address length 5, AFI IPv4 (1): 172.17.0.121
          Interface Index Interface Numbering (2): 1
          OID length 12\0x01\0x03\0x06\0x01\0x02\0x01\0x1f\0x01\0x01\0x01\0x01\0x01
        Port Description TLV (4), length 8: ge-0/0/0
        Organization specific TLV (127), length 9: OUI IEEE 802.3 Private (0x00120f)
          MAC/PHY configuration/status Subtype (1)
            autonegotiation [supported, enabled] (0x03)
            PMD autoneg capability [10BASE-T hdx, 10BASE-T fdx, 100BASE-TX hdx, 100BASE-TX fdx, Asym and Sym PAUSE for fdx, 1000BASE-{X LX SX CX} hdx, 1000BASE-{X LX SX CX} fdx, 1000BASE-T fdx] (0x6c1d)
            MAU type Unknown (0x0000)
        Organization specific TLV (127), length 9: OUI IEEE 802.3 Private (0x00120f)
          Link aggregation Subtype (3)
            aggregation status [supported], aggregation port ID 0
        Organization specific TLV (127), length 6: OUI IEEE 802.3 Private (0x00120f)
          Max frame size Subtype (4)
            MTU size 9000
        End TLV (0), length 0
...
```

I wonder if it would be cleaner to use a separate argument, e.g. '--int' to specify linux interfaces. But that makes launching snabb a bit more complex when 10GE and linux network interfaces are mixed (each launched with its own snabb instances). Personally I'd prefer some auto-detection mechanism, where one simply specifies a network identifier and snabb loads the most appropriate driver for it.  This is my cheap approach with some auto-detection if no driver can be found for the given identifier.
