### PR TITLE
Rename counters var

### DIFF
--- a/src/program/snabbvmx/tests/end-to-end/core-end-to-end.sh
+++ b/src/program/snabbvmx/tests/end-to-end/core-end-to-end.sh
@@ -37,7 +37,7 @@ function run_and_cmp {
 }
 
 function run_and_regen_counters {
-   conf=$1; v4_in=$2; v6_in=$3; v4_out=$4; v6_out=$5; counters=$6
+   conf=$1; v4_in=$2; v6_in=$3; v4_out=$4; v6_out=$5; counters_path=$6
    endoutv4="${TEST_OUT}/endoutv4.pcap"; endoutv6="${TEST_OUT}/endoutv6.pcap";
    rm -f $endoutv4 $endoutv6
    ${SNABB_LWAFTR} check -r \

--- a/src/program/snabbvmx/tests/nexthop/selftest.sh
+++ b/src/program/snabbvmx/tests/nexthop/selftest.sh
@@ -30,6 +30,7 @@ SNABBVMX_CONF=$SNABBVMX_DIR/tests/conf/snabbvmx-lwaftr.cfg
 SNABBVMX_ID=xe1
 SNABB_TELNET0=5000
 VHU_SOCK0=/tmp/vh1a.sock
+GUEST_MEM=1024
 
 function last_32bit {
     mac=$1


### PR DESCRIPTION
Fixes #530.

SnabVMX's end-to-end.sh script was not regenerating counters correctly because the variable name that held the path to counters file was incorrectly named, thus snabbvmx check received nil as counters path and didn't regenerate counters.

The PR includes #537 because SnabbVMX nexthop test was failing.
