### PR TITLE
set interface mtu based on lwaftr v4/v6 mtu

### DIFF
--- a/src/program/snabbvmx/README.md
+++ b/src/program/snabbvmx/README.md
@@ -53,11 +53,11 @@ source, destination or within an IPv4-in-IPv6 packet.
 return {
    lwaftr = "snabbvmx-lwaftr.conf",
    ipv6_interface = {
-      mtu = 9500,
+     cache_refresh_interval = 1,
    },
    ipv4_interface = {
-      ipv4_address = "10.0.1.1",
-      mtu = 1460,
+     ipv4_address = "10.0.1.1",
+     cache_refresh_interval = 1,
    },
    settings = {
       vlan = false,
@@ -68,8 +68,9 @@ return {
 lwaftr points to Snabb's lwAFTR configuration file.
 
 Othe attributes are further refined by SnabbVMX.  Attributes `ipv6_interface`
-and `ipv4_interface` are mandatory and they should include the IP addresses
-of the correspondent lwAFTR IPv4 and IPv6 interfaces.
+and `ipv4_interface` are mandatory and ipv4_interface must include the IP addresses
+of the correspondent lwAFTR IPv4 interfaces. The IPv4 address is used to send matching
+packets to the VMX instead of trying to find a match in the binding table for encap.
 
 Attribute `settings` may include a `vlan` tag attribute, which can be either
 false in case VLAN tagging is not enabled or a VLAN tag number (0-4095).

--- a/src/program/snabbvmx/lwaftr/README
+++ b/src/program/snabbvmx/lwaftr/README
@@ -22,11 +22,11 @@ Example config file:
 return {
    lwaftr = "snabbvmx-lwaftr-xe0.conf",
    ipv6_interface = {
-      mtu = 9500,
+     cache_refresh_interval = 1,
    },
    ipv4_interface = {
-      ipv4_address = "10.0.1.1",
-      mtu = 1460,
+     ipv4_address = "10.0.1.1",
+     cache_refresh_interval = 1,
    },
    settings = {},
 }

--- a/src/program/snabbvmx/lwaftr/lwaftr.lua
+++ b/src/program/snabbvmx/lwaftr/lwaftr.lua
@@ -6,6 +6,7 @@ local lib = require("core.lib")
 local lwcounter = require("apps.lwaftr.lwcounter")
 local lwtypes = require("apps.lwaftr.lwtypes")
 local lwutil = require("apps.lwaftr.lwutil")
+local constants = require("apps.lwaftr.constants")
 local setup = require("program.snabbvmx.lwaftr.setup")
 local shm = require("core.shm")
 
@@ -143,10 +144,14 @@ function run(args)
 
    local mtu = DEFAULT_MTU
    if lwconf.ipv6_mtu then
-     mtu = lwconf.ipv6_mtu + 14
+     mtu = lwconf.ipv6_mtu 
    end
    if lwconf.ipv4_mtu and lwconf.ipv4_mtu > lwconf.ipv6_mtu then
-     mtu = lwconf.ipv4_mtu + 14
+     mtu = lwconf.ipv4_mtu
+   end
+   mtu = mtu + constants.ethernet_header_size
+   if lwconf.vlan_tagging then
+     mtu = mtu + 4
    end
    conf.interface = {
       mac_address = mac,

--- a/src/program/snabbvmx/lwaftr/lwaftr.lua
+++ b/src/program/snabbvmx/lwaftr/lwaftr.lua
@@ -141,11 +141,18 @@ function run(args)
 
    local vlan = conf.settings and conf.settings.vlan or false
 
+   local mtu = DEFAULT_MTU
+   if lwconf.ipv6_mtu then
+     mtu = lwconf.ipv6_mtu + 14
+   end
+   if lwconf.ipv4_mtu and lwconf.ipv4_mtu > lwconf.ipv6_mtu then
+     mtu = lwconf.ipv4_mtu + 14
+   end
    conf.interface = {
       mac_address = mac,
       pci = pci,
       id = id,
-      mtu = DEFAULT_MTU,
+      mtu = mtu,
       vlan = vlan,
       mirror_id = mirror_id,
    }

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -48,20 +48,24 @@ local function load_virt (c, nic_id, lwconf, interface)
    }
 
    local v4_nic_name, v6_nic_name = nic_id..'_v4', nic_id..'v6'
+   local v4_mtu = lwconf.ipv4_mtu + 14
+   print(("Setting %s interface MTU to %d"):format(v4_nic_name, v4_mtu))
    config.app(c, v4_nic_name, driver, {
       pciaddr = interface.pci,
       vmdq = lwconf.vlan_tagging,
       vlan = lwconf.vlan_tagging and lwconf.v4_vlan_tag,
       qprdc = qprdc,
       macaddr = ethernet:ntop(lwconf.aftr_mac_inet_side),
-      mtu = interface.mtu})
+      mtu = v4_mtu})
+   local v6_mtu = lwconf.ipv6_mtu + 14
+   print(("Setting %s interface MTU to %d"):format(v6_nic_name, v6_mtu))
    config.app(c, v6_nic_name, driver, {
       pciaddr = interface.pci,
       vmdq = lwconf.vlan_tagging,
       vlan = lwconf.vlan_tagging and lwconf.v6_vlan_tag,
       qprdc = qprdc,
       macaddr = ethernet:ntop(lwconf.aftr_mac_b4_side),
-      mtu = interface.mtu})
+      mtu = v6_mtu})
 
    return v4_nic_name, v6_nic_name
 end
@@ -86,7 +90,7 @@ local function load_phy (c, nic_id, interface)
          mtu = interface.mtu})
       chain_input, chain_output = nic_id .. ".rx", nic_id .. ".tx"
    elseif net_exists(interface.pci) then
-      print(("%s network interface %s"):format(nic_id, interface.pci))
+      print(("%s network interface %s mtu %d"):format(nic_id, interface.pci, interface.mtu))
       if vlan then
          print(("WARNING: VLAN not supported over %s. %s vlan %d"):format(interface.pci, nic_id, vlan))
       end


### PR DESCRIPTION
Fix for https://github.com/Igalia/snabb/issues/487

It calculates the MTU for the interface based on the ipv4_mtu and ipv6_mtu, by taking the numerically larger one and add 14 to cover the size of the ethernet header. The change will also print out the mtu to STDOUT together with the interface name.

Fixing README files for snabbvmx ipv4_interface and ipv6_interface settings.
