### PR TITLE
Lwaftr benchmark

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@
 { pkgs ? (import <nixpkgs> {})
 , source ? ./.
 , version ? "dev"
+, supportOpenstack ? true
 }:
 
 with pkgs;
@@ -23,7 +24,7 @@ stdenv.mkDerivation rec {
     for f in $(find src/program/snabbnfv/ -type f); do
       substituteInPlace $f --replace "/bin/bash" "${bash}/bin/bash"
     done
-
+  '' + lib.optionalString supportOpenstack ''
     # We need a way to pass $PATH to the scripts
     sed -i '2iexport PATH=${git}/bin:${mariadb}/bin:${which}/bin:${procps}/bin:${coreutils}/bin' src/program/snabbnfv/neutron_sync_master/neutron_sync_master.sh.inc
     sed -i '2iexport PATH=${git}/bin:${coreutils}/bin:${diffutils}/bin:${nettools}/bin' src/program/snabbnfv/neutron_sync_agent/neutron_sync_agent.sh.inc

--- a/src/program/lwaftr/doc/README.virtualization.md
+++ b/src/program/lwaftr/doc/README.virtualization.md
@@ -183,8 +183,6 @@ There is a screen on:
 
 Attach to this screen to see the RX/TX statistics of the runnign lwAFTR process.
 
-```
-
 # Stop lwAFTR in a guest
 
 All the listed command so far can take a `stop` action that will stop them running.

--- a/src/program/lwaftr/virt/lwaftrctl
+++ b/src/program/lwaftr/virt/lwaftrctl
@@ -108,7 +108,7 @@ start_snabbnfv_process() {
     fi
 
     # Run snabbnfv inside screen.
-    screen -dmS $screen bash -c \
+    screen -L -dmS $screen bash -c \
         "cd ${SNABB_HOST_PATH}/src; \
          sudo numactl -m ${NUMA_NODE} taskset -c ${core} sudo ./snabb snabbnfv traffic -b ${pci} ${conf} ${sock};"
     sleep 0.5

--- a/src/program/lwaftr/virt/lwaftrctl
+++ b/src/program/lwaftr/virt/lwaftrctl
@@ -61,7 +61,7 @@ start_vm() {
 
 stop_vm() {
     echo "Switching off VM. Please wait..."
-    ssh ${VM_USER}@${VM_IP} 'sudo halt'
+    ssh $SSH_OPTS ${VM_USER}@${VM_IP} 'sudo halt'
     sleep 10
     pid=`pidof qemu-system-x86_64`
     sudo kill ${pid} 2>/dev/null
@@ -76,13 +76,13 @@ restart_vm() {
 start_lwaftr() {
     echo "Start lwAFTR"
 
-    ssh ${VM_USER}@${VM_IP} "~/run_lwaftr.sh"
+    ssh $SSH_OPTS${VM_USER}@${VM_IP} "~/run_lwaftr.sh"
 }
 
 stop_lwaftr() {
     echo "Stop lwAFTR"
 
-    ssh ${VM_USER}@${VM_IP} 'sudo killall snabb 2>/dev/null'
+    ssh $SSH_OPTS ${VM_USER}@${VM_IP} 'sudo killall snabb 2>/dev/null'
 }
 
 restart_lwaftr() {

--- a/src/program/lwaftr/virt/lwaftrctl
+++ b/src/program/lwaftr/virt/lwaftrctl
@@ -110,14 +110,14 @@ start_snabbnfv_process() {
     # Run snabbnfv inside screen.
     screen -L -dmS $screen bash -c \
         "cd ${SNABB_HOST_PATH}/src; \
-         sudo numactl -m ${NUMA_NODE} taskset -c ${core} sudo ./snabb snabbnfv traffic -b ${pci} ${conf} ${sock};"
+         sudo numactl -m ${NUMA_NODE} taskset -c ${core} ./snabb snabbnfv traffic -b ${pci} ${conf} ${sock};"
     sleep 0.5
     status=$(screen -ls | grep ${screen})
 
     # Check exit status.
     if [[ -z ${status} ]]; then
         echo "Start of snabbnfv failed: "
-        echo -e "\tsudo numactl -m ${NUMA_NODE} taskset -c ${core} sudo ./snabb snabbnfv traffic -b ${pci} ${conf} ${sock}"
+        echo -e "\tsudo numactl -m ${NUMA_NODE} taskset -c ${core} ./snabb snabbnfv traffic -b ${pci} ${conf} ${sock}"
         exit 1
     fi
 


### PR DESCRIPTION
I can run the benchmark without the chroot using these patches.

Note: OpenStack support is optional in order to only copy 25MB of Snabb executable to the VM instead of 500MB using OpenStack, which MySQL pulls in.

cc @teknico @dpino  @wingo