### PR TITLE
Use the same option name for the benchmark filename

### DIFF
--- a/src/program/lwaftr/bench/README
+++ b/src/program/lwaftr/bench/README
@@ -11,10 +11,11 @@ Usage: bench CONF IPV4-IN.PCAP IPV6-IN.PCAP
                              rather than the default:
 
                                Time (s),Decap. MPPS,Decap. Gbps,Encap. MPPS,Encap. Gbps
-  -f FILENAME, --filename FILENAME
-                             The file or path name to which CSV data is written.
-                             A simple filename or relative pathname will be based
-                             on the current directory. Default is "bench.csv".
+  -b FILENAME, --bench-file FILENAME
+                              The file or path name to which benchmark data is
+                              written. A simple filename or relative pathname
+                              will be based on the current directory. Default
+                              is "bench.csv".
   -D DURATION, --duration DURATION
                              Duration in seconds.
 

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -13,17 +13,16 @@ end
 
 function parse_args(args)
    local handlers = {}
-   local opts = {}
-   opts.filename = "bench.csv"
+   local opts = { bench_file = 'bench.csv' }
    function handlers.D(arg)
       opts.duration = assert(tonumber(arg), "duration must be a number")
       assert(opts.duration >= 0, "duration can't be negative")
    end
-   function handlers.f(arg) opts.filename = arg end
+   function handlers.b(arg) opts.bench_file = arg end
    function handlers.y() opts.hydra = true end
    function handlers.h() show_usage(0) end
-   args = lib.dogetopt(args, handlers, "hyf:D:", {
-      help="h", hydra="y", filename="f", duration="D" })
+   args = lib.dogetopt(args, handlers, "hyb:D:", {
+      help="h", hydra="y", ["bench-file"]="b", duration="D" })
    if #args ~= 3 then show_usage(1) end
    return opts, unpack(args)
 end
@@ -36,7 +35,7 @@ function run(args)
    setup.load_bench(c, conf, inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
    app.configure(c)
 
-   local csv = csv_stats.CSVStatsTimer:new(opts.filename, opts.hydra)
+   local csv = csv_stats.CSVStatsTimer:new(opts.bench_file, opts.hydra)
    csv:add_app('sinkv4', { 'input' }, { input=opts.hydra and 'decap' or 'Decap.' })
    csv:add_app('sinkv6', { 'input' }, { input=opts.hydra and 'encap' or 'Encap.' })
    csv:activate()


### PR DESCRIPTION
In the `lwaftr bench` command, use the same option name for the benchmark filename as in the other commands like `lwaftr run`, `lwaftr run_nohw` and `lwaftr transient`.
