### PR TITLE
Implement headroom by moving packet around

### DIFF
--- a/src/apps/ipv6/nd_light.lua
+++ b/src/apps/ipv6/nd_light.lua
@@ -109,7 +109,6 @@ function nd_light:new (arg)
    -- Prepare packet for solicitation of next hop
    local nh = { nsent = 0 }
    local dgram = datagram:new()
-   nh.packet = dgram:packet()
    local sol_node_mcast = ipv6:solicited_node_mcast(conf.next_hop)
    local ipv6 = ipv6:new({ next_header = 58, -- ICMP6
          hop_limit = 255,
@@ -134,6 +133,7 @@ function nd_light:new (arg)
    dgram:push(ethernet:new({ src = conf.local_mac,
                              dst = ethernet:ipv6_mcast(sol_node_mcast),
                              type = 0x86dd }))
+   nh.packet = dgram:packet()
    dgram:free()
 
    -- Timer for retransmits of neighbor solicitations
@@ -162,7 +162,6 @@ function nd_light:new (arg)
    -- Prepare packet for solicited neighbor advertisement
    local sna = {}
    dgram = datagram:new()
-   sna.packet = dgram:packet()
    -- Leave dst address unspecified.  It will be set to the source of
    -- the incoming solicitation
    ipv6 = ipv6:new({ next_header = 58, -- ICMP6
@@ -183,6 +182,8 @@ function nd_light:new (arg)
    -- Leave dst address unspecified.
    dgram:push(ethernet:new({ src = conf.local_mac,
                              type = 0x86dd }))
+   sna.packet = dgram:packet()
+
    -- Parse the headers we want to modify later on from our template
    -- packet.
    dgram = dgram:new(sna.packet, ethernet)

--- a/src/apps/keyed_ipv6_tunnel/tunnel.lua
+++ b/src/apps/keyed_ipv6_tunnel/tunnel.lua
@@ -189,7 +189,7 @@ function SimpleKeyedTunnel:push()
 
    while not link.empty(l_in) do
       local p = link.receive(l_in)
-      packet.prepend(p, self.header, HEADER_SIZE)
+      p = packet.prepend(p, self.header, HEADER_SIZE)
       local plength = ffi.cast(plength_ctype, p.data + LENGTH_OFFSET)
       plength[0] = lib.htons(SESSION_COOKIE_SIZE + p.length - HEADER_SIZE)
       link.transmit(l_out, p)
@@ -244,7 +244,7 @@ function SimpleKeyedTunnel:push()
          -- discard packet
          packet.free(p)
       else
-         packet.shiftleft(p, HEADER_SIZE)
+         p = packet.shiftleft(p, HEADER_SIZE)
          link.transmit(l_out, p)
       end
    end

--- a/src/apps/lwaftr/arp.lua
+++ b/src/apps/lwaftr/arp.lua
@@ -94,6 +94,7 @@ function form_request(src_eth, src_ipv4, dst_ipv4)
    local dgram = datagram:new(req_pkt)
    dgram:push(ethernet:new({ src = src_eth, dst = ethernet_broadcast,
                              type = ethertype_arp }))
+   req_pkt = dgram:packet()
    dgram:free()
    return req_pkt
 end
@@ -107,6 +108,7 @@ function form_reply(local_eth, local_ipv4, arp_request_pkt)
    local dgram = datagram:new(reply_pkt)
    dgram:push(ethernet:new({ src = local_eth, dst = dst_eth,
                              type = ethertype_arp }))
+   reply_pkt = dgram:packet()
    dgram:free()
    return reply_pkt
 end

--- a/src/apps/lwaftr/fragmentv4_hardened.lua
+++ b/src/apps/lwaftr/fragmentv4_hardened.lua
@@ -149,13 +149,6 @@ local function fix_pkt_checksum(pkt)
         htons(ipsum(pkt.data + ehs, ihl, 0)))
 end
 
-local function pseudo_clone(data, len)
-   local p = packet.allocate()
-   p.headroom = 0
-   packet.append(p, data, len)
-   return p
-end
-
 local function attempt_reassembly(frags_table, reassembly_buf, fragment)
    local ihl = get_ihl_from_offset(fragment, ehs)
    local frag_id = get_frag_id(fragment)
@@ -213,8 +206,8 @@ local function attempt_reassembly(frags_table, reassembly_buf, fragment)
       local pkt_len = htons(reassembly_buf.reassembly_length - ehs)
       local o_len = ehs + o_ipv4_total_length
       wr16(reassembly_data + o_len, pkt_len)
-      local reassembled_packet = pseudo_clone(reassembly_buf.reassembly_data,
-                                              reassembly_buf.reassembly_length)
+      local reassembled_packet = packet.from_pointer(
+         reassembly_buf.reassembly_data, reassembly_buf.reassembly_length)
       fix_pkt_checksum(reassembled_packet)
       free_reassembly_buf_and_pkt(fragment, frags_table)
       return REASSEMBLY_OK, reassembled_packet

--- a/src/apps/lwaftr/fragmentv6_hardened.lua
+++ b/src/apps/lwaftr/fragmentv6_hardened.lua
@@ -145,13 +145,6 @@ local function reassembly_status(reassembly_buf)
    return REASSEMBLY_OK
 end
 
-local function pseudo_clone(data, len)
-   local p = packet.allocate()
-   p.headroom = 0
-   packet.append(p, data, len)
-   return p
-end
-
 local function attempt_reassembly(frags_table, reassembly_buf, fragment)
    local frag_id = get_frag_id(fragment)
    if frag_id ~= reassembly_buf.fragment_id then -- unreachable
@@ -204,8 +197,8 @@ local function attempt_reassembly(frags_table, reassembly_buf, fragment)
 
    local restatus = reassembly_status(reassembly_buf)
    if restatus == REASSEMBLY_OK then
-      local reassembled_packet = pseudo_clone(reassembly_buf.reassembly_data,
-                                              reassembly_buf.reassembly_length)
+      local reassembled_packet = packet.from_pointer(
+         reassembly_buf.reassembly_data, reassembly_buf.reassembly_length)
       free_reassembly_buf_and_pkt(fragment, frags_table)
       return REASSEMBLY_OK, reassembled_packet
    else

--- a/src/apps/lwaftr/generator.lua
+++ b/src/apps/lwaftr/generator.lua
@@ -277,7 +277,7 @@ function ipv6_encapsulate(ipv4_pkt, params)
 
    local payload_length = p.length - ethernet_header_size
    local dscp_and_ecn = p.data[ethernet_header_size + IPV4_DSCP_AND_ECN_OFFSET]
-   packet.shiftright(p, ipv6_header_size)
+   p = packet.shiftright(p, ipv6_header_size)
 
    -- IPv6 packet is tagged
    local eth_hdr

--- a/src/apps/lwaftr/icmp.lua
+++ b/src/apps/lwaftr/icmp.lua
@@ -85,8 +85,9 @@ function new_icmpv4_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, config
                                  protocol = constants.proto_icmp,
                                  src = from_ip, dst = to_ip})
    dgram:push(ipv4_header)
+   new_pkt = dgram:packet()
    ipv4_header:free()
-   packet.shiftright(new_pkt, ehs)
+   new_pkt = packet.shiftright(new_pkt, ehs)
    write_eth_header(new_pkt.data, from_eth, to_eth, constants.n_ethertype_ipv4, config.vlan_tag)
 
    -- Generate RFC 1812 ICMPv4 packets, which carry as much payload as they can,
@@ -126,7 +127,7 @@ function new_icmpv6_packet(from_eth, to_eth, from_ip, to_ip, initial_pkt, config
                                  next_header = constants.proto_icmpv6,
                                  src = from_ip, dst = to_ip})
    dgram:push(ipv6_header)
-   packet.shiftright(new_pkt, ehs)
+   new_pkt = packet.shiftright(dgram:packet(), ehs)
    write_eth_header(new_pkt.data, from_eth, to_eth, constants.n_ethertype_ipv6)
 
    local max_size = constants.max_icmpv6_packet_size

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -490,7 +490,7 @@ local function encapsulate_and_transmit(lwstate, pkt, ipv6_dst, ipv6_src, pkt_sr
    local l3_header = get_ethernet_payload(pkt)
    local dscp_and_ecn = get_ipv4_dscp_and_ecn(l3_header)
    -- Note that this may invalidate any pointer into pkt.data.  Be warned!
-   packet.shiftright(pkt, ipv6_fixed_header_size)
+   pkt = packet.shiftright(pkt, ipv6_fixed_header_size)
    -- Fetch possibly-moved L3 header location.
    l3_header = get_ethernet_payload(pkt)
    write_eth_header(pkt.data, ether_src, ether_dst, n_ethertype_ipv6)
@@ -732,7 +732,7 @@ local function flush_decapsulation(lwstate)
           and ipv6_equals(get_ipv6_dst_address(ipv6_header), br_addr)) then
          -- Source softwire is valid; decapsulate and forward.
          -- Note that this may invalidate any pointer into pkt.data.  Be warned!
-         packet.shiftleft(pkt, ipv6_fixed_header_size)
+         pkt = packet.shiftleft(pkt, ipv6_fixed_header_size)
          write_eth_header(pkt.data, lwstate.aftr_mac_inet_side, lwstate.inet_mac,
                           n_ethertype_ipv4)
          transmit_ipv4(lwstate, pkt)

--- a/src/apps/lwaftr/ndp.lua
+++ b/src/apps/lwaftr/ndp.lua
@@ -222,17 +222,18 @@ function form_ns(local_eth, local_ipv6, dst_ipv6)
    local i = ipv6:new({ hop_limit = hop_limit, 
                         next_header = proto_icmpv6,
                         src = local_ipv6, dst = dst_ipv6 })
-   i:payload_length(ns_pkt.length)
+   i:payload_length(dgram:packet().length)
    
-   local ph = i:pseudo_header(ns_pkt.length, proto_icmpv6)
+   local ph = i:pseudo_header(dgram:packet().length, proto_icmpv6)
    local ph_len = ipv6_pseudoheader_size
    local base_checksum = checksum.ipsum(ffi.cast("uint8_t*", ph), ph_len, 0)
-   local csum = checksum.ipsum(ns_pkt.data, ns_pkt.length, bit.bnot(base_checksum))
-   wr16(ns_pkt.data + 2, C.htons(csum))
+   local csum = checksum.ipsum(dgram:packet().data, dgram:packet().length, bit.bnot(base_checksum))
+   wr16(dgram:packet().data + 2, C.htons(csum))
    
    dgram:push(i)
    dgram:push(ethernet:new({ src = local_eth, dst = ethernet_broadcast,
                              type = ethertype_ipv6 }))
+   ns_pkt = dgram:packet()
    dgram:free()
    return ns_pkt
 end
@@ -265,17 +266,19 @@ local function form_sna(local_eth, local_ipv6, is_router, soliciting_pkt)
    local i = ipv6:new({ hop_limit = hop_limit,
                         next_header = proto_icmpv6,
                         src = local_ipv6, dst = dst_ipv6 })
-   i:payload_length(na_pkt.length)
+   i:payload_length(dgram:packet().length)
    
-   local ph = i:pseudo_header(na_pkt.length, proto_icmpv6)
+   local ph = i:pseudo_header(dgram:packet().length, proto_icmpv6)
    local ph_len = ipv6_pseudoheader_size
    local base_checksum = checksum.ipsum(ffi.cast("uint8_t*", ph), ph_len, 0)
-   local csum = checksum.ipsum(na_pkt.data, na_pkt.length, bit.bnot(base_checksum))
-   wr16(na_pkt.data + 2, C.htons(csum))
+   local csum = checksum.ipsum(dgram:packet().data, dgram:packet().length,
+                               bit.bnot(base_checksum))
+   wr16(dgram:packet().data + 2, C.htons(csum))
    
    dgram:push(i)
    dgram:push(ethernet:new({ src = local_eth, dst = dst_eth,
                              type = ethertype_ipv6 }))
+   na_pkt = dgram:packet()
    dgram:free()
    return na_pkt
 end

--- a/src/apps/vpn/vpws.lua
+++ b/src/apps/vpn/vpws.lua
@@ -88,6 +88,7 @@ function vpws:push()
             datagram:push(encap.gre)
             datagram:push(encap.ipv6)
             datagram:push(encap.ether)
+            p = datagram:packet()
          else
             -- Check for encapsulated frame coming in on uplink
             if self._filter:match(datagram:payload()) then
@@ -115,6 +116,7 @@ function vpws:push()
                  -- Unsupported GRE options or flags
                   valid = false
                end
+               p = datagram:packet()
                if not valid then
                   packet.free(p)
                   p = nil

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -5,10 +5,7 @@ enum { PACKET_PAYLOAD_SIZE = 10*1024 };
 
 // Packet of network data, with associated metadata.
 struct packet {
-    unsigned char *data;
     uint16_t length;           // data payload length
-    uint16_t headroom;         // payload starts this many bytes into data_
-    uint32_t padding;
-    unsigned char data_[PACKET_PAYLOAD_SIZE];
+    unsigned char data[PACKET_PAYLOAD_SIZE];
 };
 

--- a/src/lib/protocol/datagram.lua
+++ b/src/lib/protocol/datagram.lua
@@ -147,7 +147,7 @@ function datagram:push_raw (data, length)
       -- The memmove() would invalidate the data pointer of headers
       -- that have already been parsed.
       assert(self._parse.index == 0, "parse stack not empty")
-      packet.prepend(self._packet[0], data, length)
+      self._packet[0] = packet.prepend(self._packet[0], data, length)
       self._parse.offset = self._parse.offset + length
    end
 end
@@ -277,7 +277,7 @@ function datagram:pop_raw (length, ulp)
       -- The memmove() would invalidate the data pointer of headers
       -- that have already been parsed.
       assert(self._parse.index == 0, "parse stack not empty")
-      packet.shiftleft(self._packet[0], length)
+      self._packet[0] = packet.shiftleft(self._packet[0], length)
    end
    if ulp then self._parse.ulp = ulp end
 end
@@ -347,6 +347,7 @@ function selftest ()
    dgram:push(l2tp)
    dgram:push(ip)
    dgram:push(ether)
+   p = dgram:packet()
    local _, p_size = dgram:payload(data, data_size)
    assert(p_size == data_size)
    local _, d_size = dgram:data()
@@ -379,7 +380,7 @@ function selftest ()
    dgram:commit()
    _, d_size = dgram:data()
    assert(d_size == ether2:sizeof() + ip2:sizeof() + l2tp:sizeof() + data_size)
-   dgram:new(p, ethernet, { delayed_commit = true })
+   dgram:new(dgram:packet(), ethernet, { delayed_commit = true })
    assert(ether2:eq(dgram:parse()))
    assert(ip2:eq(dgram:parse()))
    assert(l2tp:eq(dgram:parse()))

--- a/src/lib/virtio/virtq_driver.lua
+++ b/src/lib/virtio/virtq_driver.lua
@@ -96,7 +96,7 @@ function VirtioVirtq:add(p, len, flags, csum_start, csum_offset)
    self.num_free = self.num_free -1
    desc.next = -1
 
-   packet.shiftright(p, pk_header_size)
+   p = packet.shiftright(p, pk_header_size)
    local header = ffi.cast("struct virtio_net_hdr *", p.data)
    header.flags = flags
    header.gso_type = 0
@@ -147,7 +147,7 @@ function VirtioVirtq:get()
    if debug then assert(p ~= nil) end
    if debug then assert(physical(p.data) == desc.addr) end
    p.length = used.len
-   packet.shiftleft(p, pk_header_size)
+   p = packet.shiftleft(p, pk_header_size)
 
    self.last_used_idx = self.last_used_idx + 1
    desc.next = self.free_head


### PR DESCRIPTION
Instead of mutating a pointer inside "struct packet" to do cheap
shiftleft/shiftright, this patch instead moves around the packet
pointer itself.

The only performance testing I did was "snabb lwaftr bench", where it
appears to be neutral-to-slight-win.  I am hoping that the Hydra/R
scientists can help me out on this one.

This change to the packet structure does have a knock-on effect, in
two significant ways.  One is that the shiftleft, shiftright, and
prepend functions now return a new packet pointer and silently
corrupt the old one (because probably they shifted around the data but
still had to update the new "length" pointer).  That's somewhat OK
though.

The problem comes in the datagram library, which sometimes wants
to work on a user-supplied packet.  The sequence was:

  local dgram = datagram:new(pkt)
  dgram:push(....)
  dgram:free()
  ...
  foo(pkt)

This pattern is no longer valid :(  The reason is that the datagram
methods that mutate a packet often do so by packet.prepend().  The
datagram library updates its internal packet pointer, but the external
one that was initially passed in is no longer valid.  So much of this
patch is visiting (hopefully) all of the uses/users and updating them.
