### PR TITLE
Fix shm.exists() check in ingress drop monitor

### DIFF
--- a/src/lib/timers/ingress_drop_monitor.lua
+++ b/src/lib/timers/ingress_drop_monitor.lua
@@ -31,7 +31,7 @@ function new(args)
       if not args.counter:match(".counter$") then
          args.counter = args.counter..".counter"
       end
-      if not shm.exists("/"..S.getpid().."/"..args.counter) then
+      if not shm.exists(args.counter) then
          ret.counter = counter.create(args.counter, 0)
       else
          ret.counter = counter.open(args.counter)


### PR DESCRIPTION
If we are recording ingress drops to a counter, use the right check for
the counter's existence.  Addresses
https://github.com/snabbco/snabb/pull/1047#pullrequestreview-5090751.
