### PR TITLE
lwaftr tests: /bin/sh instead of /usr/bin/env bash

### DIFF
--- a/src/program/lwaftr/tests/data/add-vlan.sh
+++ b/src/program/lwaftr/tests/data/add-vlan.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # https://en.wikipedia.org/wiki/IEEE_802.1Q 
 # 802.1q payload:

--- a/src/program/lwaftr/tests/end-to-end/benchmark-end-to-end.sh
+++ b/src/program/lwaftr/tests/end-to-end/benchmark-end-to-end.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 SNABB_BASE=../../../..
 TEST_BASE=../data

--- a/src/program/lwaftr/tests/end-to-end/core-end-to-end.sh
+++ b/src/program/lwaftr/tests/end-to-end/core-end-to-end.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root" 1>&2
@@ -88,7 +88,7 @@ function snabb_run_and_cmp {
    fi
 }
 
-source "test_env.sh"
+. ./test_env.sh
 
 TEST_OUT="/tmp"
 SNABB_LWAFTR="../../../../snabb lwaftr"

--- a/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end-vlan.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 TEST_BASE=../data/vlan ./core-end-to-end.sh $@

--- a/src/program/lwaftr/tests/end-to-end/end-to-end.sh
+++ b/src/program/lwaftr/tests/end-to-end/end-to-end.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 TEST_BASE=../data ./core-end-to-end.sh $@

--- a/src/program/lwaftr/tests/end-to-end/test_env.sh
+++ b/src/program/lwaftr/tests/end-to-end/test_env.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/bin/sh
 
 COUNTERS="../data/counters"
 EMPTY="../data/empty.pcap"

--- a/src/program/lwaftr/tests/qemu-b4/run-b4-tap
+++ b/src/program/lwaftr/tests/qemu-b4/run-b4-tap
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 
 exec qemu-system-x86_64 -enable-kvm \
 	-M pc-q35-2.0 \

--- a/src/program/lwaftr/tests/qemu-b4/tap-b4
+++ b/src/program/lwaftr/tests/qemu-b4/tap-b4
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/bin/sh
+
 echo "Configuring $1"
 ifconfig $1 up
 if [[ $1 == aftr ]] ; then

--- a/src/program/lwaftr/tests/soaktest/core-soaktest.sh
+++ b/src/program/lwaftr/tests/soaktest/core-soaktest.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root" 1>&2

--- a/src/program/lwaftr/tests/soaktest/soaktest-vlan.sh
+++ b/src/program/lwaftr/tests/soaktest/soaktest-vlan.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 TEST_BASE=../data/vlan ./core-soaktest.sh $@

--- a/src/program/lwaftr/tests/soaktest/soaktest.sh
+++ b/src/program/lwaftr/tests/soaktest/soaktest.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 TEST_BASE=../data ./core-soaktest.sh $@


### PR DESCRIPTION
This lets the tests run on a default GuixSD environment, which lacks
/usr/bin/env.
