### PR TITLE
Remove stale timers code

### DIFF
--- a/src/core/timer.lua
+++ b/src/core/timer.lua
@@ -61,21 +61,6 @@ function activate (t)
    end
 end
 
-local function find_timer (name)
-   for tick, set in pairs(timers) do
-      for i, t in ipairs(set) do
-         if t.name == name then
-            return tick, i
-         end
-      end
-   end
-   return nil
-end
-
-local function is_timer (t)
-   return type(t) == "table" and (t.name and t.fn and t.ticks)
-end
-
 function new (name, fn, nanos, mode)
    return { name = name,
             fn = fn,


### PR DESCRIPTION
Remove code added in 0b5c3133f5fb7a69ee6d2cc65b2b419c4ec1c087, but
then when the ultimate functionality was removed in
9e86b23880b2dab4013cbf66d174469588bc12d8 there were these vestigial
interfaces left behind.
