### PR TITLE
Update lwaftr check

### DIFF
--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -75,8 +75,8 @@ function set_dst_ethernet(pkt, dst_eth)
 end
 
 function write_to_file(filename, content)
-   local fd = assert(io.open(filename, "wt"),
-      ("Couldn't open file: '%s'"):format(filename))
+   local fd, err = io.open(filename, "wt+")
+   if not fd then error(err) end
    fd:write(content)
    fd:close()
 end

--- a/src/program/lwaftr/check/README
+++ b/src/program/lwaftr/check/README
@@ -4,13 +4,14 @@ Usage: check [-r] CONF V4-IN.PCAP V6-IN.PCAP V4-OUT.PCAP V6-OUT.PCAP [COUNTERS.L
   -h, --help
                              Print usage information.
   -r, --regen
-                             Regenerate counter files, instead of checking
+                             Regenerate counter files, instead of checking.
+  --on-a-stick
+                             Run in on-a-stick mode.
 
 Without -r:
 Run the lwAFTR with input from IPV4-IN.PCAP and IPV6-IN.PCAP, and record
 output to IPV4-OUT.PCAP and IPV6-OUT.PCAP. COUNTERS.LUA contains a table that
 defines the counters and by how much each should increment.
-Note that this checks both "2 interface" mode and "on a stick" mode.
 Exit when finished.  This program is used in the lwAFTR test suite.
 
 With -r:

--- a/src/program/lwaftr/check/check.lua
+++ b/src/program/lwaftr/check/check.lua
@@ -35,7 +35,9 @@ function parse_args (args)
 end
 
 function load_requested_counters(counters)
-   return dofile(counters)
+   local result = dofile(counters)
+   assert(type(result) == "table", "Not a valid counters file: "..counters)
+   return result
 end
 
 function read_counters(c)

--- a/src/program/lwaftr/check/check.lua
+++ b/src/program/lwaftr/check/check.lua
@@ -108,10 +108,10 @@ function run(args)
       engine.main({duration=0.10})
       local final_counters = read_counters(c)
       local counters_diff = diff_counters(final_counters, initial_counters)
-      local req_counters = load_requested_counters(counters_path)
       if opts.r then
          regen_counters(counters_diff, counters_path)
       else
+         local req_counters = load_requested_counters(counters_path)
          validate_diff(counters_diff, req_counters)
       end
    else


### PR DESCRIPTION
Several fixes in lwaftr check:
- Updated README: Removed comment check runs in normal an on-a-stick mode. Documented option --on-a-stick.
- Removed duplicated code for on-a-stick mode.
- When regenerating counters file, create file if it doesn't exist.
- Add check result of parsing a counters file must be a table.
