### PR TITLE
Ingress packet drops counter

### DIFF
--- a/src/apps/lwaftr/lwcounter.lua
+++ b/src/apps/lwaftr/lwcounter.lua
@@ -119,6 +119,9 @@ counter_names = {
    "out-ipv6-frag",
    "out-ipv6-frag-not",
    "memuse-ipv6-frag-reassembly-buffer",
+
+-- Ingress packet drops
+   "ingress-packet-drops",
 }
 
 function init_counters ()

--- a/src/program/snabbvmx/lwaftr/lwaftr.lua
+++ b/src/program/snabbvmx/lwaftr/lwaftr.lua
@@ -148,9 +148,6 @@ function run(args)
       mtu = DEFAULT_MTU,
       vlan = vlan,
       mirror_id = mirror_id,
-      discard_threshold = discard_threshold,
-      discard_wait = discard_wait,
-      discard_check_timer = discard_check_timer,
    }
 
    local c = config.new()
@@ -165,11 +162,15 @@ function run(args)
       timer.activate(t)
    end
 
-   if opts.ingress_drop_monitor then
+   if interface.discard_threshold then
       local counter_path = lwcounter.counters_dir.."/ingress-packet-drops"
-      local mon = ingress_drop_monitor.new({action=opts.ingress_drop_monitor,
-                                            counter=counter_path})
-      timer.activate(mon:timer())
+      local mon = ingress_drop_monitor.new({
+         action = interface.discard_action or opts.ingress_drop_monitor,
+         counter = counter_path,
+         threshold = interface.discard_threshold,
+         wait = interface.discard_wait,
+      })
+      timer.activate(mon:timer(discard_check_timer))
    end
 
    engine.busywait = true

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -97,11 +97,6 @@ local function load_phy (c, nic_id, interface)
          pciaddr = interface.pci,
          vmdq = true,
          vlan = vlan,
-         qprdc = {
-            discard_check_timer = interface.discard_check_timer,
-            discard_wait = interface.discard_wait,
-            discard_threshold = interface.discard_threshold,
-         },
          macaddr = interface.mac_address,
          mtu = interface.mtu})
       chain_input, chain_output = nic_id .. ".rx", nic_id .. ".tx"


### PR DESCRIPTION
Adds an extra flag 'counter' to ingress-drop-monitor timer so ingress-packet-drops value is written to a counter too.

In another commit, ingress-packet-drops is activated by default in SnabbVMX. As the ingress-packet-drops counter is part of the lwAFTR counters, it can be listed with `lwaftr query`.

```
$ sudo ./snabb lwaftr query 27462 ingress
lwAFTR operational counters (non-zero)
ingress-packet-drops: 20,675,608
```
