### PR TITLE
ok to have no v4/v6 input/output ports in passthru mode

### DIFF
--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -172,7 +172,6 @@ function lwaftr_app(c, conf, lwconf, sock_path)
          v4_input, v6_input   = "nic_v4v6.v4", "nic_v4v6.v6"
       end
    end
-   assert(v4_input and v6_input and v4_output and v6_output)
 
    if conf.ipv6_interface then
       conf.ipv6_interface.mac_address = conf.interface.mac_address


### PR DESCRIPTION
It is ok in passthru mode (when there are no config files passed to snabbvmx) to not have v4_input, v6_input, v4_output and v6_output ports: The interface is linked straight to VhostUser, so packets pass between the wire and the VM "unharmed".
