### PR TITLE
Fix snabbvmx tests

### DIFF
--- a/src/program/snabbvmx/lwaftr/lwaftr.lua
+++ b/src/program/snabbvmx/lwaftr/lwaftr.lua
@@ -99,6 +99,10 @@ function run(args)
    if file_exists(conf_file) then
       conf = lib.load_conf(conf_file)
       if not file_exists(conf.lwaftr) then
+         -- Search in main config file.
+         conf.lwaftr = lib.dirname(conf_file).."/"..conf.lwaftr
+      end
+      if not file_exists(conf.lwaftr) then
          fatal(("lwAFTR conf file '%s' not found"):format(conf.lwaftr))
       end
       lwconf = require('apps.lwaftr.conf').load_lwaftr_config(conf.lwaftr)

--- a/src/program/snabbvmx/tests/nexthop/selftest.sh
+++ b/src/program/snabbvmx/tests/nexthop/selftest.sh
@@ -29,7 +29,7 @@ function quit_screens {
 
 function cleanup {
     quit_screens
-    kill $snabbvmx_pid $packetblaster_pid
+    kill $packetblaster_pid
     exit 0
 }
 
@@ -44,15 +44,14 @@ TARGET_MAC_B4=02:99:99:99:99:99
 rm -f $SNABBVMX_LOG
 
 # Run SnabbVMX.
-./snabb snabbvmx lwaftr --conf $SNABBVMX_CONF --id $SNABBVMX_ID \
-    --pci $SNABB_PCI0 --mac $MAC_ADDRESS_NET0 --sock $VHU_SOCK0 &>> $SNABBVMX_LOG &
-snabbvmx_pid=$!
+cmd="./snabb snabbvmx lwaftr --conf $SNABBVMX_CONF --id $SNABBVMX_ID --pci $SNABB_PCI0 --mac $MAC_ADDRESS_NET0 --sock $VHU_SOCK0"
+run_cmd_in_screen "snabbvmx" "$cmd"
 
 # Run QEMU.
-start_test_env &>> $SNABBVMX_LOG
+start_test_env
 
 # Flush lwAFTR packets to SnabbVMX.
-./snabb packetblaster replay -D 10 $PCAP_INPUT/v4v6-256.pcap $SNABB_PCI1 &>> $SNABBVMX_LOG &
+./snabb packetblaster replay -D 10 $PCAP_INPUT/v4v6-256.pcap $SNABB_PCI1 &
 packetblaster_pid=$!
 
 # Query nexthop for 10 seconds.


### PR DESCRIPTION
Snabbvmx conf file points to lwaftr conf file (`lwaftr` property) For instance:

**snabbvmx-lwaftr-xe0.cfg**

```
return {
   lwaftr = "snabbvmx-lwaftr-xe0.conf",
   ipv6_interface = {
      cache_refresh_interval = 1,
      mtu = 9500,
   },
   ipv4_interface = {
      ipv4_address = "10.0.1.1",
      cache_refresh_interval = 1,
      mtu = 1460,
   },
   settings = {
      vlan = false,
      ingress_drop_monitor = 'flush',
      ingress_drop_threshhold = 100000,
      ingress_drop_wait = 15,
      ingress_drop_interval = 1e8,
   },
}
```

When snabbvmx is run pointing to a conf file not in the current directory:

```
$ sudo ./snabb snabbvmx lwaftr --conf ./program/snabbvmx/tests/conf/snabbvmx-lwaftr-xe0.cfg --id xe0 --pci 0000:81:00.0                               
lwAFTR conf file 'snabbvmx-lwaftr-xe0.conf' not found
```

Since lwaftr points to a file in the current directory. To avoid this, if file was not found tries to open it in the location of .cfg directory.

The second patch fixes nexthop test. It got stuck but when running snabbvmx within a screen program it worked. The patch cleans up the script too to show more output (trying to connect to VM prompt) since it gave the impression the script was frozen.
