### PR TITLE
Fix the bench-file option in various commands

### DIFF
--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -157,7 +157,7 @@ function run(args)
    end
 
    if opts.verbosity >= 1 then
-      local csv = csv_stats.CSVStatsTimer.new(opts.csv_file, opts.hydra)
+      local csv = csv_stats.CSVStatsTimer.new(opts.bench_file, opts.hydra)
       -- Why are the names cross-referenced like this?
       local ipv4_tx = opts.hydra and 'ipv4rx' or 'IPv4 RX'
       local ipv4_rx = opts.hydra and 'ipv4tx' or 'IPv4 TX'

--- a/src/program/lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/lwaftr/run_nohw/run_nohw.lua
@@ -44,7 +44,7 @@ local function parse_args(args)
    lib.dogetopt(args, handlers, "b:c:B:I:vh", {
       help = "h", conf = "c", verbose = "v",
       ["b4-if"] = "B", ["inet-if"] = "I",
-      bench_file = 0,
+      ["bench-file"] = 0,
    })
    check(conf_file, "no configuration specified (--conf/-c)")
    check(b4_if, "no B4-side interface specified (--b4-if/-B)")

--- a/src/program/lwaftr/transient/transient.lua
+++ b/src/program/lwaftr/transient/transient.lua
@@ -126,7 +126,7 @@ function run(args)
    rate_adjuster()
    timer.activate(timer.new("adjust_rate", rate_adjuster,
                             opts.duration * 1e9, 'repeating'))
-   local csv = csv_stats.CSVStatsTimer.new(opts.csv_file)
+   local csv = csv_stats.CSVStatsTimer.new(opts.bench_file)
    for _,stream in ipairs(streams) do
       csv:add_app(stream.nic_id, { 'rx', 'tx' },
                   { rx=stream.name..' TX', tx=stream.name..' RX' })


### PR DESCRIPTION
Fix the `bench-file` option in the `run`, `run_nohw` and `transient` commands.
