### PR TITLE
If there is a br address for a bad softwire, use it

### DIFF
--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -418,7 +418,7 @@ local function drop_ipv6_packet_from_bad_softwire(lwstate, pkt, br_addr)
    end
 
    local ipv6_header = get_ethernet_payload(pkt)
-   local orig_src_addr = get_ipv6_src_address(ipv6_header)
+   local orig_src_addr_icmp_dst = get_ipv6_src_address(ipv6_header)
    -- If br_addr is specified, use that as the source addr. Otherwise, send it
    -- back from the IPv6 address it was sent to.
    local icmpv6_src_addr = br_addr or get_ipv6_dst_address(ipv6_header)
@@ -427,7 +427,7 @@ local function drop_ipv6_packet_from_bad_softwire(lwstate, pkt, br_addr)
                        }
    local b4fail_icmp = icmp.new_icmpv6_packet(
       lwstate.aftr_mac_b4_side, lwstate.next_hop6_mac, icmpv6_src_addr,
-      orig_src_addr --[[now dest--]], pkt, icmp_config)
+      orig_src_addr_icmp_dst, pkt, icmp_config)
    drop(pkt)
    transmit_icmpv6_reply(lwstate.o6, b4fail_icmp)
 end

--- a/src/program/lwaftr/doc/CHANGELOG.md
+++ b/src/program/lwaftr/doc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Pre-release changes
+
+ * Send ICMPv6 unreachable messages from the most appropriate source address
+   available (the one associated with a B4 if possible, or else the one the
+   packet one is in reply to had as a destination.) 
+
 ## [2.10] - 2016-06-17
 
 A Snabb NFV performance fix, which results in more reliable performance


### PR DESCRIPTION
The lwAFTR sends ICMPv6 unreachable (code 5) messages if it gets a message
from a bad softwire (ie, from a B4 that is not in the binding table, or to
a br address that is not associated with that B4). If a br address can be
associated with the IPv6 address being replied to, use that as the source
address; otherwise, use the IPv6 address it was sent to.
