### PR TITLE
Fix snabbvmx top

### DIFF
--- a/src/program/snabbvmx/top/top.lua
+++ b/src/program/snabbvmx/top/top.lua
@@ -4,11 +4,13 @@ local counter = require("core.counter")
 local ffi = require("ffi")
 local lib = require("core.lib")
 local lwcounter = require("apps.lwaftr.lwcounter")
+local lwutil = require("apps.lwaftr.lwutil")
 local lwtypes = require("apps.lwaftr.lwtypes")
 local shm = require("core.shm")
 local top = require("program.top.top")
 
 local C = ffi.C
+local fatal = lwutil.fatal
 
 local long_opts = {
    help = "h"
@@ -64,6 +66,10 @@ local counter_names = (function ()
       return key == "lwaftr_v4" and ipv4_counters or ipv6_counters
    end
 end)()
+
+local function has_lwaftr_app (tree)
+   return shm.exists(tree.."/"..lwcounter.counters_dir)
+end
 
 local function open_counters (tree)
    local function open_counter (name)
@@ -212,6 +218,9 @@ end
 function run (args)
    local target_pid = parse_args(args)
    local instance_tree = "/"..select_snabb_instance(target_pid)
+   if not has_lwaftr_app(instance_tree) then
+      fatal("Selected instance doesn't include lwaftr app")
+   end
    local counters = open_counters(instance_tree)
    local last_stats = nil
    local last_time = nil

--- a/src/program/snabbvmx/top/top.lua
+++ b/src/program/snabbvmx/top/top.lua
@@ -27,12 +27,12 @@ local function select_snabb_instance_by_id (target_id)
          end
       end
    end
-   print("Couldn't find instance with id '%s'"):format(target_id)
+   print(("Couldn't find instance with id '%s'"):format(target_id))
    main.exit(1)
 end
 
 local function select_snabb_instance (id)
-   if tonumber(id) then
+   if not id or tonumber(id) then
       return top.select_snabb_instance(id)
    else
       return select_snabb_instance_by_id(id)


### PR DESCRIPTION
Several fixes in "snabbvmx top":
- Fix bad formatted print error message. Use top.select_snabb_instance(id) if id is nil.
- Exit if selected snabbvmx top instance is not a lwaftr process.
