### PR TITLE
Define skipped code in SnabbVMX's nexhop test

### DIFF
--- a/src/program/snabbvmx/tests/nexthop/selftest.sh
+++ b/src/program/snabbvmx/tests/nexthop/selftest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+SKIPPED_CODE=43
+
 if [[ $EUID != 0 ]]; then
     echo "This script must be run as root"
     exit 1


### PR DESCRIPTION
The test was exiting with status code 0 (success) when PCI card was not defined (should be skipped). Fixes https://github.com/Igalia/snabb/issues/486

After fix:

``` bash
$ sudo ./program/snabbvmx/tests/nexthop/selftest.sh 
Skip test: SNABB_PCI0 not defined
$ echo $?
43
```
