### PR TITLE
Fix crash in non-matching incoming IPv4 packets, alternate version

### DIFF
--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -35,12 +35,13 @@ local ntohs, ntohl = htons, htonl
 local keys = lwutil.keys
 local write_eth_header, write_ipv6_header = lwheader.write_eth_header, lwheader.write_ipv6_header
 
--- Note whether an IPv4 packet is actually coming from the internet, or from
--- a b4 and hairpinned to be re-encapsulated in another IPv6 packet.
+-- Note whether an IPv4 packet is created locally, is coming from the internet,
+-- or from a b4 and hairpinned to be re-encapsulated in another IPv6 packet.
+PKT_LOCAL = 0
 PKT_FROM_INET = 1
 PKT_HAIRPINNED = 2
 
-local debug = false
+local debug = lib.getenv("LWAFTR_DEBUG")
 
 -- Local bindings for constants that are used in the hot path of the
 -- data plane.  Not having them here is a 1-2% performance penalty.
@@ -160,7 +161,7 @@ local function drop_ipv4(lwstate, pkt, pkt_src_link)
       local orig_packet_len = pkt.length + ipv6_fixed_header_size
       counter.add(lwstate.counters["drop-all-ipv6-iface-bytes"], orig_packet_len)
       counter.add(lwstate.counters["drop-all-ipv6-iface-packets"])
-   else
+   elseif pkt_src_link ~= PKT_LOCAL then
       assert(false, "Programming error, bad pkt_src_link: " .. pkt_src_link)
    end
    return drop(pkt)
@@ -212,7 +213,7 @@ local function init_transmit_icmpv4_reply (lwstate)
    local icmpv4_rate_limiter_n_packets = lwstate.icmpv4_rate_limiter_n_packets
    local num_packets = 0
    local last_time
-   return function (o, pkt, orig_pkt)
+   return function (o, pkt, orig_pkt, orig_pkt_link)
       local now = tonumber(engine.now())
       last_time = last_time or now
       -- Reset if elapsed time reached.
@@ -223,7 +224,7 @@ local function init_transmit_icmpv4_reply (lwstate)
       -- Send packet if limit not reached.
       if num_packets < icmpv4_rate_limiter_n_packets then
          num_packets = num_packets + 1
-         drop(orig_pkt)
+         drop_ipv4(lwstate, orig_pkt, orig_pkt_link)
          counter.add(lwstate.counters["out-icmpv4-bytes"], pkt.length)
          counter.add(lwstate.counters["out-icmpv4-packets"])
          -- Only locally generated error packets are handled here.  We transmit
@@ -401,8 +402,7 @@ local function drop_ipv4_packet_to_unreachable_host(lwstate, pkt, pkt_src_link)
       lwstate.aftr_mac_inet_side, lwstate.inet_mac, lwstate.aftr_ipv4_ip,
       to_ip, pkt, icmp_config)
 
-   drop_ipv4(lwstate, pkt, pkt_src_link)
-   return transmit_icmpv4_reply(lwstate, icmp_dis, pkt)
+   return transmit_icmpv4_reply(lwstate, icmp_dis, pkt, pkt_src_link)
 end
 
 -- ICMPv6 type 1 code 5, as per RFC 7596.
@@ -475,8 +475,7 @@ local function encapsulate_and_transmit(lwstate, pkt, ipv6_dst, ipv6_src, pkt_sr
          lwstate.aftr_mac_inet_side, lwstate.inet_mac, lwstate.aftr_ipv4_ip,
          dst_ip, pkt, icmp_config)
 
-      drop_ipv4(lwstate, pkt, pkt_src_link)
-      return transmit_icmpv4_reply(lwstate, reply, pkt)
+      return transmit_icmpv4_reply(lwstate, reply, pkt, pkt_src_link)
    end
 
    if debug then print("ipv6", ipv6_src, ipv6_dst) end
@@ -494,8 +493,7 @@ local function encapsulate_and_transmit(lwstate, pkt, ipv6_dst, ipv6_src, pkt_sr
          return drop_ipv4(lwstate, pkt, pkt_src_link)
       end
       local reply = cannot_fragment_df_packet_error(lwstate, pkt)
-      drop_ipv4(lwstate, pkt, pkt_src_link)
-      return transmit_icmpv4_reply(lwstate, reply, pkt)
+      return transmit_icmpv4_reply(lwstate, reply, pkt, pkt_src_link)
    end
 
    local payload_length = get_ethernet_payload_length(pkt)
@@ -692,7 +690,7 @@ local function icmpv6_incoming(lwstate, pkt)
       local reply = tunnel_unreachable(lwstate, pkt,
                                        constants.icmpv4_datagram_too_big_df,
                                        mtu)
-      return transmit_icmpv4_reply(lwstate, reply, pkt)
+      return transmit_icmpv4_reply(lwstate, reply, pkt, PKT_LOCAL)
    -- Take advantage of having already checked for 'packet too big' (2), and
    -- unreachable node/hop limit exceeded/paramater problem being 1, 3, 4 respectively
    elseif icmp_type <= constants.icmpv6_parameter_problem then
@@ -711,7 +709,7 @@ local function icmpv6_incoming(lwstate, pkt)
       -- Accept all unreachable or parameter problem codes
       local reply = tunnel_unreachable(lwstate, pkt,
                                        constants.icmpv4_host_unreachable)
-      return transmit_icmpv4_reply(lwstate, reply, pkt)
+      return transmit_icmpv4_reply(lwstate, reply, pkt, PKT_LOCAL)
    else
       -- No other types of ICMPv6, including echo request/reply, are
       -- handled.

--- a/src/program/packetblaster/lwaftr/lwaftr.lua
+++ b/src/program/packetblaster/lwaftr/lwaftr.lua
@@ -38,8 +38,8 @@ local long_opts = {
    ipv4         = "I",    -- fix public IPv4 address
    count        = "c",    -- how many b4 clients to simulate
    rate         = "r",    -- rate in MPPS (0 => listen only)
-   v4only       = "P",    -- generate only public IPv4 traffic
-   v6only       = "E",    -- generate only public IPv6 encapsulated traffic
+   v4only       = "4",    -- generate only public IPv4 traffic
+   v6only       = "6",    -- generate only public IPv6 encapsulated traffic
    pcap         = "o"     -- output packet to the pcap file
 }
 


### PR DESCRIPTION
This is a modification of #439 that changes `drop_ipv4` rather than working around it.
