### PR TITLE
Change lwAFTR counters location

### DIFF
--- a/src/apps/lwaftr/lwcounter.lua
+++ b/src/apps/lwaftr/lwcounter.lua
@@ -12,7 +12,7 @@ local shm = require("core.shm")
 --   - reason: reasons for dropping;
 -- - protocol+version: "icmpv4", "icmpv6", "ipv4", "ipv6";
 -- - size: "bytes", "packets".
-counters_dir = "app/lwaftr/counters/"
+counters_dir = "apps/lwaftr/"
 -- Referenced by program/check/check.lua
 counter_names = {
 


### PR DESCRIPTION
If a `shm` attribute, containing a table, is passed to an app on initialization, Snabb automatically creates counters for that app (See https://github.com/snabbco/snabb/blob/master/src/core/app.lua#L194). Counters are created in "apps/<app-name/".

To keep things consistent, we should create lwAFTR counters at the same location. OTOH, counters hook directly from the app's name folder, without an extra `counters/` directory.
