### PR TITLE
Compile yang configurations to binary streams

### DIFF
--- a/src/lib/README.cltable.md
+++ b/src/lib/README.cltable.md
@@ -1,0 +1,65 @@
+### cltable (lib.cltable)
+
+Ever been annoyed that you can't create a hash table where the keys are
+FFI values, like raw IPv4 addresses, but the values are Lua objects?
+Well of course you can key a normal Lua table by any Lua value, but the
+key is looked up by identity and not by value, which is rarely what you
+want.  `foo[lib.protocol.ipv4:pton('1.2.3.4')]` will not be the same as
+`foo[lib.protocol.ipv4:pton('1.2.3.4')]`, as the `pton` call produces a
+fresh value every time.  What you usually want with FFI-keyed tables is
+to be able to look up the entry by value, not by identity.
+
+Well never fear, *cltable* is here.  A cltable is a data type that
+associates FFI keys with any old Lua value.  When you look up a key in a
+cltable, the key is matched by-value.
+
+Externally, a cltable provides the same interface as a Lua table, with
+the exception that to iterate over the table's values, you need to use
+`cltable.pairs` function instead of `pairs`.
+
+Internally, cltable uses a [`ctable`](./README.ctable.md) to map the key
+to an index, then if an entry is found, looks up that index in a side
+table of Lua objects.  See the ctable documentation for more performance
+characteristics.
+
+To create a cltable, use pass an appropriate parameter table to
+`cltable.new`, like this:
+
+```lua
+local cltable = require('lib.cltable')
+local ffi = require('ffi')
+local params = { key_type = ffi.typeof('uint8_t[4]') }
+local cltab = cltable.new(params)
+```
+
+— Function **cltable.new** *parameters*
+
+Create a new cltable.  *parameters* is a table of key/value pairs.  The
+following key is required:
+
+ * `key_type`: An FFI type (LuaJIT "ctype") for keys in this table.
+
+Optional entries that may be present in the *parameters* table are
+`hash_fn`, `initial_size`, `max_occupancy_rate`, and
+`min_occupancy_rate`.  See the ctable documentation for their meanings.
+
+— Function **cltable.build** *keys* *values*
+
+Given the ctable *keys* that maps keys to indexes, and a corresponding
+Lua table *values* containing the index->value associations, return a
+cltable.
+
+— Property **.keys**
+
+A cltable's `keys` property holds the table's keys, as a ctable.  If you
+modify it, you get to keep both pieces.
+
+— Property **.values**
+
+Likewise, a cltable's `values` property holds the table's values, as a
+Lua array (table).  If you break it, you buy it!
+
+— Function **cltable.pairs** *cltable*
+
+Return an iterator over the keys and values in *cltable*.  Use this when
+you would use `pairs` on a regular Lua table.

--- a/src/lib/README.ctable.md
+++ b/src/lib/README.ctable.md
@@ -83,6 +83,15 @@ Optional entries that may be present in the *parameters* table include:
  * `min_occupancy_rate`: Minimum ratio of `occupancy/size`.  Removing an
    entry from an "empty" table will shrink the table.
 
+— Function **ctable.load** *stream* *parameters*
+
+Load a ctable that was previously saved out to a binary format.
+*parameters* are as for `ctable.new`.  *stream* should be an object
+that has a **:read_ptr**(*ctype*) method, which returns a pointer to
+an embedded instances of *ctype* in the stream, advancing the stream
+over the object; and **:read_array**(*ctype*, *count*) which is the
+same but reading *count* instances of *ctype* instead of just one.
+
 #### Methods
 
 Users interact with a ctable through methods.  In these method
@@ -155,6 +164,13 @@ Remove an entry from a ctable, keyed by *key*.
 Return true if we actually do find a value and remove it.  Otherwise if
 no entry is found in the table and *missing_allowed* is true, then
 return false.  Otherwise raise an error.
+
+— Method **:save** *stream*
+
+Save a ctable to a byte sink.  *stream* should be an object that has a
+**:write_ptr**(*ctype*) method, which writes an instance of a struct
+type out to a stream, and **:write_array**(*ctype*, *count*) which is
+the same but writing *count* instances of *ctype* instead of just one.
 
 — Method **:selfcheck**
 

--- a/src/lib/README.ctable.md
+++ b/src/lib/README.ctable.md
@@ -62,7 +62,6 @@ following keys are required:
 
  * `key_type`: An FFI type (LuaJIT "ctype") for keys in this table.
  * `value_type`: An FFI type (LuaJT "ctype") for values in this table.
- * `hash_fn`: A function that takes a key and returns a hash value.
 
 Hash values are unsigned 32-bit integers in the range `[0,
 0xFFFFFFFF)`.  That is to say, `0xFFFFFFFF` is the only unsigned 32-bit
@@ -71,6 +70,9 @@ hash value in the correct range.
 
 Optional entries that may be present in the *parameters* table include:
 
+ * `hash_fn`: A function that takes a key and returns a hash value.
+   If not given, defaults to the result of calling `compute_hash_fn`
+   on the key type.
  * `initial_size`: The initial size of the hash table, including free
    space.  Defaults to 8 slots.
  * `max_occupancy_rate`: The maximum ratio of `occupancy/size`, where
@@ -198,3 +200,9 @@ Hash the first 48 bits of a byte sequence.
 — Function **ctable.hashv_64** *ptr*
 
 Hash the first 64 bits of a byte sequence.
+
+— Function **ctable.compute_hash_fn** *ctype*
+
+Return a `hashv_`-like hash function over the bytes in instances of
+*ctype*.  Note that the same reservations apply as for `hash_32`
+above.

--- a/src/lib/cltable.lua
+++ b/src/lib/cltable.lua
@@ -3,8 +3,6 @@ module(..., package.seeall)
 local ffi = require("ffi")
 local ctable = require("lib.ctable")
 
-CLTable = {}
-
 function build(keys, values)
    return setmetatable({ keys = keys, values = values },
                        {__index=get, __newindex=set})

--- a/src/lib/cltable.lua
+++ b/src/lib/cltable.lua
@@ -1,0 +1,68 @@
+module(..., package.seeall)
+
+local ffi = require("ffi")
+local ctable = require("lib.ctable")
+
+CLTable = {}
+
+function build(keys, values)
+   return setmetatable({ keys = keys, values = values },
+                       {__index=get, __newindex=set})
+end
+
+function new(params)
+   local ctable_params = {}
+   for k,v in _G.pairs(params) do ctable_params[k] = v end
+   assert(not ctable_params.value_type)
+   ctable_params.value_type = ffi.typeof('uint32_t')
+   return build(ctable.new(ctable_params), {})
+end
+
+function get(cltable, key)
+   local entry = cltable.keys:lookup_ptr(key)
+   if not entry then return nil end
+   return cltable.values[entry.value]
+end
+
+function set(cltable, key, value)
+   local entry = cltable.keys:lookup_ptr(key)
+   if entry then
+      cltable.values[entry.value] = value
+      if value ~= nil then
+         cltable.keys:remove_ptr(entry)
+         -- FIXME: Leaking the slot in the values array.
+      end
+   elseif value ~= nil then
+      table.insert(cltable.values, value)
+      cltable.keys:add(key, #cltable.values)
+   end
+end
+
+function pairs(cltable)
+   local ctable_next, ctable_max, ctable_entry = cltable.keys:iterate()
+   return function()
+      ctable_entry = ctable_next(ctable_max, ctable_entry)
+      if not ctable_entry then return end
+      return ctable_entry.key, cltable.values[ctable_entry.value]
+   end
+end
+
+function selftest()
+   print("selftest: cltable")
+
+   local ipv4 = require('lib.protocol.ipv4')
+   local params = { key_type = ffi.typeof('uint8_t[4]') }
+   local cltab = new(params)
+
+   for i=0,255 do
+      local addr = ipv4:pton('1.2.3.'..i)
+      cltab[addr] = 'hello, '..i
+   end
+
+   for i=0,255 do
+      local addr = ipv4:pton('1.2.3.'..i)
+      assert(cltab[addr] == 'hello, '..i)
+   end
+
+   print("selftest: ok")
+end

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -168,6 +168,45 @@ function CTable:get_backing_size()
    return self.byte_size
 end
 
+local header_t = ffi.typeof[[
+struct {
+   uint32_t size;
+   uint32_t occupancy;
+   uint32_t max_displacement;
+   double max_occupancy_rate;
+   double min_occupancy_rate;
+}
+]]
+
+function load(stream, params)
+   local header = stream:read_ptr(header_t)
+   local params_copy = {}
+   for k,v in pairs(params) do params_copy[k] = v end
+   params_copy.initial_size = header.size
+   params_copy.min_occupancy_rate = header.min_occupancy_rate
+   params_copy.max_occupancy_rate = header.max_occupancy_rate
+   local ctab = new(params_copy)
+   ctab.occupancy = header.occupancy
+   ctab.max_displacement = header.max_displacement
+   local entry_count = ctab.size + ctab.max_displacement + 1
+
+   -- Slurp the entries directly into the ctable's backing store.
+   -- This ensures that the ctable is in hugepages.
+   C.memcpy(ctab.entries,
+            stream:read_array(ctab.entry_type, entry_count),
+            ffi.sizeof(ctab.entry_type) * entry_count)
+
+   return ctab
+end
+
+function CTable:save(stream)
+   stream:write_ptr(header_t(self.size, self.occupancy, self.max_displacement,
+                             self.max_occupancy_rate, self.min_occupancy_rate))
+   stream:write_array(self.entries,
+                      self.entry_type,
+                      self.size + self.max_displacement + 1)
+end
+
 function CTable:insert(hash, key, value, updates_allowed)
    if self.occupancy + 1 > self.occupancy_hi then
       self:resize(self.size * 2)
@@ -450,21 +489,60 @@ function selftest()
       ctab:add(i, v)
    end
 
-   -- In this case we know max_displacement is 8.  Assert here so that
-   -- we can detect any future deviation or regression.
-   assert(ctab.max_displacement == 8)
+   for i=1,2 do
+      -- In this case we know max_displacement is 8.  Assert here so that
+      -- we can detect any future deviation or regression.
+      assert(ctab.max_displacement == 8)
 
-   ctab:selfcheck()
+      ctab:selfcheck()
 
-   for i = 1, occupancy do
-      local value = ctab:lookup_ptr(i).value[0]
-      assert(value == bnot(i))
+      for i = 1, occupancy do
+         local value = ctab:lookup_ptr(i).value[0]
+         assert(value == bnot(i))
+      end
+      ctab:selfcheck()
+
+      local iterated = 0
+      for entry in ctab:iterate() do iterated = iterated + 1 end
+      assert(iterated == occupancy)
+
+      -- Save the table out to disk, reload it, and run the same
+      -- checks.
+      local tmp = os.tmpname()
+      do
+         local file = io.open(tmp, 'wb')
+         local function write(ptr, size)
+
+            file:write(ffi.string(ptr, size))
+         end
+         local stream = {}
+         function stream:write_ptr(ptr)
+            write(ptr, ffi.sizeof(ptr))
+         end
+         function stream:write_array(ptr, type, count)
+            write(ptr, ffi.sizeof(type) * count)
+         end
+         ctab:save(stream)
+         file:close()
+      end
+      do
+         local file = io.open(tmp, 'rb')
+         local function read(size)
+            return ffi.new('uint8_t[?]', size, file:read(size))
+         end
+         local stream = {}
+         function stream:read_ptr(type)
+            return ffi.cast(ffi.typeof('$*', type), read(ffi.sizeof(type)))
+         end
+         function stream:read_array(type, count)
+            return ffi.cast(ffi.typeof('$*', type),
+                            read(ffi.sizeof(type) * count))
+         end
+         ctab = load(stream, params)
+         file:close()
+      end         
+      os.remove(tmp)
    end
-   ctab:selfcheck()
-
-   local iterated = 0
-   for entry in ctab:iterate() do iterated = iterated + 1 end
-   assert(iterated == occupancy)
 
    -- OK, all looking good with our ctab.
 

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -91,8 +91,9 @@ end
 -- FIXME: For now the value_type option is required, but in the future
 -- we should allow for a nil value type to create a set instead of a
 -- map.
-local required_params = set('key_type', 'value_type', 'hash_fn')
+local required_params = set('key_type', 'value_type')
 local optional_params = {
+   hash_fn = false,
    initial_size = 8,
    max_occupancy_rate = 0.9,
    min_occupancy_rate = 0.0
@@ -103,7 +104,7 @@ function new(params)
    local params = parse_params(params, required_params, optional_params)
    ctab.entry_type = make_entry_type(params.key_type, params.value_type)
    ctab.type = make_entries_type(ctab.entry_type)
-   ctab.hash_fn = params.hash_fn
+   ctab.hash_fn = params.hash_fn or compute_hash_fn(params.key_type)
    ctab.equal_fn = make_equal_fn(params.key_type)
    ctab.size = 0
    ctab.occupancy = 0
@@ -391,6 +392,7 @@ function hash_32(i32)
    return uint32_cast[0]
 end
 
+local cast = ffi.cast
 function hashv_32(key)
    return hash_32(cast(uint32_ptr_t, key)[0])
 end
@@ -408,6 +410,22 @@ function hashv_64(key)
    local hi = cast(uint32_ptr_t, key)[0]
    local lo = cast(uint32_ptr_t, key)[1]
    return hash_32(bxor(hi, hash_32(lo)))
+end
+
+local hash_fns_by_size = { [4]=hashv_32, [8]=hashv_64 }
+function compute_hash_fn(ctype)
+   local size = ffi.sizeof(ctype)
+   if not hash_fns_by_size[size] then
+      hash_fns_by_size[size] = function(key)
+         local h = 0
+         local words = cast(uint32_ptr_t, key)
+         local bytes = cast('uint8_t*', key)
+         for i=0,size/4 do h = hash_32(bxor(h, words[i])) end
+         for i=1,size%4 do h = hash_32(bxor(h, bytes[size-i])) end
+         return h
+      end
+   end
+   return hash_fns_by_size[size]
 end
 
 function selftest()
@@ -457,8 +475,11 @@ function selftest()
 
    local function check_bytes_equal(type, a, b)
       local equal_fn = make_equal_fn(type)
+      local hash_fn = compute_hash_fn(type)
       assert(equal_fn(ffi.new(type, a), ffi.new(type, a)))
       assert(not equal_fn(ffi.new(type, a), ffi.new(type, b)))
+      assert(hash_fn(ffi.new(type, a)) == hash_fn(ffi.new(type, a)))
+      assert(hash_fn(ffi.new(type, a)) ~= hash_fn(ffi.new(type, b)))
    end
    check_bytes_equal(ffi.typeof('uint16_t[1]'), {1}, {2})         -- 2 byte
    check_bytes_equal(ffi.typeof('uint32_t[1]'), {1}, {2})         -- 4 byte

--- a/src/lib/yang/README.md
+++ b/src/lib/yang/README.md
@@ -28,7 +28,7 @@ module snabb-simple-router {
     list route {
       key addr;
       leaf addr { type inet:ipv4-address; mandatory true; }
-      leaf port { type uint8 { range 0..11; }; mandatory true; }
+      leaf port { type uint8 { range 0..11; } mandatory true; }
     }
   }
 }

--- a/src/lib/yang/README.md
+++ b/src/lib/yang/README.md
@@ -144,8 +144,19 @@ hand.
 
 #### Compiled configurations
 
-[TODO] We will support compiling configurations to an efficient binary
-representation that can be loaded without validation.
+Loading a schema and using it to parse a data file can be a bit
+expensive, especially if the data file includes a large routing table or
+other big structure.  It can be useful to pay for this this parsing and
+validation cost "offline", without interrupting a running data plane.
+
+For this reason, Snabb support compiling configurations to binary data.
+A data plane can load a compiled configuration without any validation,
+very cheaply.  Users can explicitly call the `compile_data_for_schema`
+or `compile_data_for_schema_by_name` functions.  Support is planned also
+for automatic compilation and of source configuration files as well, so
+that the user can just edit configurations as text and still take
+advantage of the speedy binary configuration loads when nothing has
+changed.
 
 #### Querying and updating configurations
 
@@ -305,3 +316,33 @@ including some important ones like `union`.
 
 Like `load_data_for_schema`, but identifying the schema by name instead
 of by value, as in `load_schema_by_name`.
+
+— Function **compile_data_for_schema** *schema* *data* *filename* *mtime*
+
+Compile *data*, using a compiler generated for *schema*, and write out
+the result to the file named *filename*.  *mtime*, if given, should be a
+table with `secs` and `nsecs` keys indicating the modification time of
+the source file.  This information will be serialized in the compiled
+file, and may be used when loading the file to determine whether the
+configuration is up to date.
+
+— Function **compile_data_for_schema_by_name** *schema_name* *data* *filename* *mtime*
+
+Like `compile_data_for_schema_by_name`, but identifying the schema by
+name instead of by value, as in `load_schema_by_name`.
+
+— Function **load_compiled_data_file** *filename*
+
+Load the compiled data file at *filename*.  If the file is not a
+compiled YANG configuration, an error will be signalled.  The return
+value will be table containing four keys:
+
+ * `schema_name`: The name of the schema for which this file was
+    compiled.
+ * `revision_date`: The revision date  of the schema for which this file
+    was compiled, or the empty string (`''`) if unknown.
+ * `source_mtime`: An `mtime` table, as for `compile_data_for_schema`.
+    If no mtime was written into the file, both `secs` and `nsecs` will
+    be zero.
+ * `data`: The configuration data, in the same format as returned by
+    `load_data_for_schema`.

--- a/src/lib/yang/README.md
+++ b/src/lib/yang/README.md
@@ -187,7 +187,35 @@ partial) state data.
 #### API reference
 
 The public entry point to the YANG library is the `lib.yang.yang`
-module, which exports the following bindings:
+module, which exports the following bindings.  Note that unless you have
+special needs, probably the only one you want to use is
+`load_configuration`.
+
+— Function **load_configuration** *filename* *parameters*
+
+Load a configuration from disk.  If *filename* is a compiled
+configuration, load it directly.  Otherwise it must be a source file.
+In that case, try to load a corresponding compiled file instead if
+possible.  If all that fails, actually parse the source configuration,
+and try to residualize a corresponding compiled file so that we won't
+have to go through the whole thing next time.
+
+*parameters* is a table of key/value pairs.  The following key is
+required:
+
+ * `schema_name`: The name of the YANG schema that describes the
+   configuration.   This is the name that appears as the *id* in `module
+   id { ... }` in the schema.
+
+Optional entries that may be present in the *parameters* table include:
+
+ * `verbose`: Set to true to print verbose information about which files
+   are being loaded and compiled.
+ * `revision_date`: If set, assert that the loaded configuration was
+   built against this particular schema revision date.
+
+For more information on the format of the returned value, see the
+documentation below for `load_data_for_schema`.
 
 — Function **load_schema** *src* *filename*
 

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -331,6 +331,12 @@ local function read_compiled_data(stream, strtab)
    return read1()
 end
 
+function has_magic(stream)
+   local success, header = pcall(stream.read_ptr, stream, header_t)
+   stream:seek(0)
+   return success and ffi.string(header.magic, ffi.sizeof(header.magic)) == MAGIC
+end
+
 function load_compiled_data(stream)
    local uint32_t = ffi.typeof('uint32_t')
    function stream:read_uint32()

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -1,0 +1,296 @@
+-- Use of this source code is governed by the Apache 2.0 license; see
+-- COPYING.
+module(..., package.seeall)
+
+local ffi = require("ffi")
+local schema = require("lib.yang.schema")
+local util = require("lib.yang.util")
+local value = require("lib.yang.value")
+local stream = require("lib.yang.stream")
+local data = require('lib.yang.data')
+
+local MAGIC = "yangconf"
+local VERSION = 0x00001000
+
+local header_t = ffi.typeof([[
+struct {
+   uint8_t magic[8];
+   uint32_t version;
+   uint64_t source_mtime_sec;
+   uint32_t source_mtime_nsec;
+   uint32_t schema_name;
+   uint32_t revision_date;
+   uint32_t data_start;
+   uint32_t data_len;
+   uint32_t strtab_start;
+   uint32_t strtab_len;
+}
+]])
+
+-- A string table is written out as a uint32 count, followed by that
+-- many offsets indicating where the Nth string ends, followed by the
+-- string data for those strings.
+local function string_table_builder()
+   local strtab = {}
+   local strings = {}
+   local count = 0
+   function strtab:intern(str)
+      if strings[str] then return strings[str] end
+      strings[str] = count
+      count = count + 1
+      return strings[str]
+   end
+   function strtab:emit(stream)
+      local by_index = {}
+      for str, idx in pairs(strings) do by_index[idx] = str end
+      stream:align(4)
+      local strtab_start = stream.written
+      stream:write_uint32(count)
+      local str_end = 0
+      for i=0,count-1 do
+         str_end = str_end + by_index[i]:len()
+         stream:write_uint32(str_end)
+      end
+      for i=0,count-1 do
+         str_end = str_end + by_index[i]:len()
+         stream:write(by_index[i], by_index[i]:len())
+      end
+      return strtab_start, stream.written - strtab_start
+   end
+   return strtab
+end
+
+local function read_string_table(stream, strtab_len)
+   stream:align(4)
+   assert(strtab_len >= 4)
+   local count = stream:read_uint32()
+   assert(strtab_len >= (4 * (count + 1)))
+   local offsets = stream:read_array(ffi.typeof('uint32_t'), count)
+   assert(strtab_len == (4 * (count + 1)) + offsets[count-1])
+   local strings = {}
+   local offset = 0
+   for i=0,count-1 do
+      local len = offsets[i] - offset
+      assert(len >= 0)
+      strings[i] = stream:read_string(len)
+      offset = offset + len
+   end
+   return strings
+end
+
+-- TODO: Implement raw structs, arrays, and tables, as follows:
+
+-- RawStruct ::= Tag<RawStruct> CData
+-- CData ::= CType CDataContents
+-- CType ::= StringRef of ffi type
+-- CDataContents ::= raw data as bytes
+-- 
+-- -- CType is something like "struct { int32 a; double b; }", suitable
+-- -- to pass to ffi.typeof.  The data itself will be aligned to the type
+-- -- alignment and padded on the end to next 32-bit boundary.
+
+-- -- For RawArray, the CType indicates the type of a single item.
+-- RawArray ::= Tag<RawArray> ArrayCount CData
+-- CArray ::= CType CArrayContents
+-- CType ::= StringRef of ffi type
+-- CArrayContents ::= raw data as bytes
+
+-- -- Here the raw keys or values, respectively, are collected into an
+-- -- array as in RawArray, and then the tagged values or keys follow.
+-- -- Note that the CType denotes the key or value type, not the type of
+-- -- the array as a whole.  As before, when the table is loaded by the
+-- -- data plane, it will have to build a Lua table on its own.  (Perhaps
+-- -- we could optimize this in the RawTagged case by using a ctable for
+-- -- the keys.)
+-- RawTaggedTable ::= Tag<RawTaggedTable> TableCount CData SubData...
+-- TaggedRawTable ::= Tag<TaggedRawTable> TableCount CData SubData...
+-- 
+-- -- This is the case we are optimizing for with the binding table: here
+-- -- we just serialize the CTable.
+-- RawRawTable ::= Tag<RawRawTable> CTable
+-- CTable ::= KeyType ValueType CTableHeader CTableData
+-- KeyType ::= CType
+-- ValueType ::= CType
+-- CTableHeader ::= CTableSize CTableOccupancy CTableMaxDisplacement \
+--                  CTableMaxOccupancyRate CTableMinOccupancyRate
+-- CTableSize ::= uint32 count for number of slots in table including empty
+-- CTableOccupancy ::= uint32 count for number of occupied slots in table
+-- CTableMaxDisplacement ::= uint32 measured maximum displacement for table
+-- CTableMaxOccupancyRate ::= configured maximum fraction of occupied slots as double before resize
+-- CTableMinOccupancyRate ::= configured minimum fraction of occupied slots as double before resize
+-- CTableData ::= raw entries as bytes
+-- 
+-- -- The number of slots in the table will be CTableSize +
+-- -- CTableMaxDisplacement + 1.  We assume that the code that generates
+-- -- the compiled configuration is using the same hash function as the
+-- -- code that uses the compiled table.
+
+local value_emitters = {}
+local function value_emitter(primitive_type)
+   print(primitive_type)
+   local ctype = assert(assert(value.types[primitive_type]).ctype)
+   if value_emitters[ctype] then return value_emitters[ctype] end
+   local type = ffi.typeof(ctype)
+   local align = ffi.alignof(type)
+   local size = ffi.sizeof(type)
+   local buf = ffi.typeof('$[1]', type)()
+   local function emit(val, stream)
+      buf[0] = val
+      stream:write_ptr(buf)
+   end
+   value_emitters[ctype] = emit
+   return emit
+end
+
+function table_size(tab)
+   local size = 0
+   for k,v in pairs(tab) do size = size + 1 end
+   return size
+end
+
+function data_emitter(production)
+   local handlers = {}
+   local function visit1(production)
+      return assert(handlers[production.type])(production)
+   end
+   local function visitn(productions)
+      local ret = {}
+      for keyword,production in pairs(productions) do
+         ret[keyword] = visit1(production)
+      end
+      return ret
+   end
+   function handlers.struct(production)
+      local member_names = {}
+      for k,_ in pairs(production.members) do table.insert(member_names, k) end
+      table.sort(member_names)
+      local emit_member = visitn(production.members)
+      return function(data, stream)
+         stream:write_stringref('tagged-struct')
+         stream:write_uint32(table_size(data))
+         for _,k in ipairs(member_names) do
+            if data[k] ~= nil then
+               stream:write_stringref(k)
+               emit_member[k](data[k], stream)
+            end
+         end
+      end
+   end
+   function handlers.array(production)
+      local emit_tagged_value = visit1(
+         {type='scalar', argument_type=production.element_type})
+      return function(data, stream)
+         stream:write_stringref('tagged-array')
+         stream:write_uint32(#data)
+         for i=1,#data do emit_tagged_value(data[i], stream) end
+      end
+   end
+   function handlers.table(production)
+      local emit_key = visit1({type='struct', members=production.keys})
+      local emit_value = visit1({type='struct', members=production.values})
+      return function(data, stream)
+         stream:write_stringref('tagged-table')
+         stream:write_uint32(#data)
+         -- FIXME: relies on data being an assoc
+         for _,v in ipairs(data) do
+            emit_key(v.key, stream)
+            emit_value(v.key, stream)
+         end
+      end
+   end
+   function handlers.scalar(production)
+      local primitive_type = production.argument_type.primitive_type
+      -- FIXME: needs a case for unions
+      if primitive_type == 'string' then
+         return function(data, stream)
+            stream:write_stringref('tagged-string')
+            stream:write_stringref(data)
+         end
+      else
+         local emit_value = value_emitter(primitive_type)
+         return function(data, stream)
+            stream:write_stringref('cdata')
+            stream:write_stringref(primitive_type)
+            emit_value(data, stream)
+         end
+      end
+   end
+
+   return visit1(production)
+end
+
+function data_compiler_from_grammar(emit_data, schema_name, schema_revision)
+   return function(data, filename, source_mtime)
+      source_mtime = source_mtime or {sec=0, nsec=0}
+      local stream = stream.open_temporary_output_byte_stream(filename)
+      local strtab = string_table_builder()
+      local header = header_t(
+         MAGIC, VERSION, source_mtime.sec, source_mtime.nsec,
+         strtab:intern(schema_name), strtab:intern(schema_revision or ''))
+      stream:write_ptr(header) -- Write with empty data_len etc, fix it later.
+      stream:align(4)
+      header.data_start = stream.written
+      local u32buf = ffi.new('uint32_t[1]')
+      function stream:write_uint32(val)
+         u32buf[0] = val
+         return self:write_ptr(u32buf)
+      end
+      function stream:write_stringref(str)
+         return self:write_uint32(strtab:intern(str))
+      end
+      emit_data(data, stream)
+      header.data_len = stream.written - header.data_start
+      header.strtab_start, header.strtab_len = strtab:emit(stream)
+      stream:rewind()
+      -- Fix up header.
+      stream:write_ptr(header)
+      stream:close_and_rename()
+   end
+end
+
+function data_compiler_from_schema(schema)
+   local grammar = data.data_grammar_from_schema(schema)
+   return data_compiler_from_grammar(data_emitter(grammar),
+                                     schema.id, schema.revision_date)
+end
+
+function compile_data_for_schema(schema, data, filename, source_mtime)
+   return data_compiler_from_schema(schema)(data, filename, source_mtime)
+end
+
+function compile_data_for_schema_by_name(schema_name, data, filename, source_mtime)
+   return compile_data_for_schema(schema.load_schema_by_name(schema_name),
+                                  data, filename, source_mtime)
+end
+
+function selftest()
+   local test_schema = schema.load_schema([[module snabb-simple-router {
+      namespace snabb:simple-router;
+      prefix simple-router;
+
+      import ietf-inet-types {prefix inet;}
+
+      leaf active { type boolean; default true; }
+
+      container routes {
+         presence true;
+         list route {
+            key addr;
+            leaf addr { type inet:ipv4-address; mandatory true; }
+            leaf port { type uint8 { range 0..11; } mandatory true; }
+         }
+      }
+   }]])
+   local data = data.load_data_for_schema(test_schema, [[
+      active true;
+      routes {
+        route { addr 1.2.3.4; port 1; }
+        route { addr 2.3.4.5; port 10; }
+        route { addr 3.4.5.6; port 2; }
+      }
+   ]])
+
+   local tmp = os.tmpname()
+   compile_data_for_schema(test_schema, data, tmp)
+   os.remove(tmp)
+end

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -157,7 +157,7 @@ local function data_emitter(production)
       end
       return ret
    end
-   function handlers.struct(production)
+   function handlers.tagged_struct(production)
       local member_names = {}
       for k,_ in pairs(production.members) do table.insert(member_names, k) end
       table.sort(member_names)
@@ -173,7 +173,7 @@ local function data_emitter(production)
          end
       end
    end
-   function handlers.array(production)
+   function handlers.tagged_array(production)
       local emit_tagged_value = visit1(
          {type='scalar', argument_type=production.element_type})
       return function(data, stream)
@@ -182,9 +182,9 @@ local function data_emitter(production)
          for i=1,#data do emit_tagged_value(data[i], stream) end
       end
    end
-   function handlers.table(production)
-      local emit_key = visit1({type='struct', members=production.keys})
-      local emit_value = visit1({type='struct', members=production.values})
+   function handlers.tagged_tagged_table(production)
+      local emit_key = visit1({type='tagged_struct', members=production.keys})
+      local emit_value = visit1({type='tagged_struct', members=production.values})
       return function(data, stream)
          stream:write_stringref('tagged-table')
          stream:write_uint32(#data)
@@ -214,7 +214,7 @@ local function data_emitter(production)
       end
    end
 
-   return visit1(production)
+   return visit1(data.choose_representations(production))
 end
 
 function data_compiler_from_grammar(emit_data, schema_name, schema_revision)

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -78,53 +78,6 @@ local function read_string_table(stream, strtab_len)
    return strings
 end
 
--- TODO: Implement raw structs, arrays, and tables, as follows:
-
--- RawStruct ::= Tag<RawStruct> CData
--- CData ::= CType CDataContents
--- CType ::= StringRef of ffi type
--- CDataContents ::= raw data as bytes
--- 
--- -- CType is something like "struct { int32 a; double b; }", suitable
--- -- to pass to ffi.typeof.  The data itself will be aligned to the type
--- -- alignment and padded on the end to next 32-bit boundary.
-
--- -- For RawArray, the CType indicates the type of a single item.
--- RawArray ::= Tag<RawArray> ArrayCount CData
--- CArray ::= CType CArrayContents
--- CType ::= StringRef of ffi type
--- CArrayContents ::= raw data as bytes
-
--- -- Here the raw keys or values, respectively, are collected into an
--- -- array as in RawArray, and then the tagged values or keys follow.
--- -- Note that the CType denotes the key or value type, not the type of
--- -- the array as a whole.  As before, when the table is loaded by the
--- -- data plane, it will have to build a Lua table on its own.  (Perhaps
--- -- we could optimize this in the RawTagged case by using a ctable for
--- -- the keys.)
--- RawTaggedTable ::= Tag<RawTaggedTable> TableCount CData SubData...
--- TaggedRawTable ::= Tag<TaggedRawTable> TableCount CData SubData...
--- 
--- -- This is the case we are optimizing for with the binding table: here
--- -- we just serialize the CTable.
--- RawRawTable ::= Tag<RawRawTable> CTable
--- CTable ::= KeyType ValueType CTableHeader CTableData
--- KeyType ::= CType
--- ValueType ::= CType
--- CTableHeader ::= CTableSize CTableOccupancy CTableMaxDisplacement \
---                  CTableMaxOccupancyRate CTableMinOccupancyRate
--- CTableSize ::= uint32 count for number of slots in table including empty
--- CTableOccupancy ::= uint32 count for number of occupied slots in table
--- CTableMaxDisplacement ::= uint32 measured maximum displacement for table
--- CTableMaxOccupancyRate ::= configured maximum fraction of occupied slots as double before resize
--- CTableMinOccupancyRate ::= configured minimum fraction of occupied slots as double before resize
--- CTableData ::= raw entries as bytes
--- 
--- -- The number of slots in the table will be CTableSize +
--- -- CTableMaxDisplacement + 1.  We assume that the code that generates
--- -- the compiled configuration is using the same hash function as the
--- -- code that uses the compiled table.
-
 local value_emitters = {}
 local function value_emitter(ctype)
    if value_emitters[ctype] then return value_emitters[ctype] end
@@ -163,12 +116,16 @@ local function data_emitter(production)
       for k,_ in pairs(production.members) do table.insert(member_names, k) end
       table.sort(member_names)
       if production.ctype then
-         error('unimplemented')
+         return function(data, stream)
+            stream:write_stringref('cdata')
+            stream:write_stringref(production.ctype)
+            stream:write_ptr(data)
+         end
       else
          local emit_member = visitn(production.members)
          local normalize_id = data.normalize_id
          return function(data, stream)
-            stream:write_stringref('tagged-struct')
+            stream:write_stringref('lstruct')
             stream:write_uint32(table_size(data))
             for _,k in ipairs(member_names) do
                local id = normalize_id(k)
@@ -182,12 +139,18 @@ local function data_emitter(production)
    end
    function handlers.array(production)
       if production.ctype then
-         error('unimplemented')
+         local emit_value = value_emitter(production.ctype)
+         return function(data, stream)
+            stream:write_stringref('carray')
+            stream:write_stringref(production.ctype)
+            stream:write_uint32(#data)
+            stream:write_array(data, ffi.typeof(production.ctype), #data)
+         end
       else
          local emit_tagged_value = visit1(
             {type='scalar', argument_type=production.element_type})
          return function(data, stream)
-            stream:write_stringref('tagged-array')
+            stream:write_stringref('larray')
             stream:write_uint32(#data)
             for i=1,#data do emit_tagged_value(data[i], stream) end
          end
@@ -201,22 +164,41 @@ local function data_emitter(production)
             stream:write_stringref(production.value_ctype)
             data:save(stream)
          end
-      else
-         -- TODO: here we should implement mixed table types if key_t or
-         -- value_t is non-nil, or string-keyed tables if the key is a
-         -- string.  For the moment, fall back to the old assoc
-         -- implementation.
-         -- if production.key_ctype then error('unimplemented') end
-         -- if production.value_ctype then error('unimplemented') end
-         local emit_key = visit1({type='struct', members=production.keys})
+      elseif production.string_key then
+         local emit_value = visit1({type='struct', members=production.values,
+                                    ctype=production.value_ctype})
+         -- FIXME: sctable if production.value_ctype?
+         return function(data, stream)
+            -- A string-keyed table is the same as a tagged struct.
+            stream:write_stringref('lstruct')
+            stream:write_uint32(table_size(data))
+            for k,v in pairs(data) do
+               stream:write_stringref(k)
+               emit_value(v, stream)
+            end
+         end
+      elseif production.key_ctype then
+         local emit_keys = visit1({type='table', key_ctype=production.key_ctype,
+                                   value_ctype='uint32_t'})
          local emit_value = visit1({type='struct', members=production.values})
          return function(data, stream)
-            stream:write_stringref('tagged-table')
-            stream:write_uint32(#data)
-            -- FIXME: relies on data being an assoc
-            for _,v in ipairs(data) do
-               emit_key(v.key, stream)
-               emit_value(v.value, stream)
+            stream:write_stringref('cltable')
+            emit_keys(data.keys)
+            stream:write_uint32(#data.values)
+            for i=1,#data.values do emit_value(data.values[i], stream) end
+         end
+      else
+         local emit_key = visit1({type='struct', members=production.keys,
+                                  ctype=production.key_ctype})
+         local emit_value = visit1({type='struct', members=production.values,
+                                    ctype=production.value_ctype})
+         -- FIXME: lctable if production.value_ctype?
+         return function(data, stream)
+            stream:write_stringref('lltable')
+            stream:write_uint32(table_count(data))
+            for k,v in pairs(data) do
+               emit_key(k, stream)
+               emit_value(v, stream)
             end
          end
       end
@@ -226,7 +208,7 @@ local function data_emitter(production)
       -- FIXME: needs a case for unions
       if primitive_type == 'string' then
          return function(data, stream)
-            stream:write_stringref('tagged-string')
+            stream:write_stringref('stringref')
             stream:write_stringref(data)
          end
       else
@@ -290,12 +272,18 @@ local function read_compiled_data(stream, strtab)
    local function read_string()
       return assert(strtab[stream:read_uint32()])
    end
+   local ctypes = {}
+   local function scalar_type(ctype)
+      if not ctypes[ctype] then ctypes[ctype] = ffi.typeof(ctype) end
+      return ctypes[ctype]
+   end
+
    local readers = {}
    local function read1()
       local tag = read_string()
       return assert(readers[tag], tag)()
    end
-   readers['tagged-struct'] = function ()
+   function readers.lstruct()
       local ret = {}
       for i=1,stream:read_uint32() do
          local k = read_string()
@@ -303,12 +291,28 @@ local function read_compiled_data(stream, strtab)
       end
       return ret
    end
-   readers['tagged-array'] = function ()
+   function readers.carray()
+      local ctype = scalar_type(read_string())
+      return stream:read_array(ctype, stream:read_uint32())
+   end
+   function readers.larray()
       local ret = {}
       for i=1,stream:read_uint32() do table.insert(ret, read1()) end
       return ret
    end
-   readers['tagged-table'] = function ()
+   function readers.ctable()
+      local key_ctype = read_string()
+      local value_ctype = read_string()
+      local key_t, value_t = ffi.typeof(key_ctype), ffi.typeof(value_ctype)
+      return ctable.load(stream, {key_type=key_t, value_type=value_t})
+   end
+   function readers.cltable()
+      local keys = read1()
+      local values = {}
+      for i=1,stream:read_uint32() do table.insert(values, read1()) end
+      return cltable.build(keys, values)
+   end
+   function readers.lltable()
       local ret = data.make_assoc()
       for i=1,stream:read_uint32() do
          local k = read1()
@@ -316,21 +320,10 @@ local function read_compiled_data(stream, strtab)
       end
       return ret
    end
-   readers['ctable'] = function ()
-      local key_ctype = read_string()
-      local value_ctype = read_string()
-      local key_t, value_t = ffi.typeof(key_ctype), ffi.typeof(value_ctype)
-      return ctable.load(stream, {key_type=key_t, value_type=value_t})
-   end
-   readers['tagged-string'] = function ()
+   function readers.stringref()
       return read_string()
    end
-   local ctypes = {}
-   local function scalar_type(ctype)
-      if not ctypes[ctype] then ctypes[ctype] = ffi.typeof(ctype) end
-      return ctypes[ctype]
-   end
-   readers['cdata'] = function ()
+   function readers.cdata()
       local ctype = scalar_type(read_string())
       return stream:read_ptr(ctype)[0]
    end
@@ -365,6 +358,7 @@ function load_compiled_data_file(filename)
 end
 
 function selftest()
+   print('selfcheck: lib.yang.binary')
    local test_schema = schema.load_schema([[module snabb-simple-router {
       namespace snabb:simple-router;
       prefix simple-router;
@@ -393,23 +387,20 @@ function selftest()
 
    local ipv4 = require('lib.protocol.ipv4')
 
-   assert(data.is_active == true)
-   local routing_table = data.routes.route
-   assert(routing_table:lookup_ptr(ipv4:pton('1.2.3.4')).value.port == 1)
-   assert(routing_table:lookup_ptr(ipv4:pton('2.3.4.5')).value.port == 10)
-   assert(routing_table:lookup_ptr(ipv4:pton('3.4.5.6')).value.port == 2)
+   for i=1,3 do
+      assert(data.is_active == true)
+      local routing_table = data.routes.route
+      assert(routing_table:lookup_ptr(ipv4:pton('1.2.3.4')).value.port == 1)
+      assert(routing_table:lookup_ptr(ipv4:pton('2.3.4.5')).value.port == 10)
+      assert(routing_table:lookup_ptr(ipv4:pton('3.4.5.6')).value.port == 2)
 
-   local tmp = os.tmpname()
-   compile_data_for_schema(test_schema, data, tmp)
-   local data2 = load_compiled_data_file(tmp)
-   assert(data2.schema_name == 'snabb-simple-router')
-   assert(data2.revision_date == '')
-   data = data2.data
-   os.remove(tmp)
-
-   assert(data.is_active == true)
-   local routing_table = data.routes.route
-   assert(routing_table:lookup_ptr(ipv4:pton('1.2.3.4')).value.port == 1)
-   assert(routing_table:lookup_ptr(ipv4:pton('2.3.4.5')).value.port == 10)
-   assert(routing_table:lookup_ptr(ipv4:pton('3.4.5.6')).value.port == 2)
+      local tmp = os.tmpname()
+      compile_data_for_schema(test_schema, data, tmp)
+      local data2 = load_compiled_data_file(tmp)
+      assert(data2.schema_name == 'snabb-simple-router')
+      assert(data2.revision_date == '')
+      data = data2.data
+      os.remove(tmp)
+   end
+   print('selfcheck: ok')
 end

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -165,13 +165,15 @@ local function data_emitter(production)
          error('unimplemented')
       else
          local emit_member = visitn(production.members)
+         local normalize_id = data.normalize_id
          return function(data, stream)
             stream:write_stringref('tagged-struct')
             stream:write_uint32(table_size(data))
             for _,k in ipairs(member_names) do
-               if data[k] ~= nil then
-                  stream:write_stringref(k)
-                  emit_member[k](data[k], stream)
+               local id = normalize_id(k)
+               if data[id] ~= nil then
+                  stream:write_stringref(id)
+                  emit_member[k](data[id], stream)
                end
             end
          end
@@ -355,7 +357,7 @@ function selftest()
 
       import ietf-inet-types {prefix inet;}
 
-      leaf active { type boolean; default true; }
+      leaf is-active { type boolean; default true; }
 
       container routes {
          presence true;
@@ -367,7 +369,7 @@ function selftest()
       }
    }]])
    local data = data.load_data_for_schema(test_schema, [[
-      active true;
+      is-active true;
       routes {
         route { addr 1.2.3.4; port 1; }
         route { addr 2.3.4.5; port 10; }
@@ -383,7 +385,7 @@ function selftest()
    local ipv4 = require('lib.protocol.ipv4')
    assert(data2.schema_name == 'snabb-simple-router')
    assert(data2.revision_date == '')
-   assert(data2.data.active == true)
+   assert(data2.data.is_active == true)
    -- These tests don't work yet because we need to fix our
    -- associative data structure to usefully allow cdata keys.
    -- assert(data2.data.routes.route:get_value(ipv4:pton('1.2.3.4')).port == 1)

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -164,7 +164,7 @@ end
 
 -- Simple temporary associative array until we get the various Table
 -- kinds working.
-local function make_assoc()
+function make_assoc()
    local assoc = {}
    function assoc:get_entry(k)
       assert(type(k) ~= 'table', 'multi-key lookup unimplemented')

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -181,16 +181,20 @@ local function array_parser(keyword, element_type, ctype)
    local parsev = value_parser(element_type)
    local function parse1(node)
       assert_scalar(node, keyword)
-      return parsev(node.argument, k)
+      return parsev(node.argument, keyword)
    end
    local function parse(node, out)
       table.insert(out, parse1(node))
       return out
    end
-   local array_t = ctype and ffi.typeof('$[?]', ffi.typeof(ctype))
+   local elt_t = ctype and ffi.typeof(ctype)
+   local array_t = ctype and ffi.typeof('$[?]', ffi.typeof(elt_t))
    local function finish(out)
       -- FIXME check min-elements
-      if array_t then return array_t(out) else return out end
+      if array_t then
+         out = util.ffi_array(array_t(#out, out), elt_t)
+      end
+      return out
    end
    return {init=init, parse=parse, finish=finish}
 end

--- a/src/lib/yang/stream.lua
+++ b/src/lib/yang/stream.lua
@@ -1,0 +1,167 @@
+module(..., package.seeall)
+
+local ffi = require("ffi")
+local S = require("syscall")
+local lib = require("core.lib")
+
+local function round_up(x, y) return y*math.ceil(x/y) end
+
+function open_output_byte_stream(filename)
+   local fd, err =
+      S.open(filename, "creat, wronly, trunc", "rusr, wusr, rgrp, roth")
+   if not fd then
+      error("error opening output file "..filename..": "..tostring(err))
+   end
+   local ret = { written = 0, name = filename }
+   function ret:close()
+      fd:close()
+   end
+   function ret:error(msg)
+      self:close()
+      error('while writing file '..filename..': '..msg)
+   end
+   function ret:write(ptr, size)
+      assert(size)
+      ptr = ffi.cast("uint8_t*", ptr)
+      local to_write = size
+      while to_write > 0 do
+         local written, err = S.write(fd, ptr, to_write)
+         if not written then self:error(err) end
+         ptr = ptr + written
+         self.written = self.written + written
+         to_write = to_write - written
+      end
+   end
+   function ret:write_ptr(ptr)
+      self:align(ffi.alignof(ptr))
+      self:write(ptr, ffi.sizeof(ptr))
+   end
+   function ret:rewind()
+      fd:seek(0, 'set')
+      ret.written = 0 -- more of a position at this point
+   end
+   function ret:write_array(ptr, type, count)
+      self:align(ffi.alignof(type))
+      self:write(ptr, ffi.sizeof(type) * count)
+   end
+   function ret:align(alignment)
+      local padding = round_up(self.written, alignment) - self.written
+      self:write(string.rep(' ', padding), padding)
+   end
+   return ret
+end
+
+local function mktemp(name, mode)
+   if not mode then mode = "rusr, wusr, rgrp, roth" end
+   -- FIXME: If nothing seeds math.random, this produces completely
+   -- predictable numbers.
+   local t = math.random(1e7)
+   local tmpnam, fd, err
+   for i = t, t+10 do
+      tmpnam = name .. '.' .. i
+      fd, err = S.open(tmpnam, "creat, wronly, excl", mode)
+      if fd then
+         fd:close()
+         return tmpnam, nil
+      end
+      i = i + 1
+   end
+   return nil, err
+end
+
+function open_temporary_output_byte_stream(target)
+   local tmp_file, err = mktemp(target)
+   if not tmp_file then
+      local dir = lib.dirname(target)
+      error("failed to create temporary file in "..dir..": "..tostring(err))
+   end
+   local stream = open_output_byte_stream(tmp_file)
+   function stream:close_and_rename()
+      self:close()
+      local res, err = S.rename(tmp_file, target)
+      if not res then
+         error("failed to rename "..tmp_file.." to "..target..": "..err)
+      end
+   end
+   return stream
+end
+
+-- FIXME: Try to copy file into huge pages?
+function open_input_byte_stream(filename)
+   local fd, err = S.open(filename, "rdonly")
+   if not fd then return 
+      error("error opening "..filename..": "..tostring(err))
+   end
+   local stat = S.fstat(fd)
+   local size = stat.size
+   local mem, err = S.mmap(nil, size, 'read, write', 'private', fd, 0)
+   fd:close()
+   if not mem then error("mmap failed: " .. tostring(err)) end
+   mem = ffi.cast("uint8_t*", mem)
+   local pos = 0
+   local ret = {
+      name=filename,
+      mtime_sec=stat.st_mtime,
+      mtime_nsec=stat.st_mtime_nsec
+   }
+   function ret:close()
+      -- FIXME: Currently we don't unmap any memory.
+      -- S.munmap(mem, size)
+      mem, pos = nil, nil
+   end
+   function ret:error(msg)
+      error('while reading file '..filename..': '..msg)
+   end
+   function ret:read(count)
+      assert(count >= 0)
+      local ptr = mem + pos
+      pos = pos + count
+      if pos > size then
+         self:error('unexpected EOF')
+      end
+      return ptr
+   end
+   function ret:align(alignment)
+      self:read(round_up(pos, alignment) - pos)
+   end
+   function ret:seek(new_pos)
+      assert(new_pos >= 0)
+      assert(new_pos <= size)
+      pos = new_pos
+   end
+   function ret:read_ptr(type)
+      ret:align(ffi.alignof(type))
+      return ffi.cast(ffi.typeof('$*', type), ret:read(ffi.sizeof(type)))
+   end
+   function ret:read_array(type, count)
+      ret:align(ffi.alignof(type))
+      return ffi.cast(ffi.typeof('$*', type),
+                      ret:read(ffi.sizeof(type) * count))
+   end
+   function ret:read_char()
+      return ffi.string(ret:read(1), 1)
+   end
+   function ret:as_text_stream(len)
+      local end_pos = size
+      if len then end_pos = pos + len end
+      return {
+         name = ret.name,
+         mtime_sec = ret.mtime_sec,
+         mtime_nsec = ret.mtime_nsec,
+         read = function(self, n)
+            assert(n==1)
+            if pos == end_pos then return nil end
+            return ret:read_char()
+         end,
+         close = function() ret:close() end
+      }
+   end
+   return ret
+end
+
+-- You're often better off using Lua's built-in files.  This is here
+-- because it gives a file-like object whose FD you can query, for
+-- example to get its mtime.
+function open_input_text_stream(filename)
+   return open_input_byte_stream(filename):as_text_stream()
+end

--- a/src/lib/yang/stream.lua
+++ b/src/lib/yang/stream.lua
@@ -125,6 +125,7 @@ function open_input_byte_stream(filename)
       self:read(round_up(pos, alignment) - pos)
    end
    function ret:seek(new_pos)
+      if new_pos == nil then return pos end
       assert(new_pos >= 0)
       assert(new_pos <= size)
       pos = new_pos

--- a/src/lib/yang/stream.lua
+++ b/src/lib/yang/stream.lua
@@ -142,6 +142,9 @@ function open_input_byte_stream(filename)
    function ret:read_char()
       return ffi.string(ret:read(1), 1)
    end
+   function ret:read_string()
+      return ffi.string(ret:read(size - pos), size - pos)
+   end
    function ret:as_text_stream(len)
       local end_pos = size
       if len then end_pos = pos + len end

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -34,8 +34,13 @@ function tointeger(str, what, min, max)
    if is_negative then
       res = ffi.new('int64_t[1]', -1*res)[0]
       check(res <= 0)
+      if min then check(min <= 0 and min <= res) end
+   else
+      -- Only compare min and res if both are positive, otherwise if min
+      -- is a negative int64_t then the comparison will treat it as a
+      -- large uint64_t.
+      if min then check(min <= 0 or min <= res) end
    end
-   if min then check(min <= res) end
    if max then check(res <= max) end
    -- Only return Lua numbers for values within int32 + uint32 range.
    if -0x8000000 <= res and res <= 0xffffffff then return tonumber(res) end

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -47,6 +47,29 @@ function tointeger(str, what, min, max)
    return res
 end
 
+function ffi_array(ptr, elt_t, count)
+   local mt = {}
+   local size = count or ffi.sizeof(ptr)/ffi.sizeof(elt_t)
+   function mt:__len() return size end
+   function mt:__index(idx)
+      assert(1 <= idx and idx <= size)
+      return ptr[idx-1]
+   end
+   function mt:__setindex(idx, val)
+      assert(1 <= idx and idx <= size)
+      ptr[idx-1] = val
+   end
+   function mt:__ipairs()
+      local idx = -1
+      return function()
+         idx = idx + 1
+         if idx >= size then return end
+         return idx+1, ptr[idx]
+      end
+   end
+   return ffi.metatype(ffi.typeof('struct { $* ptr; }', elt_t), mt)(ptr)
+end
+
 function selftest()
    assert(tointeger('0') == 0)
    assert(tointeger('-0') == 0)

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -62,7 +62,7 @@ end
 types.binary = unimplemented('binary')
 types.bits = unimplemented('bits')
 
-types.boolean = {}
+types.boolean = {ctype='bool'}
 function types.boolean.parse(str, what)
    local str = assert(str, 'missing value for '..what)
    if str == 'true' then return true end

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -5,6 +5,8 @@ module(..., package.seeall)
 local util = require("lib.yang.util")
 local ipv4 = require("lib.protocol.ipv4")
 local ipv6 = require("lib.protocol.ipv6")
+local ffi = require("ffi")
+local bit = require("bit")
 local ethernet = require("lib.protocol.ethernet")
 
 -- FIXME:
@@ -16,8 +18,15 @@ local ethernet = require("lib.protocol.ethernet")
 
 types = {}
 
-local function integer_type(min, max)
-   local ret = {}
+local function integer_type(ctype)
+   local ret = {ctype=ctype}
+   local min, max = ffi.new(ctype, 0), ffi.new(ctype, -1)
+   if max < 0 then
+      -- A signed type.  Hackily rely on unsigned types having 'u'
+      -- prefix.
+      max = ffi.new(ctype, bit.rshift(ffi.new('u'..ctype, max), 1))
+      min = max - max - max - 1
+   end
    function ret.parse(str, what)
       return util.tointeger(str, what, min, max)
    end
@@ -30,14 +39,14 @@ local function integer_type(min, max)
    return ret
 end
 
-types.int8 = integer_type(-0xf0, 0x7f)
-types.int16 = integer_type(-0xf000, 0x7fff)
-types.int32 = integer_type(-0xf000000, 0x7fffffff)
-types.int64 = integer_type(-0xf00000000000000LL, 0x7fffffffffffffffLL)
-types.uint8 = integer_type(0, 0xff)
-types.uint16 = integer_type(0, 0xffff)
-types.uint32 = integer_type(0, 0xffffffff)
-types.uint64 = integer_type(0, 0xffffffffffffffffULL)
+types.int8 = integer_type('int8_t')
+types.int16 = integer_type('int16_t')
+types.int32 = integer_type('int32_t')
+types.int64 = integer_type('int64_t')
+types.uint8 = integer_type('uint8_t')
+types.uint16 = integer_type('uint16_t')
+types.uint32 = integer_type('uint32_t')
+types.uint64 = integer_type('uint64_t')
 
 local function unimplemented(type_name)
    local ret = {}
@@ -81,21 +90,25 @@ end
 types.union = unimplemented('union')
 
 types['ipv4-address'] = {
+   ctype = 'uint8_t[4]',
    parse = function(str, what) return assert(ipv4:pton(str)) end,
    tostring = function(val) return ipv4:ntop(val) end
 }
 
 types['ipv6-address'] = {
+   ctype = 'uint8_t[16]',
    parse = function(str, what) return assert(ipv6:pton(str)) end,
    tostring = function(val) return ipv6:ntop(val) end
 }
 
 types['mac-address'] = {
+   ctype = 'uint8_t[6]',
    parse = function(str, what) return assert(ethernet:pton(str)) end,
    tostring = function(val) return ethernet:ntop(val) end
 }
 
 types['ipv4-prefix'] = {
+   ctype = 'struct { uint8_t[4] prefix; uint8_t len; }',
    parse = function(str, what)
       local prefix, len = str:match('^([^/]+)/(.*)$')
       return { assert(ipv4:pton(prefix)), util.tointeger(len, 1, 32) }
@@ -104,6 +117,7 @@ types['ipv4-prefix'] = {
 }
 
 types['ipv6-prefix'] = {
+   ctype = 'struct { uint8_t[16] prefix; uint8_t len; }',
    parse = function(str, what)
       local prefix, len = str:match('^([^/]+)/(.*)$')
       return { assert(ipv6:pton(prefix)), util.tointeger(len, 1, 128) }
@@ -112,5 +126,11 @@ types['ipv6-prefix'] = {
 }
 
 function selftest()
-   assert(types['uint8'].parse('100') == 100)
+   assert(types['uint8'].parse('0') == 0)
+   assert(types['uint8'].parse('255') == 255)
+   assert(not pcall(types['uint8'].parse, '256'))
+   assert(types['int8'].parse('-128') == -128)
+   assert(types['int8'].parse('0') == 0)
+   assert(types['int8'].parse('127') == 127)
+   assert(not pcall(types['int8'].parse, '128'))
 end

--- a/src/lib/yang/yang.lua
+++ b/src/lib/yang/yang.lua
@@ -3,6 +3,7 @@ module(..., package.seeall)
 
 local schema = require("lib.yang.schema")
 local data = require("lib.yang.data")
+local binary = require("lib.yang.binary")
 
 load_schema = schema.load_schema
 load_schema_file = schema.load_schema_file
@@ -10,6 +11,11 @@ load_schema_by_name = schema.load_schema_by_name
 
 load_data_for_schema = data.load_data_for_schema
 load_data_for_schema_by_name = data.load_data_for_schema_by_name
+
+compile_data_for_schema = binary.compile_data_for_schema
+compile_data_for_schema_by_name = binary.compile_data_for_schema_by_name
+
+load_compiled_data_file = binary.load_compiled_data_file
 
 function selftest()
 end

--- a/src/lib/yang/yang.lua
+++ b/src/lib/yang/yang.lua
@@ -1,9 +1,11 @@
 -- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 module(..., package.seeall)
 
+local lib = require("core.lib")
 local schema = require("lib.yang.schema")
 local data = require("lib.yang.data")
 local binary = require("lib.yang.binary")
+local stream = require("lib.yang.stream")
 
 load_schema = schema.load_schema
 load_schema_file = schema.load_schema_file
@@ -17,5 +19,117 @@ compile_data_for_schema_by_name = binary.compile_data_for_schema_by_name
 
 load_compiled_data_file = binary.load_compiled_data_file
 
+local params = {
+   verbose = {},
+   schema_name = {required=true},
+   revision_date = {},
+}
+
+-- Load the configuration from FILENAME.  If it's compiled, load it
+-- directly.  Otherwise if it's source, then try to load a corresponding
+-- compiled file instead if possible.  If all that fails, actually parse
+-- the source configuration, and try to residualize a corresponding
+-- compiled file so that we won't have to go through the whole thing
+-- next time.
+function load_configuration(filename, opts)
+   opts = lib.parse(opts, params)
+
+   function maybe(f, ...)
+      local function catch(success, ...)
+         if success then return ... end
+      end
+      return catch(pcall(f, ...))
+   end
+   local function err_msg(msg, ...)
+      return string.format('%s: '..msg, filename, ...)
+   end
+   local function err(msg, ...) error(err_msg(msg, ...)) end
+   local function log(msg, ...)
+      io.stderr:write(err_msg(msg, ...)..'\n')
+      io.stderr:flush()
+   end
+   local function assert(exp, msg, ...)
+      if exp then return exp else err(msg, ...) end
+   end
+   local function expect(expected, got, what)
+      assert(expected == got, 'expected %s %s, but got %s', what, expected, got)
+   end
+
+   local function is_fresh(expected, got)
+   end
+   local function load_compiled(stream, source_mtime)
+      local compiled = binary.load_compiled_data(stream)
+      if opts.schema_name then
+         expect(opts.schema_name, compiled.schema_name, 'schema name')
+      end
+      if opts.revision_date then
+         expect(opts.revision_date, compiled.revision_date,
+                'schema revision date')
+      end
+      if source_mtime == nil or
+         (source_mtime.sec == compiled.source_mtime.sec and
+          source_mtime.nsec == compiled.source_mtime.nsec) then
+         return compiled.data
+      end
+   end
+
+   local source = stream.open_input_byte_stream(filename)
+   if binary.has_magic(source) then return load_compiled(source) end
+
+   -- If the file doesn't have the magic, assume it's a source file.
+   -- First, see if we compiled it previously and saved a compiled file
+   -- in a well-known place.
+   local compiled_filename = filename:gsub("%.txt$", "")..'.o'
+   local source_mtime = {sec=source.mtime_sec, nsec=source.mtime_nsec}
+   local compiled_stream = maybe(stream.open_input_byte_stream,
+                                 compiled_filename)
+   if compiled_stream then
+      if binary.has_magic(compiled_stream) then
+         log('loading compiled configuration from %s', compiled_filename)
+         local conf = load_compiled(compiled_stream, source_mtime)
+         if conf then
+            log('compiled configuration %s is up to date.', compiled_filename)
+            return conf
+         end
+         log('compiled configuration %s is out of date; recompiling.',
+             compiled_filename)
+      end
+      compiled_stream:close()
+   end
+
+   -- Load and compile it.
+   local source_str = source:read_string()
+   source:close()
+   log('loading source configuration from %s', filename)
+   local conf = load_data_for_schema_by_name(opts.schema_name, source_str,
+                                             filename)
+
+   -- Save it, if we can.
+   local success, err = pcall(binary.compile_data_for_schema_by_name,
+                              opts.schema_name, conf, compiled_filename,
+                              source_mtime)
+   if not success then
+      log('error saving compiled configuration %s: %s', compiled_filename, err)
+   end
+
+   -- Done.
+   return conf
+end
+
 function selftest()
+   print('selftest: lib.yang.yang')
+   local tmp = os.tmpname()
+   do
+      local file = io.open(tmp, 'w')
+      -- ietf-yang-types only defines types.  FIXME: use a schema that
+      -- actually defines some data nodes.
+      file:write('/* nothing */')
+      file:close()
+   end
+   load_configuration(tmp, {schema_name='ietf-yang-types'})
+   load_configuration(tmp, {schema_name='ietf-yang-types'})
+   os.remove(tmp)
+   load_configuration(tmp..'.o', {schema_name='ietf-yang-types'})
+   os.remove(tmp..'.o')
+   print('selftest: ok')
 end


### PR DESCRIPTION
This branch implements configuration compilation and loading.  It is currently a work in progress; missing items:

- [x] Support for singly-string-keyed tables

- [x] Support for raw keys but non-uniform values

- [x] Support for raw arrays

- [x] Documentation

- [x] Ability to load a configuration from a file and automatically notice if there is a corresponding up-to-date binary

- [x] Ability to automatically compile and residualize compiled configurations to disk, for later opportunistic loading

The ctable compilation is working though, which makes me very excited!!!!!  (A re-open of #531 to avoid showing older already-merged commits.)