### PR TITLE
Fix update of ingress-packet-drops counter

### DIFF
--- a/src/lib/timers/ingress_drop_monitor.lua
+++ b/src/lib/timers/ingress_drop_monitor.lua
@@ -47,7 +47,7 @@ function IngressDropMonitor:sample ()
       end
    end
    if self.counter then
-      counter.add(self.counter, sum[0])
+      counter.set(self.counter, sum[0])
    end
 end
 


### PR DESCRIPTION
Fixes #448.

After change ingress-packet-drops counter shows the same value as NIC/rxdrop:

```
$ sudo ./snabb top -l pci/03:00.0 30114 | grep rxdrop
rxdrop                         1,556,214                     
```

```
$ sudo ./snabb lwaftr query 30114 ingress
lwAFTR operational counters (non-zero)
ingress-packet-drops:                 1,557,738
```
