### PR TITLE
Fix packet allocation overflow

### DIFF
--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -210,14 +210,15 @@ local function init_transmit_icmpv4_reply (lwstate)
          last_time = now
          num_packets = 0
       end
+      -- Origin packet is always dropped.
+      if orig_pkt_link then
+         drop_ipv4(lwstate, orig_pkt, orig_pkt_link)
+      else
+         drop(orig_pkt)
+      end
       -- Send packet if limit not reached.
       if num_packets < icmpv4_rate_limiter_n_packets then
          num_packets = num_packets + 1
-         if orig_pkt_link then
-            drop_ipv4(lwstate, orig_pkt, orig_pkt_link)
-         else
-            drop(orig_pkt)
-         end
          counter.add(lwstate.counters["out-icmpv4-bytes"], pkt.length)
          counter.add(lwstate.counters["out-icmpv4-packets"])
          -- Only locally generated error packets are handled here.  We transmit

--- a/src/program/lwaftr/soaktest/soaktest.lua
+++ b/src/program/lwaftr/soaktest/soaktest.lua
@@ -21,7 +21,7 @@ function parse_args (args)
    local opts = {}
    function handlers.h() show_usage(0) end
    function handlers.D (arg)
-      opts.duration = tonumber(arg, "Duration must be a number")
+      opts.duration = assert(tonumber(arg), "Duration must be a number")
    end
    handlers["on-a-stick"] = function ()
       opts["on-a-stick"] = true

--- a/src/program/lwaftr/tests/soaktest/core-soaktest.sh
+++ b/src/program/lwaftr/tests/soaktest/core-soaktest.sh
@@ -5,6 +5,8 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
+DURATION=${1:-"0.10"}
+
 function quit_with_msg {
     errno=$1; msg="$2"
     echo "Test failed: $msg"
@@ -13,10 +15,10 @@ function quit_with_msg {
 
 function soaktest {
     conf="$1"; in_v4="$2"; in_v6="$3"
-    $SNABB_LWAFTR soaktest "$conf" "$in_v4" "$in_v6" ||
-        quit_with_msg $? "Test failed: $SNABB_LWAFTR soaktest $@"
-    $SNABB_LWAFTR soaktest --on-a-stick "$conf" "$in_v4" "$in_v6" ||
-        quit_with_msg $? "Test failed: $SNABB_LWAFTR soaktest --on-a-stick $@"
+    $SNABB_LWAFTR soaktest -D $DURATION "$conf" "$in_v4" "$in_v6" ||
+        quit_with_msg $? "$SNABB_LWAFTR soaktest -D $DURATION $conf $in_v4 $in_v6"
+    $SNABB_LWAFTR soaktest -D $DURATION --on-a-stick "$conf" "$in_v4" "$in_v6" ||
+        quit_with_msg $? "$SNABB_LWAFTR soaktest -D $DURATION --on-a-stick $conf $in_v4 $in_v6"
 }
 
 source "../end-to-end/test_env.sh"


### PR DESCRIPTION
Origin packet must be always dropped in `transmit_icmpv4_reply`, and not only if the about-to-be-sent packet can be transmitted. Not dropping the packet causes more packet allocation in packet.free_list, which eventually leads to packet allocation overflow when no more packets can be allocated in packet.free_list.

The PR also allows to passing `duration` to soaktest.sh script and fixes an issue with duration in soaktest.lua, necessary to run to reproduce #527.

This PR fixes #527.
