### PR TITLE
Set monitor by id

### DIFF
--- a/src/program/lwaftr/monitor/monitor.lua
+++ b/src/program/lwaftr/monitor/monitor.lua
@@ -3,11 +3,11 @@ module(..., package.seeall)
 local ffi = require("ffi")
 local ipv4 = require("lib.protocol.ipv4")
 local lib = require("core.lib")
+local lwtypes = require("apps.lwaftr.lwtypes")
 local lwutil = require("apps.lwaftr.lwutil")
 local shm = require("core.shm")
 
-local fatal, file_exists = lwutil.fatal, lwutil.file_exists
-local uint32_ptr_t = ffi.typeof('uint32_t*')
+local fatal = lwutil.fatal
 
 local long_opts = {
    help = "h"
@@ -28,6 +28,8 @@ local function parse_args (args)
    end
    args = lib.dogetopt(args, handlers, "h", long_opts)
    if #args < 1 or #args > 2 then usage(1) end
+
+   -- Return address and pid.
    if #args == 1 then
       local maybe_pid = tonumber(args[1])
       if maybe_pid then
@@ -38,57 +40,86 @@ local function parse_args (args)
    return args[1], args[2]
 end
 
-local function ipv4_to_num (addr)
-   local arr = ipv4:pton(addr)
-   return arr[3] * 2^24 + arr[2] * 2^16 + arr[1] * 2^8 + arr[0]
-end
-
-local function find_lwaftr_process (pid)
-   -- Check process has v4v6_mirror defined.
-   if pid then
-      pid = assert(tonumber(pid), ("Incorrect PID value: '%s'"):format(pid))
-      local v4v6_mirror = "/"..pid.."/v4v6_mirror"
-      if not file_exists(shm.root..v4v6_mirror) then
-         fatal(("lwAFTR process '%d' is not running in mirroring mode"):format(pid))
-      end
-      return v4v6_mirror
-   end
-
-   -- Return first process which has v4v6_mirror defined.
+local function find_pid_by_id (id)
    for _, pid in ipairs(shm.children("/")) do
-      pid = tonumber(pid)
-      if pid then
-         local v4v6_mirror = "/"..pid.."/v4v6_mirror"
-         if file_exists(shm.root..v4v6_mirror) then
-            return v4v6_mirror
+      local path = "/"..pid.."/nic/id"
+      if shm.exists(path) then
+         local lwaftr_id = shm.open(path, lwtypes.lwaftr_id_type)
+         if ffi.string(lwaftr_id.value) == id then
+            return pid
          end
       end
    end
 end
 
+local function find_mirror_path (pid)
+   -- Check process has v4v6_mirror defined.
+   if pid then
+      -- Pid is an id.
+      if not tonumber(pid) then
+         pid = find_pid_by_id(pid)
+         if not pid then
+            fatal("Invalid lwAFTR id '%s'"):format(pid)
+         end
+      end
+      -- Pid exists?
+      if not shm.exists("/"..pid) then
+         fatal(("No Snabb instance with pid '%d'"):format(pid))
+      end
+      -- Check process has v4v6_mirror defined.
+      local path = "/"..pid.."/v4v6_mirror"
+      if not shm.exists(path) then
+         fatal(("lwAFTR process '%d' is not running in mirroring mode"):format(pid))
+      end
+      return path, pid
+   end
+
+   -- Return first process which has v4v6_mirror defined.
+   for _, pid in ipairs(shm.children("/")) do
+      local path = "/"..pid.."/v4v6_mirror"
+      if shm.exists(path) then
+         return path, pid
+      end
+   end
+end
+
+local function set_mirror_address (address, path)
+   local function ipv4_to_num (addr)
+      local arr = ipv4:pton(addr)
+      return arr[3] * 2^24 + arr[2] * 2^16 + arr[1] * 2^8 + arr[0]
+   end
+
+   -- Validate address.
+   if address == "none" then
+      print("Monitor none")
+      address = MIRROR_NOTHING
+   elseif address == "all" then
+      print("Monitor all")
+      address = MIRROR_EVERYTHING
+   else
+      if not ipv4:pton(address) then
+         fatal(("Invalid action or incorrect IPv4 address: '%s'"):format(address))
+      end
+   end
+
+   -- Set v4v6_mirror.
+   local ipv4_num = ipv4_to_num(address)
+   local v4v6_mirror = shm.open(path, "struct { uint32_t ipv4; }")
+   v4v6_mirror.ipv4 = ipv4_num
+   shm.unmap(v4v6_mirror)
+end
+
 function run (args)
-   local action, pid = parse_args(args)
-   local path = find_lwaftr_process(pid)
+   local address, pid = parse_args(args)
+   local path, pid_number = find_mirror_path(pid)
    if not path then
       fatal("Couldn't find lwAFTR process running in mirroring mode")
    end
 
-   local ipv4_address
-   if action == "none" then
-      print("Monitor none")
-      ipv4_address = MIRROR_NOTHING
-   elseif action == "all" then
-      print("Monitor all")
-      ipv4_address = MIRROR_EVERYTHING
-   else
-      assert(ipv4:pton(action),
-            ("Invalid action or incorrect IPv4 address: '%s'"):format(action))
-      ipv4_address = action
-      print(("Mirror address set to '%s'"):format(ipv4_address))
+   set_mirror_address(address, path)
+   io.write(("Mirror address set to '%s'"):format(address))
+   if not tonumber(pid) then
+      io.write((" in PID '%d'"):format(pid_number))
    end
-
-   local ipv4_num = ipv4_to_num(ipv4_address)
-   local v4v6_mirror = shm.open(path, "struct { uint32_t ipv4; }")
-   v4v6_mirror.ipv4 = ipv4_num
-   shm.unmap(v4v6_mirror)
+   io.write("\n")
 end


### PR DESCRIPTION
- Allows to use an id instead of PID.
- Clean up code and remove unused variables.
