### PR TITLE
use integer for instance id and add name tag for the nic id

### DIFF
--- a/src/program/snabbvmx/query/example1.xml
+++ b/src/program/snabbvmx/query/example1.xml
@@ -1,6 +1,7 @@
 <snabb>
   <instance>
-   <id>xe0</id>
+   <id>0</id>
+   <name>xe0</name>
    <pid>544</pid>
    <next_hop_mac_v4>02:02:02:02:02:02</next_hop_mac_v4>
    <next_hop_mac_v6>02:02:02:02:02:02</next_hop_mac_v6>

--- a/src/program/snabbvmx/query/example2.xml
+++ b/src/program/snabbvmx/query/example2.xml
@@ -1,6 +1,7 @@
 <snabb>
   <instance>
-   <id>xe0</id>
+   <id>0</id>
+   <name>xe0</name>
    <pid>471</pid>
    <next_hop_mac_v4>00:00:00:00:00:00</next_hop_mac_v4>
    <next_hop_mac_v6>00:00:00:00:00:00</next_hop_mac_v6>
@@ -236,7 +237,8 @@
    </links>
   </instance>
   <instance>
-   <id>xe1</id>
+   <id>1</id>
+   <name>xe1</name>
    <pid>476</pid>
    <next_hop_mac_v4>00:00:00:00:00:00</next_hop_mac_v4>
    <next_hop_mac_v6>00:00:00:00:00:00</next_hop_mac_v6>

--- a/src/program/snabbvmx/query/query.lua
+++ b/src/program/snabbvmx/query/query.lua
@@ -109,19 +109,23 @@ function run (raw_args)
    parse_args(raw_args)
    print("<snabb>")
    local pids = {}
+   local pids_name = {}
    for _, pid in ipairs(shm.children("/")) do
      if shm.exists("/"..pid.."/nic/id") then
        local lwaftr_id = shm.open("/"..pid.."/nic/id", lwtypes.lwaftr_id_type)
-       local instance_id = ffi.string(lwaftr_id.value)
+       local instance_id_name = ffi.string(lwaftr_id.value)
+       local _, _, instance_id = string.find(instance_id_name, "(%d+)")
        if instance_id then
          pids[instance_id] = pid
+         pids_name[instance_id] = instance_id_name
        end
      end
    end
    for _, instance_id in ipairs(sort(keys(pids))) do
      local pid = pids[instance_id]
      print("  <instance>")
-     print(("   <id>%s</id>"):format(instance_id))
+     print(("   <id>%d</id>"):format(instance_id))
+     print(("   <name>%s</name>"):format(pids_name[instance_id]))
      print(("   <pid>%d</pid>"):format(pid))
      print_next_hop(pid, "next_hop_mac_v4")
      print_next_hop(pid, "next_hop_mac_v6")

--- a/src/program/snabbvmx/query/query.lua
+++ b/src/program/snabbvmx/query/query.lua
@@ -114,7 +114,7 @@ function run (raw_args)
      if shm.exists("/"..pid.."/nic/id") then
        local lwaftr_id = shm.open("/"..pid.."/nic/id", lwtypes.lwaftr_id_type)
        local instance_id_name = ffi.string(lwaftr_id.value)
-       local _, _, instance_id = string.find(instance_id_name, "(%d+)")
+       local instance_id = instance_id_name and instance_id_name:match("(%d+)")
        if instance_id then
          pids[instance_id] = pid
          pids_name[instance_id] = instance_id_name


### PR DESCRIPTION
Snabb instances are now configured via IETF softwire br-instances, identified via br-instance, which is a uint32. This pull request changes the id to match that br-instance value by extracting the value from the NIC id (e.g. xe0, xe1, xe2) and adding a separate <name>nic_id</name> tag.
Examples are updated to reflect that change.
