### PR TITLE
Add unit test for ipv4_cache_trigger

### DIFF
--- a/src/program/snabbvmx/tests/nexthop/selftest.sh
+++ b/src/program/snabbvmx/tests/nexthop/selftest.sh
@@ -46,8 +46,9 @@ function quit_screens {
 }
 
 function cleanup {
+    local exit_code=$1
     quit_screens
-    exit 0
+    exit $exit_code
 }
 
 trap cleanup EXIT HUP INT QUIT TERM
@@ -89,17 +90,12 @@ while true; do
           $(last_32bit "$mac_v6") == "99:99:99:99" ]]; then
         echo "Resolved MAC inet side: $mac_v4 [OK]"
         echo "Resolved MAC inet side: $mac_v6 [OK]"
-        break
+        exit 0
     fi
 
     if [[ $count == $TIMEOUT ]]; then
-        break
+        exit 1
     fi
     count=$((count + 1))
     sleep 1
 done
-
-if [[ $count == $TIMEOUT ]]; then
-    echo "Couldn't resolve nexthop"
-    exit 1
-fi

--- a/src/program/snabbvmx/tests/selftest.sh
+++ b/src/program/snabbvmx/tests/selftest.sh
@@ -191,13 +191,14 @@ function check_pcap_equals { testname=$1; output=$2; expected=$3
 }
 
 function cleanup {
+    local exit_code=$1
     screens=$(screen -ls | egrep -o "[0-9]+\." | sed 's/\.//')
     for each in $screens; do
         if [[ "$each" > 0 ]]; then
             screen -S $each -X quit
         fi
     done
-    exit 0
+    echo $exit_code
 }
 
 function run_pcap_test { testname=$1; input=$2; expected=$3; filter=$4


### PR DESCRIPTION
4be802bb216dddf9592507f5d9887d9f9aad6fd0 broke `nh_fwd`. Bit functions `lshift` and `band` were not imported. SnabbVMX nexthop test didn't detect the regression because exit calls are trapped and it always returns zero (success) when exiting with an error code.

This PR fixes both bugs and introduces a unit test for ipv4_cache_trigger.
