### PR TITLE
Add Hydra mode and filename support to bench CSV output

### DIFF
--- a/src/lib/lua/alt_getopt.lua
+++ b/src/lib/lua/alt_getopt.lua
@@ -24,8 +24,6 @@ local type, pairs, ipairs, io, os = type, pairs, ipairs, io, os
 module (...)
 
 local function convert_short2long (opts)
-   local i = 1
-   local len = #opts
    local ret = {}
 
    for short_opt, accept_arg in opts:gmatch("(%w)(:?)") do

--- a/src/program/lwaftr/bench/README
+++ b/src/program/lwaftr/bench/README
@@ -2,17 +2,21 @@ Usage: bench CONF IPV4-IN.PCAP IPV6-IN.PCAP
 
   -h, --help
                              Print usage information.
-  -D DURATION, --duration DURATION
-                             Duration in seconds.
   -y HYDRA, --hydra
                              Hydra mode: emit CSV data in the format expected
                              by the Hydra reports. For instance:
 
                                benchmark,snabb,id,score,unit
 
-                             rather than
+                             rather than the default:
 
                                Time (s),Decap. MPPS,Decap. Gbps,Encap. MPPS,Encap. Gbps
+  -f FILENAME, --filename FILENAME
+                             The file or path name to which CSV data is written.
+                             A simple filename or relative pathname will be based
+                             on the current directory. Default is "bench.csv".
+  -D DURATION, --duration DURATION
+                             Duration in seconds.
 
 Run the lwAFTR with input from IPV4-IN.PCAP and IPV6-IN.PCAP. The bench
 command is used to get an idea of the raw speed of the lwaftr without

--- a/src/program/lwaftr/bench/README
+++ b/src/program/lwaftr/bench/README
@@ -2,9 +2,24 @@ Usage: bench CONF IPV4-IN.PCAP IPV6-IN.PCAP
 
   -h, --help
                              Print usage information.
+  -D DURATION, --duration DURATION
+                             Duration in seconds.
+  -y HYDRA, --hydra
+                             Hydra mode: emit CSV data in the format expected
+                             by the Hydra reports. For instance:
+
+                               benchmark,snabb,id,score,unit
+
+                             rather than
+
+                               Time (s),decap MPPS,decap Gbps,encap MPPS,encap Gbps
 
 Run the lwAFTR with input from IPV4-IN.PCAP and IPV6-IN.PCAP. The bench
 command is used to get an idea of the raw speed of the lwaftr without
 interaction with NICs, or check the impact of changes on a development
 machine that may not have Intel 82599 NICs.  Exit when finished.  This
 program is used in the lwAFTR test suite.
+
+Packets are counted and recorded, and the corresponding incoming and outgoing
+packet rates are written to standard output in CSV format, suitable for passing
+to a graphing program.

--- a/src/program/lwaftr/bench/README
+++ b/src/program/lwaftr/bench/README
@@ -25,5 +25,5 @@ machine that may not have Intel 82599 NICs.  Exit when finished.  This
 program is used in the lwAFTR test suite.
 
 Packets are counted and recorded, and the corresponding incoming and outgoing
-packet rates are written to standard output in CSV format, suitable for passing
-to a graphing program.
+packet rates are written to a file in CSV format, suitable for passing to a
+graphing program.

--- a/src/program/lwaftr/bench/README
+++ b/src/program/lwaftr/bench/README
@@ -12,7 +12,7 @@ Usage: bench CONF IPV4-IN.PCAP IPV6-IN.PCAP
 
                              rather than
 
-                               Time (s),decap MPPS,decap Gbps,encap MPPS,encap Gbps
+                               Time (s),Decap. MPPS,Decap. Gbps,Encap. MPPS,Encap. Gbps
 
 Run the lwAFTR with input from IPV4-IN.PCAP and IPV6-IN.PCAP. The bench
 command is used to get an idea of the raw speed of the lwaftr without

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -14,13 +14,16 @@ end
 function parse_args(args)
    local handlers = {}
    local opts = {}
+   opts.filename = "bench.csv"
    function handlers.D(arg)
       opts.duration = assert(tonumber(arg), "duration must be a number")
       assert(opts.duration >= 0, "duration can't be negative")
    end
-   function handlers.h() show_usage(0) end
+   function handlers.f(arg) opts.filename = arg end
    function handlers.y() opts.hydra = true end
-   args = lib.dogetopt(args, handlers, "hyD:", { help="h", hydra="y", duration="D" })
+   function handlers.h() show_usage(0) end
+   args = lib.dogetopt(args, handlers, "hyf:D:", {
+      help="h", hydra="y", filename="f", duration="D" })
    if #args ~= 3 then show_usage(1) end
    return opts, unpack(args)
 end
@@ -33,7 +36,7 @@ function run(args)
    setup.load_bench(c, conf, inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
    app.configure(c)
 
-   local csv = csv_stats.CSVStatsTimer:new(nil, opts.hydra)
+   local csv = csv_stats.CSVStatsTimer:new(opts.filename, opts.hydra)
    csv:add_app('sinkv4', { 'input' }, { input=opts.hydra and 'decap' or 'Decap.' })
    csv:add_app('sinkv6', { 'input' }, { input=opts.hydra and 'encap' or 'Encap.' })
    csv:activate()

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -34,10 +34,8 @@ function run(args)
    app.configure(c)
 
    local csv = csv_stats.CSVStatsTimer:new(nil, opts.hydra)
-   local decap = opts.hydra and 'decap' or 'Decap.'
-   local encap = opts.hydra and 'encap' or 'Encap.'
-   csv:add_app('sinkv4', { 'input' }, { input=decap })
-   csv:add_app('sinkv6', { 'input' }, { input=encap })
+   csv:add_app('sinkv4', { 'input' }, { input=opts.hydra and 'decap' or 'Decap.' })
+   csv:add_app('sinkv6', { 'input' }, { input=opts.hydra and 'encap' or 'Encap.' })
    csv:activate()
 
    app.busywait = true

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -19,7 +19,8 @@ function parse_args(args)
       assert(opts.duration >= 0, "duration can't be negative")
    end
    function handlers.h() show_usage(0) end
-   args = lib.dogetopt(args, handlers, "hD:", { help="h", duration="D" })
+   function handlers.y() opts.hydra = true end
+   args = lib.dogetopt(args, handlers, "hyD:", { help="h", hydra="y", duration="D" })
    if #args ~= 3 then show_usage(1) end
    return opts, unpack(args)
 end
@@ -32,9 +33,11 @@ function run(args)
    setup.load_bench(c, conf, inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
    app.configure(c)
 
-   local csv = csv_stats.CSVStatsTimer.new()
-   csv:add_app('sinkv4', { 'input' }, { input='Decapsulation' })
-   csv:add_app('sinkv6', { 'input' }, { input='Encapsulation' })
+   local csv = csv_stats.CSVStatsTimer:new(nil, opts.hydra)
+   local decap = opts.hydra and 'decap' or 'Decap.'
+   local encap = opts.hydra and 'encap' or 'Encap.'
+   csv:add_app('sinkv4', { 'input' }, { input=decap })
+   csv:add_app('sinkv6', { 'input' }, { input=encap })
    csv:activate()
 
    app.busywait = true

--- a/src/program/lwaftr/csv_stats.lua
+++ b/src/program/lwaftr/csv_stats.lua
@@ -88,10 +88,10 @@ function CSVStatsTimer:tick()
    local elapsed = engine.now() - self.start
    local dt = elapsed - self.prev_elapsed
    self.prev_elapsed = elapsed
-   if self.hydra_mode then
+   if not self.hydra_mode then
       -- Hydra reports seem to prefer integers for the X axis.
-      elapsed = math.ceil(elapsed)
-   else
+--      elapsed = math.ceil(elapsed)
+--   else
       self.file:write(('%f'):format(elapsed))
    end
    for _,data in ipairs(self.link_data) do
@@ -103,9 +103,10 @@ function CSVStatsTimer:tick()
       data.prev_txbytes = txbytes
       if self.hydra_mode then
          -- TODO: put the actual branch name in place of "master".
-         self.file:write(('%s_mpps,master,%i,%f,mpps\n'):format(
+         -- Hydra reports seem to prefer integers for the X (time) axis.
+         self.file:write(('%s_mpps,master,%.f,%f,mpps\n'):format(
             data.link_name,elapsed,diff_txpackets))
-         self.file:write(('%s_gbps,master,%i,%f,gbps\n'):format(
+         self.file:write(('%s_gbps,master,%.f,%f,gbps\n'):format(
             data.link_name,elapsed,diff_txbytes))
       else
          self.file:write((',%f'):format(diff_txpackets))

--- a/src/program/lwaftr/csv_stats.lua
+++ b/src/program/lwaftr/csv_stats.lua
@@ -89,9 +89,6 @@ function CSVStatsTimer:tick()
    local dt = elapsed - self.prev_elapsed
    self.prev_elapsed = elapsed
    if not self.hydra_mode then
-      -- Hydra reports seem to prefer integers for the X axis.
---      elapsed = math.ceil(elapsed)
---   else
       self.file:write(('%f'):format(elapsed))
    end
    for _,data in ipairs(self.link_data) do

--- a/src/program/lwaftr/csv_stats.lua
+++ b/src/program/lwaftr/csv_stats.lua
@@ -8,9 +8,29 @@ CSVStatsTimer = {}
 
 -- A timer that monitors packet rate and bit rate on a set of links,
 -- printing the data out to a CSV file.
-function CSVStatsTimer:new(filename)
+--
+-- Standard mode example (default):
+--
+-- Time (s),decap MPPS,decap Gbps,encap MPPS,encap Gbps
+-- 0.999197,3.362784,13.720160,3.362886,15.872824
+-- 1.999181,3.407569,13.902880,3.407569,16.083724
+--
+-- Hydra mode example:
+--
+-- benchmark,snabb,id,score,unit
+-- decap_mpps,master,1,3.362784,mpps
+-- decap_gbps,master,1,13.720160,gbps
+-- encap_mpps,master,1,3.362886,mpps
+-- encap_gbps,master,1,15.872824,gbps
+-- decap_mpps,master,2,3.407569,mpps
+-- decap_gbps,master,2,13.902880,gbps
+-- encap_mpps,master,2,3.407569,mpps
+-- encap_gbps,master,2,16.083724,gbps
+--
+function CSVStatsTimer:new(filename, hydra_mode)
    local file = filename and io.open(filename, "w") or io.stdout
-   local o = { header='Time (s)', link_data={}, file=file, period=1 }
+   local o = { hydra_mode=hydra_mode, link_data={}, file=file, period=1,
+      header = hydra_mode and "benchmark,snabb,id,score,unit" or "Time (s)" }
    return setmetatable(o, {__index = CSVStatsTimer})
 end
 
@@ -20,10 +40,13 @@ end
 -- human-readable names, for the column headers.
 function CSVStatsTimer:add_app(id, links, link_names)
    local function add_link_data(name, link)
-      local pretty_name = (link_names and link_names[name]) or name
-      local h = (',%s MPPS,%s Gbps'):format(pretty_name, pretty_name)
-      self.header = self.header..h
+      local link_name = link_names and link_names[name] or name
+      if not self.hydra_mode then
+         local h = (',%s MPPS,%s Gbps'):format(link_name, link_name)
+         self.header = self.header..h
+      end
       local data = {
+         link_name = link_name,
          txpackets = link.stats.txpackets,
          txbytes = link.stats.txbytes,
       }
@@ -65,17 +88,32 @@ function CSVStatsTimer:tick()
    local elapsed = engine.now() - self.start
    local dt = elapsed - self.prev_elapsed
    self.prev_elapsed = elapsed
-   self.file:write(('%f'):format(elapsed))
+   if self.hydra_mode then
+      -- Hydra reports seem to prefer integers for the X axis.
+      elapsed = math.ceil(elapsed)
+   else
+      self.file:write(('%f'):format(elapsed))
+   end
    for _,data in ipairs(self.link_data) do
       local txpackets = counter.read(data.txpackets)
       local txbytes = counter.read(data.txbytes)
-      local diff_txpackets = tonumber(txpackets - data.prev_txpackets)
-      local diff_txbytes = tonumber(txbytes - data.prev_txbytes)
+      local diff_txpackets = tonumber(txpackets - data.prev_txpackets) / dt / 1e6
+      local diff_txbytes = tonumber(txbytes - data.prev_txbytes) * 8 / dt / 1e9
       data.prev_txpackets = txpackets
       data.prev_txbytes = txbytes
-      self.file:write((',%f'):format(diff_txpackets / dt / 1e6))
-      self.file:write((',%f'):format(diff_txbytes * 8 / dt / 1e9))
+      if self.hydra_mode then
+         -- TODO: put the actual branch name in place of "master".
+         self.file:write(('%s_mpps,master,%i,%f,mpps\n'):format(
+            data.link_name,elapsed,diff_txpackets))
+         self.file:write(('%s_gbps,master,%i,%f,gbps\n'):format(
+            data.link_name,elapsed,diff_txbytes))
+      else
+         self.file:write((',%f'):format(diff_txpackets))
+         self.file:write((',%f'):format(diff_txbytes))
+      end
    end
-   self.file:write('\n')
+   if not self.hydra_mode then
+      self.file:write('\n')
+   end
    self.file:flush()
 end

--- a/src/program/lwaftr/run/README
+++ b/src/program/lwaftr/run/README
@@ -17,8 +17,3 @@ Optional arguments:
                                 address set by "lwaftr monitor".
        -D       <seconds>       Duration in seconds
        -v                       Verbose (repeat for more verbosity)
-
-When the -v option is used at least once, packets on the network interfaces
-are counted and recorded, and the corresponding incoming and outgoing packet
-rates are written to standard output in CSV format, suitable for passing to
-a graphing program.

--- a/src/program/lwaftr/run/README
+++ b/src/program/lwaftr/run/README
@@ -17,3 +17,8 @@ Optional arguments:
                                 address set by "lwaftr monitor".
        -D       <seconds>       Duration in seconds
        -v                       Verbose (repeat for more verbosity)
+
+When the -v option is used at least once, packets on the network interfaces
+are counted and recorded, and the corresponding incoming and outgoing packet
+rates are written to standard output in CSV format, suitable for passing to
+a graphing program.


### PR DESCRIPTION
This does two things to the lwAftr `bench` command:
- it adds support for a different CSV data format, needed for running Hydra automated benchmarks;
- it makes the command emit data to a file instead of stdout (with support for choosing it), which is not reliable because of #463.
