### PR TITLE
Increase SnabbVMX nexthop selftest qemu image RAM to 1Gb

### DIFF
--- a/src/program/snabbvmx/tests/nexthop/selftest.sh
+++ b/src/program/snabbvmx/tests/nexthop/selftest.sh
@@ -30,6 +30,7 @@ SNABBVMX_CONF=$SNABBVMX_DIR/tests/conf/snabbvmx-lwaftr.cfg
 SNABBVMX_ID=xe1
 SNABB_TELNET0=5000
 VHU_SOCK0=/tmp/vh1a.sock
+GUEST_MEM=1024
 
 function last_32bit {
     mac=$1


### PR DESCRIPTION
SnabbVMX's nexthop selftest fails intermittently for no obvious reason. When I run it isolated inside a container it always success:

```
$ sudo docker run --rm --privileged -ti -v /home/dpino/workspace/snabb:/snabb 
   -e SNABB_PCI0=0000:81:00.0 -e SNABB_PCI1=0000:81:00.1 lwaftr/snabb-test /bin/bash
# cd snabb && make clean && make
# ./program/snabbvmx/tests/nexthop/selftest.sh
Defaulting to GUEST_MEM=512
Defaulting to HUGETLBFS=/hugetlbfs
Defaulting to QUEUES=1
Defaulting to QEMU=/root/.test_env/qemu/obj/x86_64-softmmu/qemu-system-x86_64
Waiting for VM listening on telnet port 5000 to get ready... [OK]
Resolved MAC inet side: 02:99:99:99:99:99 [OK]
Resolved MAC inet side: 52:f4:99:99:99:99 [OK]
```

Before I refactored SnabbVMX selftests I remember I was using a higher amount of RAM for the QEMU image, so I want to increase the amount of RAM and check if that fixes the issue once and for all. If it continues happening I'm afraid we should need to skip this test temporarily.