### PR TITLE
Make ntohl/htonl unsigned

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -871,14 +871,14 @@ Returns a copy of *array*. *Array* must not be a "sparse array".
 — Function **lib.htons** *n*
 
 Host to network byte order conversion functions for 32 and 16 bit
-integers *n* respectively.
+integers *n* respectively. Unsigned.
 
 — Function **lib.ntohl** *n*
 
 — Function **lib.ntohs** *n*
 
 Network to host byte order conversion functions for 32 and 16 bit
-integers *n* respectively.
+integers *n* respectively. Unsigned.
 
 
 

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -10,6 +10,8 @@ require("core.clib_h")
 local bit = require("bit")
 local band, bor, bnot, lshift, rshift, bswap =
    bit.band, bit.bor, bit.bnot, bit.lshift, bit.rshift, bit.bswap
+local tonumber = tonumber -- Yes, this makes a performance difference.
+local cast = ffi.cast
 
 -- Returns true if x and y are structurally similar (isomorphic).
 function equal (x, y)
@@ -373,7 +375,8 @@ if ffi.abi("be") then
    function htonl(b) return b end
    function htons(b) return b end
 else
-   function htonl(b) return bswap(b) end
+  -- htonl is unsigned, matching the C version and expectations.
+   function htonl(b) return tonumber(cast('uint32_t', bswap(b))) end
    function htons(b) return rshift(bswap(b), 16) end
 end
 ntohl = htonl


### PR DESCRIPTION
This is the behavior in C, and which most code expects.
This also documents that ntohl/htonl are unsigned.
There should be no performance impact; the assembly code has
the same number of the essentially the same instructions as before.
