### PR TITLE
Fix initialization of Reassembly/Fragmentation apps

### DIFF
--- a/src/apps/lwaftr/ipv4_apps.lua
+++ b/src/apps/lwaftr/ipv4_apps.lua
@@ -44,14 +44,16 @@ ARP = {}
 ICMPEcho = {}
 
 function Reassembler:new(conf)
-   local o = setmetatable({}, {__index=Reassembler})
-   o.conf = conf
-   o.counters = assert(conf.counters, "Counters not initialized")
-   o.ctab = fragv4_h.initialize_frag_table(conf.max_ipv4_reassembly_packets,
-      conf.max_fragments_per_reassembly_packet)
+   local max_ipv4_reassembly_packets = assert(conf.max_ipv4_reassembly_packets)
+   local max_fragments_per_reassembly_packet = assert(conf.max_fragments_per_reassembly_packet)
+   local o = {
+      counters = assert(conf.counters, "Counters not initialized"),
+      ctab = fragv4_h.initialize_frag_table(max_ipv4_reassembly_packets,
+         max_fragments_per_reassembly_packet),
+   }
    counter.set(o.counters["memuse-ipv4-frag-reassembly-buffer"],
                o.ctab:get_backing_size())
-   return o
+   return setmetatable(o, {__index=Reassembler})
 end
 
 local function is_fragment(pkt)
@@ -114,11 +116,11 @@ function Reassembler:push ()
 end
 
 function Fragmenter:new(conf)
-   local o = setmetatable({}, {__index=Fragmenter})
-   o.conf = conf
-   o.counters = assert(conf.counters, "Counters not initialized")
-   o.mtu = assert(conf.mtu)
-   return o
+   local o = {
+      counters = assert(conf.counters, "Counters not initialized"),
+      mtu = assert(conf.mtu),
+   }
+   return setmetatable(o, {__index=Fragmenter})
 end
 
 function Fragmenter:push ()

--- a/src/apps/lwaftr/ipv6_apps.lua
+++ b/src/apps/lwaftr/ipv6_apps.lua
@@ -41,14 +41,16 @@ NDP = {}
 ICMPEcho = {}
 
 function ReassembleV6:new(conf)
-   local o = setmetatable({}, {__index = ReassembleV6})
-   o.conf = conf
-   o.counters = assert(conf.counters, "Counters not initialized")
-   o.ctab = fragv6_h.initialize_frag_table(conf.max_ipv6_reassembly_packets,
-      conf.max_fragments_per_reassembly_packet)
+   local max_ipv6_reassembly_packets = conf.max_ipv6_reassembly_packets
+   local max_fragments_per_reassembly_packet = conf.max_fragments_per_reassembly_packet
+   local o = {
+      counters = assert(conf.counters, "Counters not initialized"),
+      ctab = fragv6_h.initialize_frag_table(max_ipv6_reassembly_packets,
+         max_fragments_per_reassembly_packet),
+   }
    counter.set(o.counters["memuse-ipv6-frag-reassembly-buffer"],
                o.ctab:get_backing_size())
-   return o
+   return setmetatable(o, {__index = ReassembleV6})
 end
 
 function ReassembleV6:cache_fragment(fragment)
@@ -109,11 +111,11 @@ function ReassembleV6:push ()
 end
 
 function Fragmenter:new(conf)
-   local o = setmetatable({}, {__index=Fragmenter})
-   o.conf = conf
-   o.counters = assert(conf.counters, "Counters not initialized")
-   o.mtu = assert(conf.mtu)
-   return o
+   local o = {
+      counters = assert(conf.counters, "Counters not initialized"),
+      mtu = assert(conf.mtu),
+   }
+   return setmetatable(o, {__index=Fragmenter})
 end
 
 function Fragmenter:push ()


### PR DESCRIPTION
Reassembly apps fail if `conf.max_ipv6_reassembly_packets` or `conf.max_fragments_per_reassembly_packet` parameters are missing. They expected conf is a lwAFTR conf file but it has not to be the case (it's not the case in Snabbvmx).

Other things:
- Removed o.conf as it's not used.
- Changed initialization of Fragmentation app, not necessary per se but to keep it consistent with Reassembly app.
