### PR TITLE
Snabbvmx ignores vlan settings in .conf file

### DIFF
--- a/src/apps/test/lwaftr.lua
+++ b/src/apps/test/lwaftr.lua
@@ -282,6 +282,7 @@ function Lwaftrgen:pull ()
    local ipv4_bytes = self.ipv4_bytes
    local lost_packets = self.lost_packets
    local udp_offset = self.udp_offset
+   local o_ethertype = self.vlan and OFFSET_ETHERTYPE_VLAN or OFFSET_ETHERTYPE
 
    if self.current == 0 then
       main.exit(0)
@@ -290,7 +291,7 @@ function Lwaftrgen:pull ()
    -- count and trash incoming packets
    for _=1,link.nreadable(input) do
       local pkt = receive(input)
-      if cast(uint16_ptr_t, pkt.data + OFFSET_ETHERTYPE)[0] == PROTO_IPV6 then
+      if cast(uint16_ptr_t, pkt.data + o_ethertype)[0] == PROTO_IPV6 then
          ipv6_bytes = ipv6_bytes + pkt.length
          ipv6_packets = ipv6_packets + 1
          local payload = cast(payload_ptr_type, pkt.data + udp_offset + ipv6_header_size + udp_header_size)

--- a/src/program/snabbvmx/lwaftr/lwaftr.lua
+++ b/src/program/snabbvmx/lwaftr/lwaftr.lua
@@ -76,6 +76,19 @@ function parse_args (args)
    return opts, conf_file, id, pci, mac, sock_path, mirror_id
 end
 
+local function effective_vlan (conf, lwconf)
+   if conf.settings and conf.settings.vlan then
+      return conf.settings.vlan
+   end
+   if lwconf.vlan_tagging then
+      if lwconf.v4_vlan_tag == lwconf.v6_vlan_tag then
+         return lwconf.v4_vlan_tag
+      end
+      return {v4_vlan_tag = lwconf.v4_vlan_tag, v6_vlan_tag = lwconf.v6_vlan_tag}
+   end
+   return false
+end
+
 function run(args)
    local opts, conf_file, id, pci, mac, sock_path, mirror_id = parse_args(args)
 
@@ -140,7 +153,7 @@ function run(args)
       lwaftr_id.value = id
    end
 
-   local vlan = conf.settings and conf.settings.vlan or false
+   local vlan = effective_vlan(conf, lwconf)
 
    local mtu = DEFAULT_MTU
    if lwconf.ipv6_mtu then

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -48,12 +48,6 @@ local function load_virt (c, nic_id, lwconf, interface)
    print("Different VLAN tags: load two virtual interfaces")
    print(("%s ether %s"):format(nic_id, interface.mac_address))
 
-   local qprdc = {
-      discard_check_timer = interface.discard_check_timer,
-      discard_wait = interface.discard_wait,
-      discard_threshold = interface.discard_threshold,
-   }
-
    local v4_nic_name, v6_nic_name = nic_id..'_v4', nic_id..'v6'
    local v4_mtu = lwconf.ipv4_mtu + constants.ethernet_header_size
    if lwconf.vlan_tagging and lwconf.v4_vlan_tag then
@@ -62,9 +56,8 @@ local function load_virt (c, nic_id, lwconf, interface)
    print(("Setting %s interface MTU to %d"):format(v4_nic_name, v4_mtu))
    config.app(c, v4_nic_name, driver, {
       pciaddr = interface.pci,
-      vmdq = lwconf.vlan_tagging,
-      vlan = lwconf.vlan_tagging and lwconf.v4_vlan_tag,
-      qprdc = qprdc,
+      vmdq = interface.vlan and true,
+      vlan = interface.vlan and interface.vlan.v4_vlan_tag,
       macaddr = ethernet:ntop(lwconf.aftr_mac_inet_side),
       mtu = v4_mtu })
    local v6_mtu = lwconf.ipv6_mtu + constants.ethernet_header_size
@@ -74,9 +67,8 @@ local function load_virt (c, nic_id, lwconf, interface)
    print(("Setting %s interface MTU to %d"):format(v6_nic_name, v6_mtu))
    config.app(c, v6_nic_name, driver, {
       pciaddr = interface.pci,
-      vmdq = lwconf.vlan_tagging,
-      vlan = lwconf.vlan_tagging and lwconf.v6_vlan_tag,
-      qprdc = qprdc,
+      vmdq = interface.vlan and true,
+      vlan = interface.vlan and interface.vlan.v6_vlan_tag,
       macaddr = ethernet:ntop(lwconf.aftr_mac_b4_side),
       mtu = v6_mtu})
 


### PR DESCRIPTION
Fixes #489.

Fixes several issues:
- Packet blaster doesn't report on V6 traffic when VLAN is on although there's traffic successfully reaching the lwAFTR. Ex:

``` bash
$ snabb packetblaster lwaftr --src_mac 02:02:02:02:02:02 --dst_mac 02:b0:53:89:04:00 \
--b4 2001:db8::40,10.10.0.0,1024 --aftr 2001:db8:ffff::100 --count 60000 --rate 3.1 \
--pci 02:00.0 --vlan 100
v6+v4: 0.000+1.766 = 1.766490 MPPS, 0.000+5.330 = 5.329517 Gbps, lost 41.569%
v6+v4: 0.000+3.099 = 3.098588 MPPS, 0.000+9.348 = 9.347615 Gbps, lost 0.008%
v6+v4: 0.000+3.099 = 3.098671 MPPS, 0.000+9.348 = 9.347739 Gbps, lost 0.007%
```
-  VLAN is ignored when SnabbVMX's conf file doesn't have a VLAN and lwAFTR's conf has it but VLAN tag values are the same. Explanation here: https://github.com/Igalia/snabb/issues/489#issuecomment-254183272
