### PR TITLE
Allow empty binding table

### DIFF
--- a/src/apps/lwaftr/binding_table.lua
+++ b/src/apps/lwaftr/binding_table.lua
@@ -430,7 +430,6 @@ local function parse_br_addresses(parser)
       parser:skip_whitespace()
       if parser:check(',') then parser:skip_whitespace() end
    end
-   if #addresses == 0 then parser:error('no lwaftr addresses specified') end
    local ret = ffi.new(ffi.typeof('$[?]', br_address_t), #addresses)
    for i, addr in ipairs(addresses) do ret[i-1].addr = addr end
    return ret, #addresses

--- a/src/apps/lwaftr/rangemap.lua
+++ b/src/apps/lwaftr/rangemap.lua
@@ -93,7 +93,7 @@ function RangeMapBuilder:build(default_value)
    -- contiguous entries with the highest K having a value V, starting
    -- with UINT32_MAX and working our way down.
    local ranges = {}
-   if self.entries[#self.entries].max.key < UINT32_MAX then
+   if #self.entries == 0 or self.entries[#self.entries].max.key < UINT32_MAX then
       table.insert(self.entries,
                    { min=self.entry_type(UINT32_MAX, default_value),
                      max=self.entry_type(UINT32_MAX, default_value) })


### PR DESCRIPTION
Fixes https://github.com/Igalia/snabb/issues/451

I am not sure about the rangemap. What I intended was when there are no entries there's a one single rangemap which min value is the same as max. This means to me same as no range or empty range.

I got this counters when running with an empty binding table (shows every is dropped and there are out ICMP packets):

```
$ sudo ./snabb lwaftr query 2801
lwAFTR operational counters (non-zero)
drop-all-ipv4-iface-bytes:            5,548,127,750
drop-all-ipv4-iface-packets:          10,087,505
drop-all-ipv6-iface-bytes:            9,014,214,000
drop-all-ipv6-iface-packets:          16,389,480
drop-no-dest-softwire-ipv4-bytes:     5,548,127,750
drop-no-dest-softwire-ipv4-packets:   10,087,505
drop-no-source-softwire-ipv6-bytes:   9,014,214,000
drop-no-source-softwire-ipv6-packets: 16,389,480
drop-over-rate-limit-icmpv6-bytes:    1,961,764,714
drop-over-rate-limit-icmpv6-packets:  3,280,543
in-ipv4-bytes:                        5,548,127,750
in-ipv4-frag-reassembly-unneeded:     10,087,505
in-ipv4-packets:                      10,087,505
in-ipv6-bytes:                        9,014,214,000
in-ipv6-frag-reassembly-unneeded:     16,389,480
in-ipv6-packets:                      16,389,480
memuse-ipv4-frag-reassembly-buffer:   463,571,780
memuse-ipv6-frag-reassembly-buffer:   464,727,376
out-icmpv4-bytes:                     5,830,577,890
out-icmpv4-packets:                   10,087,505
out-icmpv6-bytes:                     7,839,144,326
out-icmpv6-packets:                   13,108,937
out-ipv4-bytes:                       5,830,577,890
out-ipv4-frag-not:                    10,087,505
out-ipv4-packets:                     10,087,505
out-ipv6-frag-not:                    13,108,937
```
