### PR TITLE
Move initialization of counters to lwAFTR app code

### DIFF
--- a/src/apps/lwaftr/ipv4_apps.lua
+++ b/src/apps/lwaftr/ipv4_apps.lua
@@ -46,7 +46,7 @@ ICMPEcho = {}
 function Reassembler:new(conf)
    local o = setmetatable({}, {__index=Reassembler})
    o.conf = conf
-   o.counters = conf.counters
+   o.counters = assert(conf.counters, "Counters not initialized")
    o.ctab = fragv4_h.initialize_frag_table(conf.max_ipv4_reassembly_packets,
       conf.max_fragments_per_reassembly_packet)
    counter.set(o.counters["memuse-ipv4-frag-reassembly-buffer"],
@@ -116,7 +116,7 @@ end
 function Fragmenter:new(conf)
    local o = setmetatable({}, {__index=Fragmenter})
    o.conf = conf
-   o.counters = conf.counters
+   o.counters = assert(conf.counters, "Counters not initialized")
    o.mtu = assert(conf.mtu)
    return o
 end

--- a/src/apps/lwaftr/ipv6_apps.lua
+++ b/src/apps/lwaftr/ipv6_apps.lua
@@ -43,7 +43,7 @@ ICMPEcho = {}
 function ReassembleV6:new(conf)
    local o = setmetatable({}, {__index = ReassembleV6})
    o.conf = conf
-   o.counters = conf.counters
+   o.counters = assert(conf.counters, "Counters not initialized")
    o.ctab = fragv6_h.initialize_frag_table(conf.max_ipv6_reassembly_packets,
       conf.max_fragments_per_reassembly_packet)
    counter.set(o.counters["memuse-ipv6-frag-reassembly-buffer"],
@@ -111,7 +111,7 @@ end
 function Fragmenter:new(conf)
    local o = setmetatable({}, {__index=Fragmenter})
    o.conf = conf
-   o.counters = conf.counters
+   o.counters = assert(conf.counters, "Counters not initialized")
    o.mtu = assert(conf.mtu)
    return o
 end

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -284,7 +284,7 @@ function LwAftr:new(conf)
    o.hairpin_lookup_queue = bt.BTLookupQueue.new(o.binding_table)
 
    o.control = channel.create('lwaftr/control', messages.lwaftr_message_t)
-   o.counters = conf.counters
+   o.counters = assert(conf.counters, "Counters not initialized")
 
    transmit_icmpv6_reply = init_transmit_icmpv6_reply(o)
    transmit_icmpv4_reply = init_transmit_icmpv4_reply(o)

--- a/src/apps/lwaftr/lwcounter.lua
+++ b/src/apps/lwaftr/lwcounter.lua
@@ -121,7 +121,7 @@ counter_names = {
    "memuse-ipv6-frag-reassembly-buffer",
 }
 
-function create_counters ()
+function init_counters ()
    local counters = {}
    for _, name in ipairs(counter_names) do
       counters[name] = {counter}

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -20,7 +20,7 @@ function lwaftr_app(c, conf)
    conf.preloaded_binding_table = bt.load(conf.binding_table)
    local function append(t, elem) table.insert(t, elem) end
    local function prepend(t, elem) table.insert(t, 1, elem) end
-   conf.counters = lwcounter.create_counters()
+   conf.counters = lwcounter.init_counters()
 
    config.app(c, "reassemblerv4", ipv4_apps.Reassembler, conf)
    config.app(c, "reassemblerv6", ipv6_apps.ReassembleV6, conf)


### PR DESCRIPTION
lwAFTR app expects to find a counters array, but right now the array is initialized externally. This may cause a crash if a script tries to use the lwAFTR app and doesn't initialize the counters array.
