### PR TITLE
Migrate "snabb lwaftr" to yang configurations

### DIFF
--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -4,7 +4,6 @@ local bt = require("apps.lwaftr.binding_table")
 local constants = require("apps.lwaftr.constants")
 local dump = require('apps.lwaftr.dump')
 local icmp = require("apps.lwaftr.icmp")
-local lwconf = require("apps.lwaftr.conf")
 local lwdebug = require("apps.lwaftr.lwdebug")
 local lwheader = require("apps.lwaftr.lwheader")
 local lwutil = require("apps.lwaftr.lwutil")
@@ -241,9 +240,6 @@ end
 LwAftr = {}
 
 function LwAftr:new(conf)
-   if type(conf) == 'string' then
-      conf = lwconf.load_legacy_lwaftr_config(conf)
-   end
    if conf.debug then debug = true end
    local o = setmetatable({}, {__index=LwAftr})
    o.conf = conf

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -9,6 +9,7 @@ local value = require("lib.yang.value")
 local stream = require("lib.yang.stream")
 local data = require('lib.yang.data')
 local ctable = require('lib.ctable')
+local cltable = require('lib.cltable')
 
 local MAGIC = "yangconf"
 local VERSION = 0x00001000

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -139,7 +139,6 @@ local function data_emitter(production)
    end
    function handlers.array(production)
       if production.ctype then
-         local emit_value = value_emitter(production.ctype)
          return function(data, stream)
             stream:write_stringref('carray')
             stream:write_stringref(production.ctype)
@@ -183,7 +182,7 @@ local function data_emitter(production)
          local emit_value = visit1({type='struct', members=production.values})
          return function(data, stream)
             stream:write_stringref('cltable')
-            emit_keys(data.keys)
+            emit_keys(data.keys, stream)
             stream:write_uint32(#data.values)
             for i=1,#data.values do emit_value(data.values[i], stream) end
          end

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -238,6 +238,22 @@ local function string_keyed_table_builder(string_key)
    return builder
 end
 
+local function cltable_builder(key_t)
+   local res = cltable.new({ key_type=key_t })
+   local builder = {}
+   function builder:add(key, value) res[key] = value end
+   function builder:finish() return res end
+   return builder
+end
+
+local function ltable_builder()
+   local res = {}
+   local builder = {}
+   function builder:add(key, value) res[key] = value end
+   function builder:finish() return res end
+   return builder
+end
+
 local function table_parser(keyword, keys, values, string_key, key_ctype,
                             value_ctype)
    local members = {}
@@ -251,13 +267,10 @@ local function table_parser(keyword, keys, values, string_key, key_ctype,
       function init() return ctable_builder(key_t, value_t) end
    elseif string_key then
       function init() return string_keyed_table_builder(string_key) end
+   elseif key_t then
+      function init() return cltable_builder(key_t) end
    else
-      -- TODO: here we should implement a cktable if key_t is non-nil.
-      -- Probably we should error if the key is a generic Lua table
-      -- though, as we don't have a good data structure to map generic
-      -- Lua tables to Lua tables.  For the moment, fall back to the old
-      -- assoc implementation.
-      error('List with non-FFI, non-string key unimplemented')
+      function init() return ltable_builder() end
    end
    local function parse1(node)
       assert_compound(node, keyword)

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -345,7 +345,23 @@ end
 
 local function encode_yang_string(str)
    if str:match("^[^%s;{}\"'/]*$") then return str end
-   error('yang string escaping unimplemented: '..str)
+   local out = {}
+   table.insert(out, '"')
+   for i=1,#str do
+      local chr = str:sub(i,i)
+      if chr == '\n' then
+         table.insert(out, '\\n')
+      elseif chr == '\t' then
+         table.insert(out, '\\t')
+      elseif chr == '"' or chr == '\\' then
+         table.insert(out, '\\')
+         table.insert(out, chr)
+      else
+         table.insert(out, chr)
+      end
+   end
+   table.insert(out, '"')
+   return table.concat(out)
 end
 
 local value_printers = {}

--- a/src/lib/yang/stream.lua
+++ b/src/lib/yang/stream.lua
@@ -143,7 +143,8 @@ function open_input_byte_stream(filename)
       return ffi.string(ret:read(1), 1)
    end
    function ret:read_string()
-      return ffi.string(ret:read(size - pos), size - pos)
+      local count = size - pos
+      return ffi.string(ret:read(count), count)
    end
    function ret:as_text_stream(len)
       local end_pos = size

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -38,7 +38,12 @@ function tointeger(str, what, min, max)
    end
    if max then check(res <= max) end
    -- Only return Lua numbers for values within int32 + uint32 range.
-   if -0x8000000 <= res and res <= 0xffffffff then return tonumber(res) end
+   -- The 0 <= res check is needed because res might be a uint64, in
+   -- which case comparing to a negative Lua number will cast that Lua
+   -- number to a uint64 :-((
+   if (0 <= res or -0x8000000 <= res) and res <= 0xffffffff then
+      return tonumber(res)
+   end
    return res
 end
 
@@ -80,6 +85,7 @@ function selftest()
    assert(tointeger('0') == 0)
    assert(tointeger('-0') == 0)
    assert(tointeger('10') == 10)
+   assert(tostring(tointeger('10')) == '10')
    assert(tointeger('-10') == -10)
    assert(tointeger('010') == 8)
    assert(tointeger('-010') == -8)

--- a/src/lib/yang/yang.lua
+++ b/src/lib/yang/yang.lua
@@ -82,7 +82,7 @@ function load_configuration(filename, opts)
    -- If the file doesn't have the magic, assume it's a source file.
    -- First, see if we compiled it previously and saved a compiled file
    -- in a well-known place.
-   local compiled_filename = filename:gsub("%.txt$", "")..'.o'
+   local compiled_filename = filename:gsub("%.conf$", "")..'.o'
    local source_mtime = {sec=source.mtime_sec, nsec=source.mtime_nsec}
    local compiled_stream = maybe(stream.open_input_byte_stream,
                                  compiled_filename)

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -29,7 +29,7 @@ end
 
 function run(args)
    local opts, conf_file, inv4_pcap, inv6_pcap = parse_args(args)
-   local conf = require('apps.lwaftr.conf').load_legacy_lwaftr_config(conf_file)
+   local conf = require('apps.lwaftr.conf').load_config(conf_file)
 
    local c = config.new()
    setup.load_bench(c, conf, inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')

--- a/src/program/lwaftr/check/check.lua
+++ b/src/program/lwaftr/check/check.lua
@@ -40,7 +40,8 @@ function run(args)
                                          or  setup.load_check
    local conf_file, inv4_pcap, inv6_pcap, outv4_pcap, outv6_pcap, counters_path =
       unpack(args)
-   local conf = lwconf.load_legacy_lwaftr_config(conf_file)
+   local conf = lwconf.load_lwaftr_config(conf_file)
+   for k,v in pairs(conf) do print(k, v) end
 
    local c = config.new()
    load_check(c, conf, inv4_pcap, inv6_pcap, outv4_pcap, outv6_pcap)

--- a/src/program/lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/lwaftr/run_nohw/run_nohw.lua
@@ -55,10 +55,11 @@ end
 
 function run(parameters)
    local verbosity, conf_file, b4_if, inet_if, bench_file = parse_args(parameters)
+   local conf = require('apps.lwaftr.conf').load_lwaftr_config(conf_file)
    local c = config.new()
 
    -- AFTR
-   config.app(c, "aftr", LwAftr, conf_file)
+   config.app(c, "aftr", LwAftr, conf)
 
    -- B4 side interface
    config.app(c, "b4if", RawSocket, b4_if)

--- a/src/program/lwaftr/soaktest/soaktest.lua
+++ b/src/program/lwaftr/soaktest/soaktest.lua
@@ -39,7 +39,7 @@ function run (args)
    local load_soak_test = opts["on-a-stick"] and setup.load_soak_test_on_a_stick
                                              or  setup.load_soak_test
    local c = config.new()
-   local conf = lwconf.load_legacy_lwaftr_config(conf_file)
+   local conf = lwconf.load_lwaftr_config(conf_file)
    load_soak_test(c, conf, inv4_pcap, inv6_pcap)
 
    engine.configure(c)

--- a/src/program/lwaftr/tests/data/big_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/big_mtu_no_icmp.conf
@@ -1,17 +1,156 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1960,
-ipv6_mtu = 2000,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-vlan_tagging = false
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1960;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 2000;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/icmp_on_fail.conf
+++ b/src/program/lwaftr/tests/data/icmp_on_fail.conf
@@ -1,17 +1,156 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-vlan_tagging = false
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/no_hairpin.conf
+++ b/src/program/lwaftr/tests/data/no_hairpin.conf
@@ -1,17 +1,156 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = false,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-vlan_tagging = false
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning false;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/no_icmp.conf
+++ b/src/program/lwaftr/tests/data/no_icmp.conf
@@ -1,17 +1,156 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-vlan_tagging = false
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/no_icmp_maxfrags1.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_maxfrags1.conf
@@ -1,19 +1,156 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-max_fragments_per_reassembly_packet = 1,
-max_ipv6_reassembly_packets = 10,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-vlan_tagging = false
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 1;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 1;
+    max-packets 10;
+  }
+}

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_accept.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_accept.conf
@@ -1,21 +1,160 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-vlan_tagging = false,
-ipv4_ingress_filter = "ip",
-ipv4_egress_filter = "ip",
-ipv6_ingress_filter = "ip6",
-ipv6_egress_filter = "ip6"
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  egress-filter ip;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ingress-filter ip;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp false;
+  egress-filter ip6;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ingress-filter ip6;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_accept.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_accept.conf
@@ -1,23 +1,162 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true,
-ipv4_ingress_filter = "ip",
-ipv4_egress_filter = "ip",
-ipv6_ingress_filter = "ip6",
-ipv6_egress_filter = "ip6"
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  egress-filter ip;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ingress-filter ip;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp false;
+  egress-filter ip6;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ingress-filter ip6;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_drop.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_drop.conf
@@ -1,23 +1,162 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true,
-ipv4_ingress_filter = "len < 0",
-ipv4_egress_filter = "len < 0",
-ipv6_ingress_filter = "len < 0",
-ipv6_egress_filter = "len < 0",
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  egress-filter "len < 0";
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ingress-filter "len < 0";
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp false;
+  egress-filter "len < 0";
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ingress-filter "len < 0";
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_drop.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_drop.conf
@@ -1,21 +1,160 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-vlan_tagging = false,
-ipv4_ingress_filter = "len < 0",
-ipv4_egress_filter = "len < 0",
-ipv6_ingress_filter = "len < 0",
-ipv6_egress_filter = "len < 0",
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  egress-filter "len < 0";
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ingress-filter "len < 0";
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp false;
+  egress-filter "len < 0";
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ingress-filter "len < 0";
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/small_ipv4_mtu_icmp.conf
+++ b/src/program/lwaftr/tests/data/small_ipv4_mtu_icmp.conf
@@ -1,17 +1,156 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 576,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-vlan_tagging = false
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 576;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp.conf
@@ -1,17 +1,156 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1500,
-ipv6_mtu = 1280,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-vlan_tagging = false
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1500;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1280;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_allow.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_allow.conf
@@ -1,17 +1,156 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1500,
-ipv6_mtu = 1280,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-vlan_tagging = false
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1500;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1280;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_vlan_allow.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_vlan_allow.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1500,
-ipv6_mtu = 1280,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1500;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1280;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/tunnel_icmp.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp.conf
@@ -1,17 +1,156 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-vlan_tagging = false
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/tunnel_icmp_without_mac4.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp_without_mac4.conf
@@ -1,17 +1,156 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop_ipv4_addr = 4.5.6.7
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-vlan_tagging = false
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    ip 4.5.6.7;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/tunnel_icmp_withoutmac.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp_withoutmac.conf
@@ -1,17 +1,156 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop_ipv6_addr = 8:9:a:b:4:3:2:1
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-vlan_tagging = false
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    ip 8:9:a:b:4:3:2:1;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+}

--- a/src/program/lwaftr/tests/data/vlan.conf
+++ b/src/program/lwaftr/tests/data/vlan.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e3,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 6000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/big_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/big_mtu_no_icmp.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1960,
-ipv6_mtu = 2000,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1960;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 2000;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/icmp_on_fail.conf
+++ b/src/program/lwaftr/tests/data/vlan/icmp_on_fail.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/no_hairpin.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_hairpin.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = false,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning false;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_maxfrags1.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_maxfrags1.conf
@@ -1,21 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-max_fragments_per_reassembly_packet = 1,
-max_ipv6_reassembly_packets = 10,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 1;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 1;
+    max-packets 10;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_accept.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_accept.conf
@@ -1,23 +1,162 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-ipv4_ingress_filter = "ip",
-ipv4_egress_filter = "ip",
-ipv6_ingress_filter = "ip6",
-ipv6_egress_filter = "ip6"
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  egress-filter ip;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ingress-filter ip;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp false;
+  egress-filter ip6;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ingress-filter ip6;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_drop.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_drop.conf
@@ -1,23 +1,162 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-ipv4_ingress_filter = "len < 0",
-ipv4_egress_filter = "len < 0",
-ipv6_ingress_filter = "len < 0",
-ipv6_egress_filter = "len < 0",
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  egress-filter "len < 0";
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ingress-filter "len < 0";
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp false;
+  egress-filter "len < 0";
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ingress-filter "len < 0";
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/small_ipv4_mtu_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv4_mtu_icmp.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 576,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 576;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1500,
-ipv6_mtu = 1280,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = DROP,
-policy_icmpv6_incoming = DROP,
-policy_icmpv4_outgoing = DROP,
-policy_icmpv6_outgoing = DROP,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1500;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp false;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors false;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1280;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp_allow.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp_allow.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1500,
-ipv6_mtu = 1280,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1500;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1280;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp_without_mac4.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp_without_mac4.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop_ipv4_addr = 4.5.6.7
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-vlan_tagging = true,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    ip 4.5.6.7;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp_withoutmac.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp_withoutmac.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e5,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop_ipv6_addr = 8:9:a:b:4:3:2:1
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    ip 8:9:a:b:4:3:2:1;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}

--- a/src/program/lwaftr/tests/data/vlan/vlan.conf
+++ b/src/program/lwaftr/tests/data/vlan/vlan.conf
@@ -1,19 +1,158 @@
-aftr_ipv4_ip = 10.10.10.10,
-aftr_ipv6_ip = 8:9:a:b:c:d:e:f,
-aftr_mac_b4_side = 22:22:22:22:22:22,
-aftr_mac_inet_side = 12:12:12:12:12:12,
-binding_table = binding-table.txt,
-hairpinning = true,
-icmpv6_rate_limiter_n_packets=6e3,
-icmpv6_rate_limiter_n_seconds=2,
-inet_mac = 68:68:68:68:68:68,
-ipv4_mtu = 1460,
-ipv6_mtu = 1500,
-next_hop6_mac = 44:44:44:44:44:44,
-policy_icmpv4_incoming = ALLOW,
-policy_icmpv6_incoming = ALLOW,
-policy_icmpv4_outgoing = ALLOW,
-policy_icmpv6_outgoing = ALLOW,
-v4_vlan_tag = 1092, # 0x444
-v6_vlan_tag = 1638, # 0x666
-vlan_tagging = true
+binding-table {
+  br-address 8:9:a:b:c:d:e:f;
+  br-address 1e:1:1:1:1:1:1:af;
+  br-address 1e:2:2:2:2:2:2:af;
+  psid-map {
+    addr 178.79.150.15;
+    psid-length 4;
+    reserved-ports-bit-count 0;
+    shift 12;
+  }
+  psid-map {
+    addr 178.79.150.233;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.1;
+    psid-length 0;
+    reserved-ports-bit-count 0;
+    shift 16;
+  }
+  psid-map {
+    addr 178.79.150.2;
+    psid-length 16;
+    reserved-ports-bit-count 0;
+    shift 0;
+  }
+  psid-map {
+    addr 178.79.150.3;
+    psid-length 6;
+    reserved-ports-bit-count 0;
+    shift 10;
+  }
+  softwire {
+    ipv4 178.79.150.3;
+    padding 0;
+    psid 4;
+    b4-ipv6 127:14:25:36:47:58:69:128;
+    br 2;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    padding 0;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    padding 0;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+    br 0;
+  }
+  softwire {
+    ipv4 178.79.150.2;
+    padding 0;
+    psid 7850;
+    b4-ipv6 127:24:35:46:57:68:79:128;
+    br 1;
+  }
+}
+external-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 600000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  ip 10.10.10.10;
+  mac 12:12:12:12:12:12;
+  mtu 1460;
+  next-hop {
+    mac 68:68:68:68:68:68;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1092;
+}
+internal-interface {
+  allow-incoming-icmp true;
+  error-rate-limiting {
+    packets 6000;
+    period 2;
+  }
+  generate-icmp-errors true;
+  hairpinning true;
+  ip 8:9:a:b:c:d:e:f;
+  mac 22:22:22:22:22:22;
+  mtu 1500;
+  next-hop {
+    mac 44:44:44:44:44:44;
+  }
+  reassembly {
+    max-fragments-per-packet 40;
+    max-packets 20000;
+  }
+  vlan-tag 1638;
+}


### PR DESCRIPTION
Here we switch the lwaftr over to the new YANG configurations.  There's lots of work yet to do -- notably documentation and good error messages -- but this does appear to pass test suites.