### PR TITLE
Add VLAN support for on-a-stick mode

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -899,10 +899,13 @@ end
 
 function M_vf:set_VLAN (vlan)
    if not vlan then return self end
-   assert(vlan>=0 and vlan<4096, "bad VLAN number")
+   if tonumber(vlan) then vlan = { vlan } end
+   for _, each in ipairs(vlan) do
+      assert(each>=0 and each<4096, "bad VLAN number")
+      self:add_receive_VLAN(each)
+          :set_tag_VLAN(each)
+   end
    return self
-      :add_receive_VLAN(vlan)
-      :set_tag_VLAN(vlan)
 end
 
 function M_vf:add_receive_VLAN (vlan)

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -147,9 +147,19 @@ function load_on_a_stick(c, conf, v4v6, args)
    local Tap = require("apps.tap.tap").Tap
    lwaftr_app(c, conf)
 
-   config.app(c, 'nic', Intel82599, {
-      pciaddr = args.pciaddr,
-   })
+   if conf.vlan_tagging then
+      config.app(c, 'nic', Intel82599, {
+         pciaddr = args.pciaddr,
+         vmdq=true,
+         vlan={conf.v4_vlan_tag, conf.v6_vlan_tag},
+         macaddr=ethernet:ntop(conf.aftr_mac_inet_side),
+      })
+   else
+      config.app(c, 'nic', Intel82599, {
+         pciaddr = args.pciaddr,
+      })
+   end
+
    if args.mirror then
       local ifname = args.mirror
       config.app(c, 'tap', Tap, ifname)


### PR DESCRIPTION
Running lwaftr on-a-stick mode with VLANs has the problem that lwAFTR configuration file can specify a VLAN tag for IPv4 packets and a different VLAN tag for IPv6 packets and the Intel82599 driver only allows one VLAN tag.

However, according to the Intel82599 Datasheet it seems it's possible to specify more than one VLAN tag for a NIC in VMDq mode:

```
Page 510, Section 8.2.3.7.11

VLAN_FLT

VLAN Filter. Each bit ‘i’ in register ‘n’ affects packets with VLAN tags equal to 32*n+i.
128 VLAN Filter registers compose a table of 4096 bits that cover all possible VLAN
tags.

Each bit when set, enables packets with the associated VLAN tags to pass. Each bit
when cleared, blocks packets with this VLAN tag.
```

Snabb's Intel82599 driver already has coded implemented for allowing more than one VLAN tag, however its interface only expects one single VLAN value.

This PR enables VLAN tag on-a-stick mode and extends Intel82599 to allow initializing multiple VLAN tags.

lwaftr-vlan.conf

```
binding_table = binding_table.txt,
aftr_ipv6_ip = fc00::100,
aftr_mac_inet_side = 02:AA:AA:AA:AA:AA,
inet_mac = 02:99:99:99:99:99,
ipv6_mtu = 9500,
policy_icmpv6_incoming = DROP,
policy_icmpv6_outgoing = DROP,
icmpv6_rate_limiter_n_packets = 6e5,
icmpv6_rate_limiter_n_seconds = 2,
aftr_ipv4_ip = 10.0.1.1,
aftr_mac_b4_side = 02:AA:AA:AA:AA:AA,
next_hop6_mac = 02:99:99:99:99:99,
ipv4_mtu = 1460,
policy_icmpv4_incoming = DROP,
policy_icmpv4_outgoing = DROP,
vlan_tagging = true,
v4_vlan_tag = 444,
v6_vlan_tag = 666,
```

Run lwAFTR:

``` bash
sudo ./snabb lwaftr run -v --conf lwaftr-vlan.conf --on-a-stick 81:00.0
```

Packetblaster:

``` bash
sudo ./snabb packetblaster replay v4v6-vlan-256.pcap 81:00.1
```

v4v6-vlan-256.pcap can be found here https://people.igalia.com/dpino/lwaftr/v4v6-vlan-256.pcap
