### PR TITLE
Fix fetch instance by name

### DIFF
--- a/src/program/lwaftr/query/query.lua
+++ b/src/program/lwaftr/query/query.lua
@@ -34,8 +34,9 @@ local function pidof(maybe_pid)
    if tonumber(maybe_pid) then return maybe_pid end
    local name_id = maybe_pid
    for _, pid in ipairs(shm.children("/")) do
-      if shm.exists(pid.."/nic/id") then
-         local lwaftr_id = shm.open("/"..pid.."/nic/id", lwtypes.lwaftr_id_type)
+      local path = "/"..pid.."/nic/id"
+      if shm.exists(path) then
+         local lwaftr_id = shm.open(path, lwtypes.lwaftr_id_type)
          if ffi.string(lwaftr_id.value) == name_id then
             return pid
          end


### PR DESCRIPTION
`lwaftr query` command when fetching Snabb instance by name (nic/id) was broken. This patch fixes it.

```
sudo ./snabb snabbvmx lwaftr -v --conf snabbvmx-lwaftr-em3-em4.cfg --id a --pci 81:00.0 --mac 02:aa:aa:aa:aa:aa --sock /tmp/vh1a.sock
```

```
sudo ./snabb packetblaster replay v4v6-256.pcap 81:00.1
```

```
sudo ./snabb lwaftr query a
lwAFTR operational counters (non-zero)
in-ipv4-bytes:                      15,944,176,786
in-ipv4-packets:                    28,989,413
in-ipv6-bytes:                      15,975,535,950
in-ipv6-packets:                    29,046,429
out-ipv4-bytes:                     14,813,678,790
out-ipv4-packets:                   29,046,429
out-ipv6-bytes:                     17,103,752,490
out-ipv6-packets:                   28,989,411
```
