### PR TITLE
Named programs

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -26,7 +26,7 @@ local use_restart = false
 
 test_skipped_code = 43
 
--- Set the directories for the named programs.
+-- Set the directory for the named programs.
 named_program_root = shm.root .. "/" .. "by-name"
 
 -- The set of all active apps and links in the system.

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -145,7 +145,7 @@ function claim_name(name)
    shm.mkdir(namedir)
 
    -- Verify that we've not already claimed a name
-   assert(configuration.name, "Name already claimed, cannot claim: "..name)
+   assert(configuration.name == nil, "Name already claimed, cannot claim: "..name)
    
    -- Create the new symlink.
    assert(S.symlink(piddir, namedir_fq))

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -169,16 +169,18 @@ end
 -- This returns a table programs with the key being the name of the program
 -- and the value being the PID of the program. Each program is checked that
 -- it's still alive. Any dead program or program without a name is not listed.
-function enumerate_named_programs()
+--
+-- The inc_dead argument is to disable the alive check (default: false)
+function enumerate_named_programs(inc_dead)
    local progs = {}
-   local dirs = S.util.dirtable(named_program_root, true)
+   local dirs = shm.children("/by-name")
    if dirs == nil then return progs end
    for _, program in pairs(dirs) do
       local fq = named_program_root .. "/" .. program
       local piddir = S.readlink(fq)
       local s, e = string.find(piddir, "/[^/]*$")
       local pid = tonumber(string.sub(piddir, s+1, e))
-      if S.kill(pid, 0) then
+      if inc_dead == true or S.kill(pid, 0) then
          local ps, pe = string.find(fq, "/[^/]*$")
          local program_name = string.sub(fq, ps+1, pe)
          progs[program_name] = pid

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -11,7 +11,6 @@ local ffi = require("ffi")
 local zone = require("jit.zone")
 local lib = require("core.lib")
 local shm = require("core.shm")
-local app = require("core.app")
 local C   = ffi.C
 -- Load ljsyscall early to help detect conflicts
 -- (e.g. FFI type name conflict between Snabb and ljsyscall)
@@ -144,7 +143,7 @@ end
 function shutdown (pid)
    if not _G.developer_debug and not lib.getenv("SNABB_SHM_KEEP") then
       -- Check if there is a backlink to the named app, if so cleanup that.
-      local backlink = shm.root.."/"..pid.."/name-backref"
+      local backlink = shm.root.."/"..pid.."/name"
       if S.lstat(backlink) then
          local name_link = S.readlink(backlink)
          S.unlink(name_link)

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -146,9 +146,10 @@ function shutdown (pid)
       shm.unlink("/"..pid)
 
       -- Look through the named apps and unlink any which are for this process.
-      local progs = app.enumerate_named_programs()
+      local npid = tonumber(pid)
+      local progs = app.enumerate_named_programs(true)
       for name, p in pairs(progs) do
-         if p == pid then
+         if p == npid then
             S.unlink(app.named_program_root .. "/" .. name)
          end
       end

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -142,13 +142,11 @@ end
 -- Cleanup after Snabb process.
 function shutdown (pid)
    if not _G.developer_debug and not lib.getenv("SNABB_SHM_KEEP") then
-      -- Check if there is a backlink to the named app, if so cleanup that.
+      -- Try cleaning up symlinks for named apps, if none exist, fail silently.
       local backlink = shm.root.."/"..pid.."/name"
-      if S.lstat(backlink) then
-         local name_link = S.readlink(backlink)
-         S.unlink(name_link)
-         S.unlink(backlink)
-      end
+      local name_link = S.readlink(backlink)
+      S.unlink(name_link)
+      S.unlink(backlink)
 
       shm.unlink("/"..pid)
    end

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -143,16 +143,15 @@ end
 -- Cleanup after Snabb process.
 function shutdown (pid)
    if not _G.developer_debug and not lib.getenv("SNABB_SHM_KEEP") then
-      shm.unlink("/"..pid)
-
-      -- Look through the named apps and unlink any which are for this process.
-      local npid = tonumber(pid)
-      local progs = app.enumerate_named_programs(true)
-      for name, p in pairs(progs) do
-         if p == npid then
-            S.unlink(app.named_program_root .. "/" .. name)
-         end
+      -- Check if there is a backlink to the named app, if so cleanup that.
+      local backlink = shm.root.."/"..pid.."/name-backref"
+      if S.lstat(backlink) then
+         local name_link = S.readlink(backlink)
+         S.unlink(name_link)
+         S.unlink(backlink)
       end
+
+      shm.unlink("/"..pid)
    end
 end
 

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -11,6 +11,7 @@ local ffi = require("ffi")
 local zone = require("jit.zone")
 local lib = require("core.lib")
 local shm = require("core.shm")
+local app = require("core.app")
 local C   = ffi.C
 -- Load ljsyscall early to help detect conflicts
 -- (e.g. FFI type name conflict between Snabb and ljsyscall)
@@ -143,6 +144,14 @@ end
 function shutdown (pid)
    if not _G.developer_debug and not lib.getenv("SNABB_SHM_KEEP") then
       shm.unlink("/"..pid)
+
+      -- Look through the named apps and unlink any which are for this process.
+      local progs = app.enumerate_named_programs()
+      for name, p in pairs(progs) do
+         if p == pid then
+            S.unlink(app.named_program_root .. "/" .. name)
+         end
+      end
    end
 end
 

--- a/src/program/example_replay/example_replay.lua
+++ b/src/program/example_replay/example_replay.lua
@@ -13,6 +13,8 @@ function run (parameters)
    local pcap_file = parameters[1]
    local interface = parameters[2]
 
+   engine.claim_name("Billybob")
+
    local c = config.new()
    config.app(c, "capture", pcap.PcapReader, pcap_file)
    config.app(c, "playback", raw.RawSocket, interface)

--- a/src/program/example_replay/example_replay.lua
+++ b/src/program/example_replay/example_replay.lua
@@ -13,8 +13,6 @@ function run (parameters)
    local pcap_file = parameters[1]
    local interface = parameters[2]
 
-   engine.claim_name("Billybob")
-
    local c = config.new()
    config.app(c, "capture", pcap.PcapReader, pcap_file)
    config.app(c, "playback", raw.RawSocket, interface)

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -32,7 +32,9 @@ function run (args)
 end
 
 function select_snabb_instance (pid)
-   local instances = shm.children("/")
+   local instances = {}
+   -- For named programs there is a "by-name" directory which isn't a process, remove it.
+   for k,v in pairs(shm.children("/")) do if v ~= "by-name" then instances[k] = v end end
    if pid then
       -- Try to use given pid
       for _, instance in ipairs(instances) do

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -32,27 +32,31 @@ function run (args)
 end
 
 function select_snabb_instance (pid)
-   local instances = {}
-   -- For named programs there is a "by-name" directory which isn't a process, remove it.
-   for k,v in pairs(shm.children("/")) do if v ~= "by-name" then instances[k] = v end end
+   local function compute_snabb_instances()
+      -- Produces set of snabb instances, excluding this one.
+      local pids = {}
+      local my_pid = S.getpid()
+      for _, name in ipairs(shm.children("/")) do
+         -- This could fail as the name could be for example "by-name"
+         local p = tonumber(name)
+         if p and p ~= my_pid then table.insert(pids, p) end
+      end
+      return pids
+   end
+
+   local instances = compute_snabb_instances()
+
    if pid then
       -- Try to use given pid
       for _, instance in ipairs(instances) do
          if instance == pid then return pid end
       end
       print("No such Snabb instance: "..pid)
-   elseif #instances == 1 then print("No Snabb instance found.")
+   elseif #instances == 1 then return instances[1]
+   elseif #instances <= 0 then print("No Snabb instance found.")
    else
-      local own_pid = tostring(S.getpid())
-      if #instances == 2 then
-         -- Two means one is us, so we pick the other.
-         return instances[1] == own_pid and instances[2] or instances[1]
-      else
-         print("Multiple Snabb instances found. Select one:")
-         for _, instance in ipairs(instances) do
-            if instance ~= own_pid then print(instance) end
-         end
-      end
+      print("Multiple Snabb instances found. Select one:")
+      for _, instance in ipairs(instances) do print(instance) end
    end
    main.exit(1)
 end


### PR DESCRIPTION
This introduces named programs as outlined in https://github.com/snabbco/snabb/issues/1033. The two main functions are `claim_name` which is suppose to be used by the programs to claim a unique name for themselves and `enumerate_named_programs` which should list all the programs by their name and PID.

I've also incorporated code into the cleanup done by the supervisor. My one concern for this is it changes `/var/run/snabb` from purely being a list of PID's with their shared memory inside, it now adds a "by-name" folder which has the symlinks to the PIDs. For example in the top program I already have to filter out the "by-name" directory out so it's not listed. I'm concerned other programs are written based on that assumption.

A possible consideration would be to instead change the directory from `/var/run/snabb` to `/var/run/snabb/by-pid/`. This would allow for a single directory to continue being just full of PID's with their shared memory. 
