### PR TITLE
Add snabb config derive-data-format program

### DIFF
--- a/src/program/config/README.inc
+++ b/src/program/config/README.inc
@@ -1,0 +1,2 @@
+Usage:
+  config derive-data-format [OPTIONS] [<module>]

--- a/src/program/config/config.lua
+++ b/src/program/config/config.lua
@@ -1,0 +1,136 @@
+module(..., package.seeall)
+
+local lib = require("core.lib")
+local usage = require("program.config.README_inc")
+local schema = require("lib.yang.schema")
+local yang_data = require("lib.yang.data")
+
+local tab_spaces = 4
+
+function derive_data_format(a)
+   function print_level(level, ...)
+      io.write(string.rep(" ", level * tab_spaces))
+      print(...)
+   end
+   function union_type(union)
+      local rtn
+      for _, t in pairs(union.argument_type.union) do
+         if rtn then
+            rtn = rtn .. " | " .. t.argument_string
+         else
+            rtn = t.argument_string
+         end
+      end
+      return rtn
+   end
+   function collate_options(name, node, keys)
+      local options = {}
+      if keys ~= nil then
+	 for _, k in pairs(keys) do
+	    if name == k then options.key = true end
+	 end
+      end
+      if node.argument_type then
+	 local at = node.argument_type
+	 if at.range then
+	    options.range = at.range.argument_string
+	 end
+      end
+      if node.mandatory then
+	 options.mandatory = true
+      end
+      return options
+   end
+   function display_node(name, node, options, level, parent)
+      function comment()
+	 local comments = {}
+	 if options.mandatory == true then
+	    comments[#comments + 1] = "mandatory"
+	 end
+	 if options.key then
+	    comments[#comments + 1] = "key"
+	 end
+	 if options.range then
+	    comments[#comments + 1] = "between " .. options.range
+	 end
+	 local rtn = nil
+	 for n, c in pairs(comments) do
+	    if n == 1 then
+	       rtn = "// " .. c
+	    else
+	       rtn = rtn  .. " " .. c
+	    end
+	 end
+	 return rtn
+      end
+      function display_leaf(keyword, argument)
+	 if argument == "union" then argument = union_type(node) end
+	 local comments = comment()
+	 local str = keyword .. " " .. argument .. ";"
+	 if comments then
+	    print_level(level, str .. " " .. comments)
+	 else
+	    print_level(level, str)
+	 end
+      end
+      if level == nil then level = 0 end
+      if node.type == "table" or node.type == "struct" then
+	 local keys = {}
+	 if node.keys then
+	    print_level(
+	       level,
+	       "// List: this nested structure is repeated with (a) unique key(s)"
+	    )
+	 end
+	 print_level(level, name.." {")
+         display_data_format(node, level + 1)
+         print_level(level, "}")
+      elseif node.type == "scalar" then
+         display_leaf(name, node.argument_type.argument_string)
+      elseif node.type == "array" then
+	 print_level(
+	    level,
+	    "// Array: made by repeating the keyword followed by each element"
+	 )
+	 display_leaf(name, node.element_type.argument_string)
+      else
+      end
+   end
+
+   function display_data_format(grammar, level)
+      for k,v in pairs(grammar.members) do
+	 local options = collate_options(k, v, grammar.keys)
+         display_node(k, v, options, level)
+      end
+   end
+
+   if #a <= 1 then
+      print(usage)
+      main.exit(1)
+   end
+
+   local module = a[2]
+
+   -- Fetch and parse the schema module.
+   local s = schema.parse_schema_file(module)
+   local grammar = yang_data.data_grammar_from_schema(s)
+
+   display_data_format(grammar, 0)
+
+end
+
+function run(args)
+   local options = {}
+   options["derive-data-format"] = derive_data_format
+
+   if #args <= 0 then
+      print(usage)
+      main.exit(1)
+   elseif options[args[1]] == nil then
+      print("Unknown argument: "..args[1])
+      print(usage)
+      main.exit(1)
+   else
+      options[args[1]](args)
+   end
+end

--- a/src/program/config/config.lua
+++ b/src/program/config/config.lua
@@ -1,136 +1,15 @@
 module(..., package.seeall)
 
-local lib = require("core.lib")
 local usage = require("program.config.README_inc")
-local schema = require("lib.yang.schema")
-local yang_data = require("lib.yang.data")
-
-local tab_spaces = 4
-
-function derive_data_format(a)
-   function print_level(level, ...)
-      io.write(string.rep(" ", level * tab_spaces))
-      print(...)
-   end
-   function union_type(union)
-      local rtn
-      for _, t in pairs(union.argument_type.union) do
-         if rtn then
-            rtn = rtn .. " | " .. t.argument_string
-         else
-            rtn = t.argument_string
-         end
-      end
-      return rtn
-   end
-   function collate_options(name, node, keys)
-      local options = {}
-      if keys ~= nil then
-	 for _, k in pairs(keys) do
-	    if name == k then options.key = true end
-	 end
-      end
-      if node.argument_type then
-	 local at = node.argument_type
-	 if at.range then
-	    options.range = at.range.argument_string
-	 end
-      end
-      if node.mandatory then
-	 options.mandatory = true
-      end
-      return options
-   end
-   function display_node(name, node, options, level, parent)
-      function comment()
-	 local comments = {}
-	 if options.mandatory == true then
-	    comments[#comments + 1] = "mandatory"
-	 end
-	 if options.key then
-	    comments[#comments + 1] = "key"
-	 end
-	 if options.range then
-	    comments[#comments + 1] = "between " .. options.range
-	 end
-	 local rtn = nil
-	 for n, c in pairs(comments) do
-	    if n == 1 then
-	       rtn = "// " .. c
-	    else
-	       rtn = rtn  .. " " .. c
-	    end
-	 end
-	 return rtn
-      end
-      function display_leaf(keyword, argument)
-	 if argument == "union" then argument = union_type(node) end
-	 local comments = comment()
-	 local str = keyword .. " " .. argument .. ";"
-	 if comments then
-	    print_level(level, str .. " " .. comments)
-	 else
-	    print_level(level, str)
-	 end
-      end
-      if level == nil then level = 0 end
-      if node.type == "table" or node.type == "struct" then
-	 local keys = {}
-	 if node.keys then
-	    print_level(
-	       level,
-	       "// List: this nested structure is repeated with (a) unique key(s)"
-	    )
-	 end
-	 print_level(level, name.." {")
-         display_data_format(node, level + 1)
-         print_level(level, "}")
-      elseif node.type == "scalar" then
-         display_leaf(name, node.argument_type.argument_string)
-      elseif node.type == "array" then
-	 print_level(
-	    level,
-	    "// Array: made by repeating the keyword followed by each element"
-	 )
-	 display_leaf(name, node.element_type.argument_string)
-      else
-      end
-   end
-
-   function display_data_format(grammar, level)
-      for k,v in pairs(grammar.members) do
-	 local options = collate_options(k, v, grammar.keys)
-         display_node(k, v, options, level)
-      end
-   end
-
-   if #a <= 1 then
-      print(usage)
-      main.exit(1)
-   end
-
-   local module = a[2]
-
-   -- Fetch and parse the schema module.
-   local s = schema.parse_schema_file(module)
-   local grammar = yang_data.data_grammar_from_schema(s)
-
-   display_data_format(grammar, 0)
-
-end
 
 function run(args)
-   local options = {}
-   options["derive-data-format"] = derive_data_format
-
+   -- Display usage if we have no arguments.
    if #args <= 0 then
       print(usage)
       main.exit(1)
-   elseif options[args[1]] == nil then
-      print("Unknown argument: "..args[1])
-      print(usage)
-      main.exit(1)
-   else
-      options[args[1]](args)
    end
+
+   local command = string.gsub(table.remove(args, 1), "-", "_")
+   local modname = ("program.config.%s.%s"):format(command, command)
+   require(modname).run(args)
 end

--- a/src/program/config/config.lua
+++ b/src/program/config/config.lua
@@ -1,14 +1,23 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 module(..., package.seeall)
 
-local usage = require("program.config.README_inc")
+local lib = require("core.lib")
+
+local function show_usage(status)
+   print(require("program.config.README_inc"))
+   main.exit(status)
+end
+
+local function parse_args(args)
+   local handlers = {}
+   handlers.h = function() show_usage(0) end
+   args = lib.dogetopt(args, handlers, "h", {help="h"})
+   if #args <= 1 then show_usage(1) end
+   return args
+end
 
 function run(args)
-   -- Display usage if we have no arguments.
-   if #args <= 0 then
-      print(usage)
-      main.exit(1)
-   end
-
+   args = parse_args(args)
    local command = string.gsub(table.remove(args, 1), "-", "_")
    local modname = ("program.config.%s.%s"):format(command, command)
    require(modname).run(args)

--- a/src/program/config/data_format/README.inc
+++ b/src/program/config/data_format/README.inc
@@ -1,0 +1,27 @@
+Data Format Usage:
+  snabb config data-format <schema>
+
+This command produces an annotated yang data format from a schema file
+which can be used to check a yang schema or help you write the data
+configuration file.
+
+The output is an option or a container of options followed by the type
+of value that is to be expected. In the case where there is a option
+with a section in curly braces that will represent a nested structure
+such as a list or a container. Comments preciding certain fields will
+indicate if for example the block is a list, or comments may proceed
+options specifying if they are for example mandatory.
+
+An exaaple of an option could be:
+
+  port uint8; // mandatory between 0..11
+
+This describes a configuration option "port" which takes an unsigned
+integer with a value between 0 and 11. The option is required so must
+have a value. An example for this field in the configuration could be:
+
+  port 7;
+
+Example usage:
+
+  $ snabb config data-format lib/yang/snabb-softwire.yang

--- a/src/program/config/data_format/data_format.lua
+++ b/src/program/config/data_format/data_format.lua
@@ -1,11 +1,26 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 module(..., package.seeall)
 
+local lib = require("core.lib")
 local schema = require("lib.yang.schema")
 local yang_data = require("lib.yang.data")
 local usage = require("program.config.data_format.README_inc")
 
 -- Number of spaces a tab should consist of when indenting config.
 local tab_spaces = 4
+
+local function show_usage(status)
+   print(require("program.config.data_format.README_inc"))
+   main.exit(status)
+end
+
+local function parse_args(args)
+   local handlers = {}
+   handlers.h = function() show_usage(0) end
+   args = lib.dogetopt(args, handlers, "h", {help="h"})
+   if #args <= 0 then show_usage(1) end
+   return unpack(args)
+end
 
 function run(args)
    function print_level(level, ...)
@@ -104,15 +119,11 @@ function run(args)
       end
    end
 
-   if #args <= 0 then
-      print(usage)
-      main.exit(1)
-   end
 
-   local yangmod = args[1]
+   local yang_module = parse_args(args)
 
    -- Fetch and parse the schema module.
-   local s = schema.parse_schema_file(yangmod)
+   local s = schema.parse_schema_file(yang_module)
    local grammar = yang_data.data_grammar_from_schema(s)
 
    display_data_format(grammar, 0)

--- a/src/program/config/data_format/data_format.lua
+++ b/src/program/config/data_format/data_format.lua
@@ -38,10 +38,10 @@ function run(args)
       end
       return rtn
    end
-   function collate_options(name, node, keys)
+   function collate_options(name, node)
       local options = {}
-      if keys ~= nil then
-	 for _, k in pairs(keys) do
+      if node.keys ~= nil then
+	 for _, k in pairs(node.keys) do
 	    if name == k then options.key = true end
 	 end
       end
@@ -56,69 +56,74 @@ function run(args)
       end
       return options
    end
-   function display_node(name, node, options, level, parent)
-      function comment()
-	 local comments = {}
-	 if options.mandatory == true then
-	    comments[#comments + 1] = "mandatory"
-	 end
-	 if options.key then
-	    comments[#comments + 1] = "key"
-	 end
-	 if options.range then
-	    comments[#comments + 1] = "between " .. options.range
-	 end
-	 local rtn = nil
-	 for n, c in pairs(comments) do
-	    if n == 1 then
-	       rtn = "// " .. c
-	    else
-	       rtn = rtn  .. " " .. c
-	    end
-	 end
-	 return rtn
+   function comment(options)
+      local comments = {}
+      if options.mandatory == true then
+	 comments[#comments + 1] = "mandatory"
       end
-      function display_leaf(keyword, argument)
-	 if argument == "union" then argument = union_type(node) end
-	 local comments = comment()
-	 local str = keyword .. " " .. argument .. ";"
-	 if comments then
-	    print_level(level, str .. " " .. comments)
+      if options.key then
+	 comments[#comments + 1] = "key"
+      end
+      if options.range then
+	 comments[#comments + 1] = "between " .. options.range
+      end
+      local rtn = nil
+      for n, c in pairs(comments) do
+	 if n == 1 then
+	    rtn = "// " .. c
 	 else
-	    print_level(level, str)
+	    rtn = rtn  .. " " .. c
 	 end
       end
+      return rtn
+   end
+
+   function display_leaf(level, keyword, argument, options)
+      if argument == "union" then argument = union_type(node) end
+      local comments = comment(options)
+      local str = keyword .. " ".. argument .. ";"
+      if comments then
+	 print_level(level, str .. " " .. comments)
+      else
+	 print_level(level, str)
+      end
+   end
+
+   local describers = {}
+   local function describe(level, name, node, options)
+      local err = "Unknown node type: "..node.type
+      local options = collate_options(name, node)
+      assert(describers[node.type], err)(level, name, node, options)
+   end
+   function describe_members(node, level)
       if level == nil then level = 0 end
-      if node.type == "table" or node.type == "struct" then
-	 local keys = {}
-	 if node.keys then
-	    print_level(
-	       level,
-	       "// List: this nested structure is repeated with (a) unique key(s)"
-	    )
-	 end
-	 print_level(level, name.." {")
-         display_data_format(node, level + 1)
-         print_level(level, "}")
-      elseif node.type == "scalar" then
-         display_leaf(name, node.argument_type.argument_string)
-      elseif node.type == "array" then
+      for name, n in pairs(node.members) do
+	 local options = collate_options(name, node)
+	 describe(level, name, n, options)
+      end
+   end
+   function describers.scalar(level, name, node, options)
+      display_leaf(level, name, node.argument_type.argument_string, options)
+   end
+   function describers.table(level, name, node, options)
+      if node.keys then
 	 print_level(
 	    level,
-	    "// Array: made by repeating the keyword followed by each element"
+	    "// List: this nested structure is repeated with (a) unique key(s)"
 	 )
-	 display_leaf(name, node.element_type.argument_string)
-      else
       end
+      print_level(level, name.." {")
+      describe_members(node, level + 1)
+      print_level(level, "}")
    end
-
-   function display_data_format(grammar, level)
-      for k,v in pairs(grammar.members) do
-	 local options = collate_options(k, v, grammar.keys)
-         display_node(k, v, options, level)
-      end
+   describers.struct = describers.table
+   function describers.array(level, name, node, options)
+      print_level(
+	 level,
+	 "// Array: made by repeating the keyword followed by each element"
+      )
+      display_leaf(level, name, node.element_type.argument_string, options)
    end
-
 
    local yang_module = parse_args(args)
 
@@ -126,5 +131,5 @@ function run(args)
    local s = schema.parse_schema_file(yang_module)
    local grammar = yang_data.data_grammar_from_schema(s)
 
-   display_data_format(grammar, 0)
+   describe_members(grammar)
 end

--- a/src/program/config/data_format/data_format.lua
+++ b/src/program/config/data_format/data_format.lua
@@ -4,14 +4,136 @@ module(..., package.seeall)
 local lib = require("core.lib")
 local schema = require("lib.yang.schema")
 local yang_data = require("lib.yang.data")
-local usage = require("program.config.data_format.README_inc")
 
 -- Number of spaces a tab should consist of when indenting config.
-local tab_spaces = 4
+local tab_spaces = 2
+
+local function print_level(level, ...)
+   io.write(string.rep(" ", level * tab_spaces))
+   print(...)
+end
+
+local function union_type(union)
+   local rtn
+   for _, t in pairs(union.argument_type.union) do
+      if rtn then
+	 rtn = rtn .. " | " .. t.argument_string
+      else
+	 rtn = t.argument_string
+      end
+   end
+   return rtn
+end
+
+local function comment(opts)
+   local comments = {}
+   if opts.mandatory == true then
+      comments[#comments + 1] = "mandatory"
+   end
+   if opts.key then
+      comments[#comments + 1] = "key"
+   end
+   if opts.range then
+      comments[#comments + 1] = "between " .. opts.range
+   end
+   local rtn = nil
+   for n, c in pairs(comments) do
+      if n == 1 then
+	 rtn = "// " .. c
+      else
+	 rtn = rtn  .. " " .. c
+      end
+   end
+   return rtn
+end
+
+local function display_leaf(level, keyword, argument, opts)
+   if argument == "union" then argument = union_type(node) end
+   local comments
+   if opts then comments = comment(opts) end
+   local str = keyword .. " ".. argument .. ";"
+   if comments then
+      print_level(level, str .. " " .. comments)
+   else
+      print_level(level, str)
+   end
+end
 
 local function show_usage(status)
    print(require("program.config.data_format.README_inc"))
    main.exit(status)
+end
+
+-- Contains verious option handling code.
+local options = {}
+
+function options.key(keys)
+   return function (name)
+      for _, k in pairs(keys) do
+	 if name == k then return true end
+      end
+      return false
+   end
+end
+
+function options.mandatory(name, node)
+   if node.mandatory then return node.mandatory end
+end
+
+function options.range(name, node)
+   if node.argument_type.range then
+      return node.argument_type.range.argument_string
+   end
+   return nil
+end
+
+-- Contains the handlers which know how to describe certain data node types.
+local describers = {}
+
+local function describe(level, name, node, ...)
+   local err = "Unknown node type: "..node.type
+   assert(describers[node.type], err)(level, name, node, ...)
+end
+
+local function describe_members(node, level, ...)
+   if level == nil then level = 0 end
+   for name, n in pairs(node.members) do
+      describe(level, name, n, ...)
+   end
+end
+
+function describers.scalar(level, name, node, is_key)
+   local opts = {}
+   if is_key then opts.key = is_key(name, node) end
+   opts.mandatory = options.mandatory(name, node)
+   opts.range = options.range(name, node)
+   display_leaf(level, name, node.argument_type.argument_string, opts)
+end
+
+function describers.table(level, name, node)
+   if node.keys then
+      print_level(
+	 level,
+	 "// List: this nested structure is repeated with (a) unique key(s)"
+      )
+   end
+   print_level(level, name.." {")
+   describe_members(node, level + 1, options.key(node.keys))
+   print_level(level, "}")
+end
+
+function describers.struct(level, name, node)
+   print_level(level, name.." {")
+   describe_members(node, level + 1)
+   print_level(level, "}")
+end
+
+function describers.array(level, name, node)
+   print_level(
+      level,
+      "// Array: made by repeating the keyword followed by each element"
+   )
+   display_leaf(level, name, node.element_type.argument_string)
 end
 
 local function parse_args(args)
@@ -23,108 +145,6 @@ local function parse_args(args)
 end
 
 function run(args)
-   function print_level(level, ...)
-      io.write(string.rep(" ", level * tab_spaces))
-      print(...)
-   end
-   function union_type(union)
-      local rtn
-      for _, t in pairs(union.argument_type.union) do
-         if rtn then
-            rtn = rtn .. " | " .. t.argument_string
-         else
-            rtn = t.argument_string
-         end
-      end
-      return rtn
-   end
-   function collate_options(name, node)
-      local options = {}
-      if node.keys ~= nil then
-	 for _, k in pairs(node.keys) do
-	    if name == k then options.key = true end
-	 end
-      end
-      if node.argument_type then
-	 local at = node.argument_type
-	 if at.range then
-	    options.range = at.range.argument_string
-	 end
-      end
-      if node.mandatory then
-	 options.mandatory = true
-      end
-      return options
-   end
-   function comment(options)
-      local comments = {}
-      if options.mandatory == true then
-	 comments[#comments + 1] = "mandatory"
-      end
-      if options.key then
-	 comments[#comments + 1] = "key"
-      end
-      if options.range then
-	 comments[#comments + 1] = "between " .. options.range
-      end
-      local rtn = nil
-      for n, c in pairs(comments) do
-	 if n == 1 then
-	    rtn = "// " .. c
-	 else
-	    rtn = rtn  .. " " .. c
-	 end
-      end
-      return rtn
-   end
-
-   function display_leaf(level, keyword, argument, options)
-      if argument == "union" then argument = union_type(node) end
-      local comments = comment(options)
-      local str = keyword .. " ".. argument .. ";"
-      if comments then
-	 print_level(level, str .. " " .. comments)
-      else
-	 print_level(level, str)
-      end
-   end
-
-   local describers = {}
-   local function describe(level, name, node, options)
-      local err = "Unknown node type: "..node.type
-      local options = collate_options(name, node)
-      assert(describers[node.type], err)(level, name, node, options)
-   end
-   function describe_members(node, level)
-      if level == nil then level = 0 end
-      for name, n in pairs(node.members) do
-	 local options = collate_options(name, node)
-	 describe(level, name, n, options)
-      end
-   end
-   function describers.scalar(level, name, node, options)
-      display_leaf(level, name, node.argument_type.argument_string, options)
-   end
-   function describers.table(level, name, node, options)
-      if node.keys then
-	 print_level(
-	    level,
-	    "// List: this nested structure is repeated with (a) unique key(s)"
-	 )
-      end
-      print_level(level, name.." {")
-      describe_members(node, level + 1)
-      print_level(level, "}")
-   end
-   describers.struct = describers.table
-   function describers.array(level, name, node, options)
-      print_level(
-	 level,
-	 "// Array: made by repeating the keyword followed by each element"
-      )
-      display_leaf(level, name, node.element_type.argument_string, options)
-   end
-
    local yang_module = parse_args(args)
 
    -- Fetch and parse the schema module.

--- a/src/program/config/data_format/data_format.lua
+++ b/src/program/config/data_format/data_format.lua
@@ -76,10 +76,6 @@ function options.key(keys)
    end
 end
 
-function options.mandatory(name, node)
-   if node.mandatory then return node.mandatory end
-end
-
 function options.range(name, node)
    if node.argument_type.range then
       return node.argument_type.range.argument_string
@@ -105,18 +101,13 @@ end
 function describers.scalar(level, name, node, is_key)
    local opts = {}
    if is_key then opts.key = is_key(name, node) end
-   opts.mandatory = options.mandatory(name, node)
+   opts.mandatory = node.mandatory
    opts.range = options.range(name, node)
    display_leaf(level, name, node.argument_type.argument_string, opts)
 end
 
 function describers.table(level, name, node)
-   if node.keys then
-      print_level(
-	 level,
-	 "// List: this nested structure is repeated with (a) unique key(s)"
-      )
-   end
+   print_level(level, "// List, key(s) must be unique.")
    print_level(level, name.." {")
    describe_members(node, level + 1, options.key(node.keys))
    print_level(level, "}")
@@ -129,10 +120,7 @@ function describers.struct(level, name, node)
 end
 
 function describers.array(level, name, node)
-   print_level(
-      level,
-      "// Array: made by repeating the keyword followed by each element"
-   )
+   print_level(level, "// Array, multiple elements by repeating the statement.")
    display_leaf(level, name, node.element_type.argument_string)
 end
 
@@ -140,7 +128,7 @@ local function parse_args(args)
    local handlers = {}
    handlers.h = function() show_usage(0) end
    args = lib.dogetopt(args, handlers, "h", {help="h"})
-   if #args <= 0 then show_usage(1) end
+   if #args ~= 0 then show_usage(1) end
    return unpack(args)
 end
 

--- a/src/program/config/data_format/data_format.lua
+++ b/src/program/config/data_format/data_format.lua
@@ -1,0 +1,119 @@
+module(..., package.seeall)
+
+local schema = require("lib.yang.schema")
+local yang_data = require("lib.yang.data")
+local usage = require("program.config.data_format.README_inc")
+
+-- Number of spaces a tab should consist of when indenting config.
+local tab_spaces = 4
+
+function run(args)
+   function print_level(level, ...)
+      io.write(string.rep(" ", level * tab_spaces))
+      print(...)
+   end
+   function union_type(union)
+      local rtn
+      for _, t in pairs(union.argument_type.union) do
+         if rtn then
+            rtn = rtn .. " | " .. t.argument_string
+         else
+            rtn = t.argument_string
+         end
+      end
+      return rtn
+   end
+   function collate_options(name, node, keys)
+      local options = {}
+      if keys ~= nil then
+	 for _, k in pairs(keys) do
+	    if name == k then options.key = true end
+	 end
+      end
+      if node.argument_type then
+	 local at = node.argument_type
+	 if at.range then
+	    options.range = at.range.argument_string
+	 end
+      end
+      if node.mandatory then
+	 options.mandatory = true
+      end
+      return options
+   end
+   function display_node(name, node, options, level, parent)
+      function comment()
+	 local comments = {}
+	 if options.mandatory == true then
+	    comments[#comments + 1] = "mandatory"
+	 end
+	 if options.key then
+	    comments[#comments + 1] = "key"
+	 end
+	 if options.range then
+	    comments[#comments + 1] = "between " .. options.range
+	 end
+	 local rtn = nil
+	 for n, c in pairs(comments) do
+	    if n == 1 then
+	       rtn = "// " .. c
+	    else
+	       rtn = rtn  .. " " .. c
+	    end
+	 end
+	 return rtn
+      end
+      function display_leaf(keyword, argument)
+	 if argument == "union" then argument = union_type(node) end
+	 local comments = comment()
+	 local str = keyword .. " " .. argument .. ";"
+	 if comments then
+	    print_level(level, str .. " " .. comments)
+	 else
+	    print_level(level, str)
+	 end
+      end
+      if level == nil then level = 0 end
+      if node.type == "table" or node.type == "struct" then
+	 local keys = {}
+	 if node.keys then
+	    print_level(
+	       level,
+	       "// List: this nested structure is repeated with (a) unique key(s)"
+	    )
+	 end
+	 print_level(level, name.." {")
+         display_data_format(node, level + 1)
+         print_level(level, "}")
+      elseif node.type == "scalar" then
+         display_leaf(name, node.argument_type.argument_string)
+      elseif node.type == "array" then
+	 print_level(
+	    level,
+	    "// Array: made by repeating the keyword followed by each element"
+	 )
+	 display_leaf(name, node.element_type.argument_string)
+      else
+      end
+   end
+
+   function display_data_format(grammar, level)
+      for k,v in pairs(grammar.members) do
+	 local options = collate_options(k, v, grammar.keys)
+         display_node(k, v, options, level)
+      end
+   end
+
+   if #args <= 0 then
+      print(usage)
+      main.exit(1)
+   end
+
+   local yangmod = args[1]
+
+   -- Fetch and parse the schema module.
+   local s = schema.parse_schema_file(yangmod)
+   local grammar = yang_data.data_grammar_from_schema(s)
+
+   display_data_format(grammar, 0)
+end


### PR DESCRIPTION
This introduces the `snabb config` program. The program only has one option at the moment, that option being `derive-data-format` which takes one argument, a yang schema module path. The program will read a schema, derive the data grammar and then display in a human readable way how the data configuration should look (see more in #529).

An example usage of this would be:
**simple-router.yang**
```yang
module snabb-simple-router {
  namespace snabb:simple-router;
  prefix simple-router;

  import ietf-inet-types {prefix inet;}

  leaf active { type boolean; default true; }

  container routes {
    presence true;
    list route {
      key addr;
      leaf addr { type inet:ipv4-address; mandatory true; }
      leaf port { type uint8 { range 0..11; } mandatory true; }
    }
  }
}
```

**Command**
```sh
$ sudo ./src/snabb config derive-data-format ./src/lib/yang/simple-router.yang
routes {
    // List: this nested structure is repeated with (a) unique key(s)
    route {
        addr inet:ipv4-address; // mandatory key
        port uint8; // mandatory between 0..11
    }
}
active boolean;
```

PTAL @wingo 