### PR TITLE
Trim example lwaftr conf files

### DIFF
--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -188,7 +188,7 @@ local function array_parser(keyword, element_type, ctype)
       return out
    end
    local elt_t = ctype and ffi.typeof(ctype)
-   local array_t = ctype and ffi.typeof('$[?]', ffi.typeof(elt_t))
+   local array_t = ctype and ffi.typeof('$[?]', elt_t)
    local function finish(out)
       -- FIXME check min-elements
       if array_t then
@@ -212,7 +212,7 @@ local function scalar_parser(keyword, argument_type, default, mandatory)
    end
    local function finish(out)
       if out ~= nil then return out end
-      if default then return parsev(default) end
+      if default then return parsev(default, keyword) end
       if mandatory then error('missing scalar value: '..keyword) end
    end
    return {init=init, parse=parse, finish=finish}
@@ -420,7 +420,7 @@ local function data_printer_from_grammar(production)
       return function(data, file, indent)
          for _,v in ipairs(data) do
             print_keyword(keyword, file, indent)
-            file:write(serialize(data))
+            file:write(serialize(v))
             file:write(';\n')
          end
       end

--- a/src/program/lwaftr/tests/data/big_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/big_mtu_no_icmp.conf
@@ -5,123 +5,95 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.10.10.10;
@@ -132,17 +104,14 @@ external-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
   mtu 2000;
@@ -151,6 +120,5 @@ internal-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/icmp_on_fail.conf
+++ b/src/program/lwaftr/tests/data/icmp_on_fail.conf
@@ -5,152 +5,116 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/no_hairpin.conf
+++ b/src/program/lwaftr/tests/data/no_hairpin.conf
@@ -5,152 +5,119 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   hairpinning false;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/no_icmp.conf
+++ b/src/program/lwaftr/tests/data/no_icmp.conf
@@ -5,152 +5,118 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/no_icmp_maxfrags1.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_maxfrags1.conf
@@ -5,147 +5,114 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 1;
-    max-packets 20000;
   }
 }
 internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_accept.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_accept.conf
@@ -5,116 +5,89 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
@@ -122,19 +95,16 @@ external-interface {
   egress-filter ip;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ingress-filter ip;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
@@ -142,19 +112,15 @@ internal-interface {
   egress-filter ip6;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ingress-filter ip6;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_accept.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_accept.conf
@@ -5,116 +5,89 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
@@ -122,19 +95,16 @@ external-interface {
   egress-filter ip;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ingress-filter ip;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
@@ -143,20 +113,16 @@ internal-interface {
   egress-filter ip6;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ingress-filter ip6;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_drop.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_drop.conf
@@ -5,116 +5,89 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
@@ -122,19 +95,16 @@ external-interface {
   egress-filter "len < 0";
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ingress-filter "len < 0";
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
@@ -143,20 +113,16 @@ internal-interface {
   egress-filter "len < 0";
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ingress-filter "len < 0";
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_drop.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_drop.conf
@@ -5,116 +5,89 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
@@ -122,19 +95,16 @@ external-interface {
   egress-filter "len < 0";
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ingress-filter "len < 0";
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
@@ -142,19 +112,15 @@ internal-interface {
   egress-filter "len < 0";
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ingress-filter "len < 0";
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/small_ipv4_mtu_icmp.conf
+++ b/src/program/lwaftr/tests/data/small_ipv4_mtu_icmp.conf
@@ -5,125 +5,95 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
   mtu 576;
@@ -132,25 +102,18 @@ external-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp.conf
@@ -5,123 +5,95 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.10.10.10;
@@ -132,17 +104,14 @@ external-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
   mtu 1280;
@@ -151,6 +120,5 @@ internal-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_allow.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_allow.conf
@@ -5,125 +5,95 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
   mtu 1500;
@@ -132,17 +102,12 @@ external-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
   mtu 1280;
@@ -151,6 +116,5 @@ internal-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_vlan_allow.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_vlan_allow.conf
@@ -5,125 +5,95 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
   mtu 1500;
@@ -132,18 +102,13 @@ external-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
   mtu 1280;
@@ -152,7 +117,6 @@ internal-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/tunnel_icmp.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp.conf
@@ -5,152 +5,114 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/tunnel_icmp_without_mac4.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp_without_mac4.conf
@@ -5,152 +5,114 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     ip 4.5.6.7;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/tunnel_icmp_withoutmac.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp_withoutmac.conf
@@ -5,152 +5,114 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     ip 8:9:a:b:4:3:2:1;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan.conf
+++ b/src/program/lwaftr/tests/data/vlan.conf
@@ -5,154 +5,116 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 6000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/big_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/big_mtu_no_icmp.conf
@@ -5,123 +5,95 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.10.10.10;
@@ -132,7 +104,6 @@ external-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
@@ -140,10 +111,8 @@ internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
   mtu 2000;
@@ -152,7 +121,6 @@ internal-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/icmp_on_fail.conf
+++ b/src/program/lwaftr/tests/data/vlan/icmp_on_fail.conf
@@ -5,134 +5,103 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
@@ -140,19 +109,14 @@ internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/no_hairpin.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_hairpin.conf
@@ -5,134 +5,104 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
@@ -140,19 +110,16 @@ internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   hairpinning false;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp.conf
@@ -5,134 +5,104 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
@@ -140,19 +110,15 @@ internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_maxfrags1.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_maxfrags1.conf
@@ -5,134 +5,104 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 1;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
@@ -140,13 +110,10 @@ internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_accept.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_accept.conf
@@ -5,116 +5,89 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
@@ -122,19 +95,16 @@ external-interface {
   egress-filter ip;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ingress-filter ip;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
@@ -143,20 +113,16 @@ internal-interface {
   egress-filter ip6;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ingress-filter ip6;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_drop.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_drop.conf
@@ -5,116 +5,89 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
@@ -122,19 +95,16 @@ external-interface {
   egress-filter "len < 0";
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ingress-filter "len < 0";
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
@@ -143,20 +113,16 @@ internal-interface {
   egress-filter "len < 0";
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ingress-filter "len < 0";
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/small_ipv4_mtu_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv4_mtu_icmp.conf
@@ -5,125 +5,95 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
   mtu 576;
@@ -132,27 +102,20 @@ external-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp.conf
@@ -5,123 +5,95 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.10.10.10;
@@ -132,7 +104,6 @@ external-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
@@ -140,10 +111,8 @@ internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
   mtu 1280;
@@ -152,7 +121,6 @@ internal-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp_allow.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp_allow.conf
@@ -5,125 +5,95 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
   mtu 1500;
@@ -132,18 +102,13 @@ external-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
   mtu 1280;
@@ -152,7 +117,6 @@ internal-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp.conf
@@ -5,154 +5,116 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp_without_mac4.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp_without_mac4.conf
@@ -5,154 +5,116 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     ip 4.5.6.7;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp_withoutmac.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp_withoutmac.conf
@@ -5,154 +5,116 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     ip 8:9:a:b:4:3:2:1;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/tests/data/vlan/vlan.conf
+++ b/src/program/lwaftr/tests/data/vlan/vlan.conf
@@ -5,154 +5,116 @@ binding-table {
   psid-map {
     addr 178.79.150.15;
     psid-length 4;
-    reserved-ports-bit-count 0;
     shift 12;
   }
   psid-map {
     addr 178.79.150.233;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.1;
     psid-length 0;
-    reserved-ports-bit-count 0;
     shift 16;
   }
   psid-map {
     addr 178.79.150.2;
     psid-length 16;
-    reserved-ports-bit-count 0;
     shift 0;
   }
   psid-map {
     addr 178.79.150.3;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
+    ipv4 178.79.150.233;
+    psid 4660;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.1;
+    psid 0;
+    b4-ipv6 127:10:20:30:40:50:60:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 80;
+    b4-ipv6 127:2:3:4:5:6:7:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 54192;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
     ipv4 178.79.150.3;
-    padding 0;
     psid 4;
     b4-ipv6 127:14:25:36:47:58:69:128;
     br 2;
   }
   softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 22788;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.1;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:10:20:30:40:50:60:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2700;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 4660;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 54192;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 7850;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 1;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 2300;
-    b4-ipv6 127:11:12:13:14:15:16:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.15;
-    padding 0;
-    psid 0;
-    b4-ipv6 127:22:33:44:55:66:77:128;
-    br 0;
-  }
-  softwire {
-    ipv4 178.79.150.233;
-    padding 0;
-    psid 80;
-    b4-ipv6 127:2:3:4:5:6:7:128;
-    br 0;
-  }
-  softwire {
     ipv4 178.79.150.2;
-    padding 0;
     psid 7850;
     b4-ipv6 127:24:35:46:57:68:79:128;
     br 1;
   }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 7850;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2300;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 22788;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.233;
+    psid 2700;
+    b4-ipv6 127:11:12:13:14:15:16:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 1;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
+  softwire {
+    ipv4 178.79.150.15;
+    psid 0;
+    b4-ipv6 127:22:33:44:55:66:77:128;
+  }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 10.10.10.10;
   mac 12:12:12:12:12:12;
-  mtu 1460;
   next-hop {
     mac 68:68:68:68:68:68;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 6000;
-    period 2;
   }
-  generate-icmp-errors true;
-  hairpinning true;
   ip 8:9:a:b:c:d:e:f;
   mac 22:22:22:22:22:22;
-  mtu 1500;
   next-hop {
     mac 44:44:44:44:44:44;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }

--- a/src/program/lwaftr/virt/confs/lwaftrctl1.conf
+++ b/src/program/lwaftr/virt/confs/lwaftrctl1.conf
@@ -1,41 +1,24 @@
 #!/usr/bin/env bash
-
-# General
-
-SNABB_HOST_PATH=~/workspace/snabb_host
-SNABB_HOST_LWAFTR=$SNABB_HOST_PATH/src/program/lwaftr
-
-# QEMU
-
-NAME=lwaftr1
-DISK=~/vm/vm_lwaftr1.qcow2
-MEM=1024M
-
-IFACE=mgmt0
-NETSCRIPT=$SNABB_HOST_LWAFTR/virt/setup_networks/lwaftr1.sh
-
-SHARED_LOCATION=~/workspace
-VHU_SOCK1=/tmp/vh1a.sock
-VHU_SOCK2=/tmp/vh1b.sock
-VNC_DISPLAY=22
-
-# VM
-
-QEMU_CORE=0
-VM_DIR=~/vm
-VM_IP=10.21.21.2
-VM_USER=igalia   # Must be in the list of sudoers        
-
-# Guest
-
-SNABB_GUEST_PATH=/mnt/host/snabb_guest/src
-
-# SnabbNFV
-
-SNABBNFV_CORE1=1
-SNABBNFV_CONF1=$SNABB_HOST_LWAFTR/virt/ports/lwaftr1/a.cfg
-SNABBNFV_PCI1=0000:02:00.0
-
-SNABBNFV_CORE2=2
-SNABBNFV_CONF2=$SNABB_HOST_LWAFTR/virt/ports/lwaftr1/b.cfg
-SNABBNFV_PCI2=0000:02:00.1
+  ^
+lib/yang/parser.lua:44: <unknown>:1:2: error: Invalid identifier
+stack traceback:
+	core/main.lua:137: in function <core/main.lua:135>
+	[C]: in function 'error'
+	lib/yang/parser.lua:44: in function 'error'
+	lib/yang/parser.lua:195: in function 'parse_identifier'
+	lib/yang/parser.lua:208: in function 'parse_keyword'
+	lib/yang/parser.lua:243: in function 'parse_statement'
+	lib/yang/parser.lua:232: in function 'parse_statement_list'
+	lib/yang/parser.lua:220: in function 'parse_string'
+	lib/yang/data.lua:332: in function 'load_data_for_schema_by_name'
+	lib/yang/yang.lua:107: in function 'load_configuration'
+	...m/lwaftr/migrate_configuration/migrate_configuration.lua:350: in function 'run'
+	program/lwaftr/lwaftr.lua:17: in function 'run'
+	core/main.lua:56: in function <core/main.lua:43>
+	[C]: in function 'xpcall'
+	core/main.lua:185: in main chunk
+	[C]: at 0x00453c60
+	[C]: in function 'pcall'
+	core/startup.lua:3: in main chunk
+	[C]: in function 'require'
+	[string "require "core.startup""]:1: in main chunk

--- a/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr-xe0.conf
+++ b/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr-xe0.conf
@@ -4,1359 +4,975 @@ binding-table {
     addr 193.5.1.100;
     end-addr 193.5.1.102;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
     ipv4 193.5.1.100;
-    padding 0;
-    psid 48;
-    b4-ipv6 fc00:1:2:3:4:5:0:ad;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 52;
-    b4-ipv6 fc00:1:2:3:4:5:0:b1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 8;
-    b4-ipv6 fc00:1:2:3:4:5:0:c4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 55;
-    b4-ipv6 fc00:1:2:3:4:5:0:132;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 49;
-    b4-ipv6 fc00:1:2:3:4:5:0:12c;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 14;
-    b4-ipv6 fc00:1:2:3:4:5:0:109;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 63;
-    b4-ipv6 fc00:1:2:3:4:5:0:fb;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 34;
-    b4-ipv6 fc00:1:2:3:4:5:0:11d;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 22;
-    b4-ipv6 fc00:1:2:3:4:5:0:111;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 39;
-    b4-ipv6 fc00:1:2:3:4:5:0:a4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 7;
-    b4-ipv6 fc00:1:2:3:4:5:0:c3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 5;
-    b4-ipv6 fc00:1:2:3:4:5:0:100;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 60;
-    b4-ipv6 fc00:1:2:3:4:5:0:137;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 40;
-    b4-ipv6 fc00:1:2:3:4:5:0:e4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 3;
-    b4-ipv6 fc00:1:2:3:4:5:0:bf;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 25;
-    b4-ipv6 fc00:1:2:3:4:5:0:d5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 56;
-    b4-ipv6 fc00:1:2:3:4:5:0:133;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 50;
-    b4-ipv6 fc00:1:2:3:4:5:0:12d;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 33;
-    b4-ipv6 fc00:1:2:3:4:5:0:9e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 61;
-    b4-ipv6 fc00:1:2:3:4:5:0:f9;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 58;
-    b4-ipv6 fc00:1:2:3:4:5:0:135;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 51;
-    b4-ipv6 fc00:1:2:3:4:5:0:ef;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 28;
-    b4-ipv6 fc00:1:2:3:4:5:0:99;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 44;
-    b4-ipv6 fc00:1:2:3:4:5:0:a9;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 27;
-    b4-ipv6 fc00:1:2:3:4:5:0:d7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
     psid 43;
     b4-ipv6 fc00:1:2:3:4:5:0:a8;
-    br 0;
   }
   softwire {
     ipv4 193.5.1.100;
-    padding 0;
-    psid 20;
-    b4-ipv6 fc00:1:2:3:4:5:0:91;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 30;
-    b4-ipv6 fc00:1:2:3:4:5:0:da;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 34;
-    b4-ipv6 fc00:1:2:3:4:5:0:de;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 41;
-    b4-ipv6 fc00:1:2:3:4:5:0:a6;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 35;
-    b4-ipv6 fc00:1:2:3:4:5:0:a0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 2;
-    b4-ipv6 fc00:1:2:3:4:5:0:be;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 10;
-    b4-ipv6 fc00:1:2:3:4:5:0:105;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 17;
-    b4-ipv6 fc00:1:2:3:4:5:0:10c;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 55;
-    b4-ipv6 fc00:1:2:3:4:5:0:b4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 23;
-    b4-ipv6 fc00:1:2:3:4:5:0:d3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 13;
-    b4-ipv6 fc00:1:2:3:4:5:0:c9;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 4;
-    b4-ipv6 fc00:1:2:3:4:5:0:81;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 1;
-    b4-ipv6 fc00:1:2:3:4:5:0:fc;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 6;
-    b4-ipv6 fc00:1:2:3:4:5:0:101;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 32;
-    b4-ipv6 fc00:1:2:3:4:5:0:11b;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 9;
-    b4-ipv6 fc00:1:2:3:4:5:0:86;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 22;
-    b4-ipv6 fc00:1:2:3:4:5:0:d2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 40;
-    b4-ipv6 fc00:1:2:3:4:5:0:123;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 39;
-    b4-ipv6 fc00:1:2:3:4:5:0:122;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 47;
-    b4-ipv6 fc00:1:2:3:4:5:0:12a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 25;
-    b4-ipv6 fc00:1:2:3:4:5:0:96;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 45;
-    b4-ipv6 fc00:1:2:3:4:5:0:e9;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 39;
-    b4-ipv6 fc00:1:2:3:4:5:0:e3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 51;
-    b4-ipv6 fc00:1:2:3:4:5:0:12e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 43;
-    b4-ipv6 fc00:1:2:3:4:5:0:126;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 12;
-    b4-ipv6 fc00:1:2:3:4:5:0:89;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 49;
-    b4-ipv6 fc00:1:2:3:4:5:0:ed;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 11;
-    b4-ipv6 fc00:1:2:3:4:5:0:106;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 20;
-    b4-ipv6 fc00:1:2:3:4:5:0:d0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 19;
-    b4-ipv6 fc00:1:2:3:4:5:0:10e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 36;
-    b4-ipv6 fc00:1:2:3:4:5:0:11f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 8;
-    b4-ipv6 fc00:1:2:3:4:5:0:103;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 38;
-    b4-ipv6 fc00:1:2:3:4:5:0:121;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 2;
-    b4-ipv6 fc00:1:2:3:4:5:0:7f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 9;
-    b4-ipv6 fc00:1:2:3:4:5:0:104;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 24;
-    b4-ipv6 fc00:1:2:3:4:5:0:95;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 63;
-    b4-ipv6 fc00:1:2:3:4:5:0:bc;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 57;
-    b4-ipv6 fc00:1:2:3:4:5:0:f5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 29;
-    b4-ipv6 fc00:1:2:3:4:5:0:9a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 26;
-    b4-ipv6 fc00:1:2:3:4:5:0:97;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 37;
-    b4-ipv6 fc00:1:2:3:4:5:0:120;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 28;
-    b4-ipv6 fc00:1:2:3:4:5:0:117;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 11;
-    b4-ipv6 fc00:1:2:3:4:5:0:88;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 61;
-    b4-ipv6 fc00:1:2:3:4:5:0:ba;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 1;
-    b4-ipv6 fc00:1:2:3:4:5:0:7e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 5;
-    b4-ipv6 fc00:1:2:3:4:5:0:c1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 13;
-    b4-ipv6 fc00:1:2:3:4:5:0:108;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 42;
-    b4-ipv6 fc00:1:2:3:4:5:0:125;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 48;
-    b4-ipv6 fc00:1:2:3:4:5:0:ec;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 23;
-    b4-ipv6 fc00:1:2:3:4:5:0:94;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 30;
-    b4-ipv6 fc00:1:2:3:4:5:0:9b;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 46;
-    b4-ipv6 fc00:1:2:3:4:5:0:ab;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 34;
-    b4-ipv6 fc00:1:2:3:4:5:0:9f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 22;
-    b4-ipv6 fc00:1:2:3:4:5:0:93;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 63;
-    b4-ipv6 fc00:1:2:3:4:5:0:13a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 9;
-    b4-ipv6 fc00:1:2:3:4:5:0:c5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 16;
-    b4-ipv6 fc00:1:2:3:4:5:0:cc;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 35;
-    b4-ipv6 fc00:1:2:3:4:5:0:df;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 53;
-    b4-ipv6 fc00:1:2:3:4:5:0:f1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 27;
-    b4-ipv6 fc00:1:2:3:4:5:0:116;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 54;
-    b4-ipv6 fc00:1:2:3:4:5:0:131;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 60;
-    b4-ipv6 fc00:1:2:3:4:5:0:f8;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 15;
-    b4-ipv6 fc00:1:2:3:4:5:0:10a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 26;
-    b4-ipv6 fc00:1:2:3:4:5:0:d6;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
     psid 45;
     b4-ipv6 fc00:1:2:3:4:5:0:aa;
-    br 0;
   }
   softwire {
     ipv4 193.5.1.101;
-    padding 0;
-    psid 31;
-    b4-ipv6 fc00:1:2:3:4:5:0:db;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 13;
-    b4-ipv6 fc00:1:2:3:4:5:0:8a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 4;
-    b4-ipv6 fc00:1:2:3:4:5:0:c0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 10;
-    b4-ipv6 fc00:1:2:3:4:5:0:87;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 59;
-    b4-ipv6 fc00:1:2:3:4:5:0:136;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 42;
-    b4-ipv6 fc00:1:2:3:4:5:0:a7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 6;
-    b4-ipv6 fc00:1:2:3:4:5:0:c2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 57;
-    b4-ipv6 fc00:1:2:3:4:5:0:134;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 19;
-    b4-ipv6 fc00:1:2:3:4:5:0:cf;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 17;
-    b4-ipv6 fc00:1:2:3:4:5:0:8e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 62;
-    b4-ipv6 fc00:1:2:3:4:5:0:fa;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 32;
-    b4-ipv6 fc00:1:2:3:4:5:0:9d;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 41;
-    b4-ipv6 fc00:1:2:3:4:5:0:e5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 3;
-    b4-ipv6 fc00:1:2:3:4:5:0:fe;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
     psid 60;
-    b4-ipv6 fc00:1:2:3:4:5:0:b9;
-    br 0;
+    b4-ipv6 fc00:1:2:3:4:5:0:f8;
   }
   softwire {
     ipv4 193.5.1.101;
-    padding 0;
-    psid 55;
-    b4-ipv6 fc00:1:2:3:4:5:0:f3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 50;
-    b4-ipv6 fc00:1:2:3:4:5:0:af;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 56;
-    b4-ipv6 fc00:1:2:3:4:5:0:f4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 52;
-    b4-ipv6 fc00:1:2:3:4:5:0:12f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 58;
-    b4-ipv6 fc00:1:2:3:4:5:0:b7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 33;
-    b4-ipv6 fc00:1:2:3:4:5:0:11c;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 28;
-    b4-ipv6 fc00:1:2:3:4:5:0:d8;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 44;
-    b4-ipv6 fc00:1:2:3:4:5:0:127;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 49;
-    b4-ipv6 fc00:1:2:3:4:5:0:ae;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 12;
-    b4-ipv6 fc00:1:2:3:4:5:0:107;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 14;
-    b4-ipv6 fc00:1:2:3:4:5:0:8b;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 21;
-    b4-ipv6 fc00:1:2:3:4:5:0:92;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 42;
-    b4-ipv6 fc00:1:2:3:4:5:0:e6;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 24;
-    b4-ipv6 fc00:1:2:3:4:5:0:d4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 5;
-    b4-ipv6 fc00:1:2:3:4:5:0:82;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 54;
-    b4-ipv6 fc00:1:2:3:4:5:0:f2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 15;
-    b4-ipv6 fc00:1:2:3:4:5:0:8c;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 40;
-    b4-ipv6 fc00:1:2:3:4:5:0:a5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 59;
-    b4-ipv6 fc00:1:2:3:4:5:0:f7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 46;
-    b4-ipv6 fc00:1:2:3:4:5:0:129;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 18;
-    b4-ipv6 fc00:1:2:3:4:5:0:10d;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 21;
-    b4-ipv6 fc00:1:2:3:4:5:0:110;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 36;
-    b4-ipv6 fc00:1:2:3:4:5:0:a1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
     psid 18;
     b4-ipv6 fc00:1:2:3:4:5:0:ce;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 23;
-    b4-ipv6 fc00:1:2:3:4:5:0:112;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 53;
-    b4-ipv6 fc00:1:2:3:4:5:0:b2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 47;
-    b4-ipv6 fc00:1:2:3:4:5:0:ac;
-    br 0;
   }
   softwire {
     ipv4 193.5.1.101;
-    padding 0;
-    psid 11;
-    b4-ipv6 fc00:1:2:3:4:5:0:c7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 20;
-    b4-ipv6 fc00:1:2:3:4:5:0:10f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 1;
-    b4-ipv6 fc00:1:2:3:4:5:0:bd;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 19;
-    b4-ipv6 fc00:1:2:3:4:5:0:90;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 48;
-    b4-ipv6 fc00:1:2:3:4:5:0:12b;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 52;
-    b4-ipv6 fc00:1:2:3:4:5:0:f0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 24;
-    b4-ipv6 fc00:1:2:3:4:5:0:113;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 51;
-    b4-ipv6 fc00:1:2:3:4:5:0:b0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 32;
-    b4-ipv6 fc00:1:2:3:4:5:0:dc;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 35;
-    b4-ipv6 fc00:1:2:3:4:5:0:11e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 50;
-    b4-ipv6 fc00:1:2:3:4:5:0:ee;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 31;
-    b4-ipv6 fc00:1:2:3:4:5:0:11a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 37;
-    b4-ipv6 fc00:1:2:3:4:5:0:a2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 2;
-    b4-ipv6 fc00:1:2:3:4:5:0:fd;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 58;
-    b4-ipv6 fc00:1:2:3:4:5:0:f6;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 38;
-    b4-ipv6 fc00:1:2:3:4:5:0:e2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 41;
-    b4-ipv6 fc00:1:2:3:4:5:0:124;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 6;
-    b4-ipv6 fc00:1:2:3:4:5:0:83;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 14;
-    b4-ipv6 fc00:1:2:3:4:5:0:ca;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 57;
-    b4-ipv6 fc00:1:2:3:4:5:0:b6;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 29;
-    b4-ipv6 fc00:1:2:3:4:5:0:118;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 16;
-    b4-ipv6 fc00:1:2:3:4:5:0:8d;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 62;
-    b4-ipv6 fc00:1:2:3:4:5:0:139;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 26;
-    b4-ipv6 fc00:1:2:3:4:5:0:115;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 56;
-    b4-ipv6 fc00:1:2:3:4:5:0:b5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 33;
-    b4-ipv6 fc00:1:2:3:4:5:0:dd;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 7;
-    b4-ipv6 fc00:1:2:3:4:5:0:84;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 21;
-    b4-ipv6 fc00:1:2:3:4:5:0:d1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 18;
-    b4-ipv6 fc00:1:2:3:4:5:0:8f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 62;
-    b4-ipv6 fc00:1:2:3:4:5:0:bb;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 27;
-    b4-ipv6 fc00:1:2:3:4:5:0:98;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 3;
-    b4-ipv6 fc00:1:2:3:4:5:0:80;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 12;
-    b4-ipv6 fc00:1:2:3:4:5:0:c8;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 8;
-    b4-ipv6 fc00:1:2:3:4:5:0:85;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 30;
-    b4-ipv6 fc00:1:2:3:4:5:0:119;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 4;
-    b4-ipv6 fc00:1:2:3:4:5:0:ff;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 54;
-    b4-ipv6 fc00:1:2:3:4:5:0:b3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 16;
-    b4-ipv6 fc00:1:2:3:4:5:0:10b;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 37;
-    b4-ipv6 fc00:1:2:3:4:5:0:e1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 31;
-    b4-ipv6 fc00:1:2:3:4:5:0:9c;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 43;
-    b4-ipv6 fc00:1:2:3:4:5:0:e7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 25;
-    b4-ipv6 fc00:1:2:3:4:5:0:114;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 15;
-    b4-ipv6 fc00:1:2:3:4:5:0:cb;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 7;
-    b4-ipv6 fc00:1:2:3:4:5:0:102;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 45;
-    b4-ipv6 fc00:1:2:3:4:5:0:128;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 38;
-    b4-ipv6 fc00:1:2:3:4:5:0:a3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 46;
-    b4-ipv6 fc00:1:2:3:4:5:0:ea;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 61;
-    b4-ipv6 fc00:1:2:3:4:5:0:138;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 36;
-    b4-ipv6 fc00:1:2:3:4:5:0:e0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 29;
-    b4-ipv6 fc00:1:2:3:4:5:0:d9;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
     psid 47;
     b4-ipv6 fc00:1:2:3:4:5:0:eb;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 44;
-    b4-ipv6 fc00:1:2:3:4:5:0:e8;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 53;
-    b4-ipv6 fc00:1:2:3:4:5:0:130;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 17;
-    b4-ipv6 fc00:1:2:3:4:5:0:cd;
-    br 0;
   }
   softwire {
     ipv4 193.5.1.100;
-    padding 0;
-    psid 59;
-    b4-ipv6 fc00:1:2:3:4:5:0:b8;
-    br 0;
+    psid 33;
+    b4-ipv6 fc00:1:2:3:4:5:0:9e;
   }
   softwire {
     ipv4 193.5.1.101;
-    padding 0;
+    psid 63;
+    b4-ipv6 fc00:1:2:3:4:5:0:fb;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 30;
+    b4-ipv6 fc00:1:2:3:4:5:0:119;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 49;
+    b4-ipv6 fc00:1:2:3:4:5:0:ed;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 9;
+    b4-ipv6 fc00:1:2:3:4:5:0:c5;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 3;
+    b4-ipv6 fc00:1:2:3:4:5:0:fe;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 56;
+    b4-ipv6 fc00:1:2:3:4:5:0:b5;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 51;
+    b4-ipv6 fc00:1:2:3:4:5:0:b0;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 26;
+    b4-ipv6 fc00:1:2:3:4:5:0:d6;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 37;
+    b4-ipv6 fc00:1:2:3:4:5:0:a2;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 44;
+    b4-ipv6 fc00:1:2:3:4:5:0:e8;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 17;
+    b4-ipv6 fc00:1:2:3:4:5:0:8e;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 48;
+    b4-ipv6 fc00:1:2:3:4:5:0:ec;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 39;
+    b4-ipv6 fc00:1:2:3:4:5:0:122;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 5;
+    b4-ipv6 fc00:1:2:3:4:5:0:c1;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 38;
+    b4-ipv6 fc00:1:2:3:4:5:0:121;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 21;
+    b4-ipv6 fc00:1:2:3:4:5:0:d1;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 50;
+    b4-ipv6 fc00:1:2:3:4:5:0:ee;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 35;
+    b4-ipv6 fc00:1:2:3:4:5:0:df;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 55;
+    b4-ipv6 fc00:1:2:3:4:5:0:b4;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 46;
+    b4-ipv6 fc00:1:2:3:4:5:0:ab;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 53;
+    b4-ipv6 fc00:1:2:3:4:5:0:b2;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 58;
+    b4-ipv6 fc00:1:2:3:4:5:0:b7;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 55;
+    b4-ipv6 fc00:1:2:3:4:5:0:f3;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 1;
+    b4-ipv6 fc00:1:2:3:4:5:0:bd;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 61;
+    b4-ipv6 fc00:1:2:3:4:5:0:ba;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 31;
+    b4-ipv6 fc00:1:2:3:4:5:0:9c;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 27;
+    b4-ipv6 fc00:1:2:3:4:5:0:116;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 54;
+    b4-ipv6 fc00:1:2:3:4:5:0:f2;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 24;
+    b4-ipv6 fc00:1:2:3:4:5:0:113;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 11;
+    b4-ipv6 fc00:1:2:3:4:5:0:88;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 34;
+    b4-ipv6 fc00:1:2:3:4:5:0:9f;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 46;
+    b4-ipv6 fc00:1:2:3:4:5:0:129;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 16;
+    b4-ipv6 fc00:1:2:3:4:5:0:cc;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 19;
+    b4-ipv6 fc00:1:2:3:4:5:0:10e;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 63;
+    b4-ipv6 fc00:1:2:3:4:5:0:13a;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 15;
+    b4-ipv6 fc00:1:2:3:4:5:0:8c;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 13;
+    b4-ipv6 fc00:1:2:3:4:5:0:8a;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 40;
+    b4-ipv6 fc00:1:2:3:4:5:0:123;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 2;
+    b4-ipv6 fc00:1:2:3:4:5:0:fd;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 21;
+    b4-ipv6 fc00:1:2:3:4:5:0:110;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 19;
+    b4-ipv6 fc00:1:2:3:4:5:0:cf;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 61;
+    b4-ipv6 fc00:1:2:3:4:5:0:138;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 32;
+    b4-ipv6 fc00:1:2:3:4:5:0:9d;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 14;
+    b4-ipv6 fc00:1:2:3:4:5:0:109;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 25;
+    b4-ipv6 fc00:1:2:3:4:5:0:96;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 20;
+    b4-ipv6 fc00:1:2:3:4:5:0:91;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 59;
+    b4-ipv6 fc00:1:2:3:4:5:0:b8;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 9;
+    b4-ipv6 fc00:1:2:3:4:5:0:104;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 23;
+    b4-ipv6 fc00:1:2:3:4:5:0:d3;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 60;
+    b4-ipv6 fc00:1:2:3:4:5:0:137;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 43;
+    b4-ipv6 fc00:1:2:3:4:5:0:e7;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 13;
+    b4-ipv6 fc00:1:2:3:4:5:0:108;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 33;
+    b4-ipv6 fc00:1:2:3:4:5:0:dd;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 47;
+    b4-ipv6 fc00:1:2:3:4:5:0:12a;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 37;
+    b4-ipv6 fc00:1:2:3:4:5:0:120;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 6;
+    b4-ipv6 fc00:1:2:3:4:5:0:83;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 48;
+    b4-ipv6 fc00:1:2:3:4:5:0:ad;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 30;
+    b4-ipv6 fc00:1:2:3:4:5:0:9b;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 62;
+    b4-ipv6 fc00:1:2:3:4:5:0:bb;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 16;
+    b4-ipv6 fc00:1:2:3:4:5:0:10b;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 50;
+    b4-ipv6 fc00:1:2:3:4:5:0:af;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 42;
+    b4-ipv6 fc00:1:2:3:4:5:0:e6;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 29;
+    b4-ipv6 fc00:1:2:3:4:5:0:118;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 52;
+    b4-ipv6 fc00:1:2:3:4:5:0:b1;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 56;
+    b4-ipv6 fc00:1:2:3:4:5:0:133;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 49;
+    b4-ipv6 fc00:1:2:3:4:5:0:ae;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 53;
+    b4-ipv6 fc00:1:2:3:4:5:0:f1;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 57;
+    b4-ipv6 fc00:1:2:3:4:5:0:134;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 36;
+    b4-ipv6 fc00:1:2:3:4:5:0:a1;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 5;
+    b4-ipv6 fc00:1:2:3:4:5:0:100;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 31;
+    b4-ipv6 fc00:1:2:3:4:5:0:db;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 58;
+    b4-ipv6 fc00:1:2:3:4:5:0:135;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 35;
+    b4-ipv6 fc00:1:2:3:4:5:0:11e;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 42;
+    b4-ipv6 fc00:1:2:3:4:5:0:a7;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 4;
+    b4-ipv6 fc00:1:2:3:4:5:0:ff;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 12;
+    b4-ipv6 fc00:1:2:3:4:5:0:89;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 3;
+    b4-ipv6 fc00:1:2:3:4:5:0:80;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 7;
+    b4-ipv6 fc00:1:2:3:4:5:0:84;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 43;
+    b4-ipv6 fc00:1:2:3:4:5:0:126;
+  }
+  softwire {
+    ipv4 193.5.1.101;
     psid 10;
     b4-ipv6 fc00:1:2:3:4:5:0:c6;
-    br 0;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 60;
+    b4-ipv6 fc00:1:2:3:4:5:0:b9;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 22;
+    b4-ipv6 fc00:1:2:3:4:5:0:d2;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 32;
+    b4-ipv6 fc00:1:2:3:4:5:0:dc;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 23;
+    b4-ipv6 fc00:1:2:3:4:5:0:112;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 41;
+    b4-ipv6 fc00:1:2:3:4:5:0:124;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 19;
+    b4-ipv6 fc00:1:2:3:4:5:0:90;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 37;
+    b4-ipv6 fc00:1:2:3:4:5:0:e1;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 25;
+    b4-ipv6 fc00:1:2:3:4:5:0:d5;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 38;
+    b4-ipv6 fc00:1:2:3:4:5:0:a3;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 23;
+    b4-ipv6 fc00:1:2:3:4:5:0:94;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 40;
+    b4-ipv6 fc00:1:2:3:4:5:0:a5;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 1;
+    b4-ipv6 fc00:1:2:3:4:5:0:7e;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 55;
+    b4-ipv6 fc00:1:2:3:4:5:0:132;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 40;
+    b4-ipv6 fc00:1:2:3:4:5:0:e4;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 15;
+    b4-ipv6 fc00:1:2:3:4:5:0:10a;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 6;
+    b4-ipv6 fc00:1:2:3:4:5:0:c2;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 28;
+    b4-ipv6 fc00:1:2:3:4:5:0:99;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 41;
+    b4-ipv6 fc00:1:2:3:4:5:0:e5;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 7;
+    b4-ipv6 fc00:1:2:3:4:5:0:c3;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 62;
+    b4-ipv6 fc00:1:2:3:4:5:0:fa;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 45;
+    b4-ipv6 fc00:1:2:3:4:5:0:128;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 31;
+    b4-ipv6 fc00:1:2:3:4:5:0:11a;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 13;
+    b4-ipv6 fc00:1:2:3:4:5:0:c9;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 59;
+    b4-ipv6 fc00:1:2:3:4:5:0:f7;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 57;
+    b4-ipv6 fc00:1:2:3:4:5:0:f5;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 11;
+    b4-ipv6 fc00:1:2:3:4:5:0:106;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 46;
+    b4-ipv6 fc00:1:2:3:4:5:0:ea;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 34;
+    b4-ipv6 fc00:1:2:3:4:5:0:11d;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 2;
+    b4-ipv6 fc00:1:2:3:4:5:0:7f;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 30;
+    b4-ipv6 fc00:1:2:3:4:5:0:da;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 45;
+    b4-ipv6 fc00:1:2:3:4:5:0:e9;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 61;
+    b4-ipv6 fc00:1:2:3:4:5:0:f9;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 17;
+    b4-ipv6 fc00:1:2:3:4:5:0:10c;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 29;
+    b4-ipv6 fc00:1:2:3:4:5:0:d9;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 33;
+    b4-ipv6 fc00:1:2:3:4:5:0:11c;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 12;
+    b4-ipv6 fc00:1:2:3:4:5:0:c8;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 4;
+    b4-ipv6 fc00:1:2:3:4:5:0:c0;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 52;
+    b4-ipv6 fc00:1:2:3:4:5:0:f0;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 18;
+    b4-ipv6 fc00:1:2:3:4:5:0:10d;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 3;
+    b4-ipv6 fc00:1:2:3:4:5:0:bf;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 10;
+    b4-ipv6 fc00:1:2:3:4:5:0:105;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 8;
+    b4-ipv6 fc00:1:2:3:4:5:0:85;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 2;
+    b4-ipv6 fc00:1:2:3:4:5:0:be;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 39;
+    b4-ipv6 fc00:1:2:3:4:5:0:a4;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 36;
+    b4-ipv6 fc00:1:2:3:4:5:0:e0;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 32;
+    b4-ipv6 fc00:1:2:3:4:5:0:11b;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 44;
+    b4-ipv6 fc00:1:2:3:4:5:0:127;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 48;
+    b4-ipv6 fc00:1:2:3:4:5:0:12b;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 20;
+    b4-ipv6 fc00:1:2:3:4:5:0:10f;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 14;
+    b4-ipv6 fc00:1:2:3:4:5:0:8b;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 24;
+    b4-ipv6 fc00:1:2:3:4:5:0:95;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 51;
+    b4-ipv6 fc00:1:2:3:4:5:0:12e;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 25;
+    b4-ipv6 fc00:1:2:3:4:5:0:114;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 10;
+    b4-ipv6 fc00:1:2:3:4:5:0:87;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 22;
+    b4-ipv6 fc00:1:2:3:4:5:0:93;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 8;
+    b4-ipv6 fc00:1:2:3:4:5:0:103;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 22;
+    b4-ipv6 fc00:1:2:3:4:5:0:111;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 56;
+    b4-ipv6 fc00:1:2:3:4:5:0:f4;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 27;
+    b4-ipv6 fc00:1:2:3:4:5:0:98;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 63;
+    b4-ipv6 fc00:1:2:3:4:5:0:bc;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 26;
+    b4-ipv6 fc00:1:2:3:4:5:0:115;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 54;
+    b4-ipv6 fc00:1:2:3:4:5:0:b3;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 44;
+    b4-ipv6 fc00:1:2:3:4:5:0:a9;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 50;
+    b4-ipv6 fc00:1:2:3:4:5:0:12d;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 9;
+    b4-ipv6 fc00:1:2:3:4:5:0:86;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 58;
+    b4-ipv6 fc00:1:2:3:4:5:0:f6;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 18;
+    b4-ipv6 fc00:1:2:3:4:5:0:8f;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 28;
+    b4-ipv6 fc00:1:2:3:4:5:0:d8;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 27;
+    b4-ipv6 fc00:1:2:3:4:5:0:d7;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 54;
+    b4-ipv6 fc00:1:2:3:4:5:0:131;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 59;
+    b4-ipv6 fc00:1:2:3:4:5:0:136;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 41;
+    b4-ipv6 fc00:1:2:3:4:5:0:a6;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 12;
+    b4-ipv6 fc00:1:2:3:4:5:0:107;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 35;
+    b4-ipv6 fc00:1:2:3:4:5:0:a0;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 11;
+    b4-ipv6 fc00:1:2:3:4:5:0:c7;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 47;
+    b4-ipv6 fc00:1:2:3:4:5:0:ac;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 24;
+    b4-ipv6 fc00:1:2:3:4:5:0:d4;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 1;
+    b4-ipv6 fc00:1:2:3:4:5:0:fc;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 8;
+    b4-ipv6 fc00:1:2:3:4:5:0:c4;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 14;
+    b4-ipv6 fc00:1:2:3:4:5:0:ca;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 17;
+    b4-ipv6 fc00:1:2:3:4:5:0:cd;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 7;
+    b4-ipv6 fc00:1:2:3:4:5:0:102;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 51;
+    b4-ipv6 fc00:1:2:3:4:5:0:ef;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 6;
+    b4-ipv6 fc00:1:2:3:4:5:0:101;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 62;
+    b4-ipv6 fc00:1:2:3:4:5:0:139;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 28;
+    b4-ipv6 fc00:1:2:3:4:5:0:117;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 16;
+    b4-ipv6 fc00:1:2:3:4:5:0:8d;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 29;
+    b4-ipv6 fc00:1:2:3:4:5:0:9a;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 42;
+    b4-ipv6 fc00:1:2:3:4:5:0:125;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 21;
+    b4-ipv6 fc00:1:2:3:4:5:0:92;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 49;
+    b4-ipv6 fc00:1:2:3:4:5:0:12c;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 57;
+    b4-ipv6 fc00:1:2:3:4:5:0:b6;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 20;
+    b4-ipv6 fc00:1:2:3:4:5:0:d0;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 52;
+    b4-ipv6 fc00:1:2:3:4:5:0:12f;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 26;
+    b4-ipv6 fc00:1:2:3:4:5:0:97;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 36;
+    b4-ipv6 fc00:1:2:3:4:5:0:11f;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 4;
+    b4-ipv6 fc00:1:2:3:4:5:0:81;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 34;
+    b4-ipv6 fc00:1:2:3:4:5:0:de;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 5;
+    b4-ipv6 fc00:1:2:3:4:5:0:82;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 38;
+    b4-ipv6 fc00:1:2:3:4:5:0:e2;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 15;
+    b4-ipv6 fc00:1:2:3:4:5:0:cb;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 39;
+    b4-ipv6 fc00:1:2:3:4:5:0:e3;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 53;
+    b4-ipv6 fc00:1:2:3:4:5:0:130;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.0.1.1;
   mac 02:aa:aa:aa:aa:aa;
-  mtu 1460;
   next-hop {
     mac 02:99:99:99:99:99;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ip fc00::100;
   mac 02:aa:aa:aa:aa:aa;
   mtu 9500;
@@ -1365,6 +981,5 @@ internal-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr.conf
+++ b/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr.conf
@@ -4,1359 +4,975 @@ binding-table {
     addr 193.5.1.100;
     end-addr 193.5.1.102;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
     ipv4 193.5.1.100;
-    padding 0;
-    psid 48;
-    b4-ipv6 fc00:1:2:3:4:5:0:ad;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 52;
-    b4-ipv6 fc00:1:2:3:4:5:0:b1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 8;
-    b4-ipv6 fc00:1:2:3:4:5:0:c4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 55;
-    b4-ipv6 fc00:1:2:3:4:5:0:132;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 49;
-    b4-ipv6 fc00:1:2:3:4:5:0:12c;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 14;
-    b4-ipv6 fc00:1:2:3:4:5:0:109;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 63;
-    b4-ipv6 fc00:1:2:3:4:5:0:fb;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 34;
-    b4-ipv6 fc00:1:2:3:4:5:0:11d;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 22;
-    b4-ipv6 fc00:1:2:3:4:5:0:111;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 39;
-    b4-ipv6 fc00:1:2:3:4:5:0:a4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 7;
-    b4-ipv6 fc00:1:2:3:4:5:0:c3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 5;
-    b4-ipv6 fc00:1:2:3:4:5:0:100;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 60;
-    b4-ipv6 fc00:1:2:3:4:5:0:137;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 40;
-    b4-ipv6 fc00:1:2:3:4:5:0:e4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 3;
-    b4-ipv6 fc00:1:2:3:4:5:0:bf;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 25;
-    b4-ipv6 fc00:1:2:3:4:5:0:d5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 56;
-    b4-ipv6 fc00:1:2:3:4:5:0:133;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 50;
-    b4-ipv6 fc00:1:2:3:4:5:0:12d;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 33;
-    b4-ipv6 fc00:1:2:3:4:5:0:9e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 61;
-    b4-ipv6 fc00:1:2:3:4:5:0:f9;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 58;
-    b4-ipv6 fc00:1:2:3:4:5:0:135;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 51;
-    b4-ipv6 fc00:1:2:3:4:5:0:ef;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 28;
-    b4-ipv6 fc00:1:2:3:4:5:0:99;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 44;
-    b4-ipv6 fc00:1:2:3:4:5:0:a9;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 27;
-    b4-ipv6 fc00:1:2:3:4:5:0:d7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
     psid 43;
     b4-ipv6 fc00:1:2:3:4:5:0:a8;
-    br 0;
   }
   softwire {
     ipv4 193.5.1.100;
-    padding 0;
-    psid 20;
-    b4-ipv6 fc00:1:2:3:4:5:0:91;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 30;
-    b4-ipv6 fc00:1:2:3:4:5:0:da;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 34;
-    b4-ipv6 fc00:1:2:3:4:5:0:de;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 41;
-    b4-ipv6 fc00:1:2:3:4:5:0:a6;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 35;
-    b4-ipv6 fc00:1:2:3:4:5:0:a0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 2;
-    b4-ipv6 fc00:1:2:3:4:5:0:be;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 10;
-    b4-ipv6 fc00:1:2:3:4:5:0:105;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 17;
-    b4-ipv6 fc00:1:2:3:4:5:0:10c;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 55;
-    b4-ipv6 fc00:1:2:3:4:5:0:b4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 23;
-    b4-ipv6 fc00:1:2:3:4:5:0:d3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 13;
-    b4-ipv6 fc00:1:2:3:4:5:0:c9;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 4;
-    b4-ipv6 fc00:1:2:3:4:5:0:81;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 1;
-    b4-ipv6 fc00:1:2:3:4:5:0:fc;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 6;
-    b4-ipv6 fc00:1:2:3:4:5:0:101;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 32;
-    b4-ipv6 fc00:1:2:3:4:5:0:11b;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 9;
-    b4-ipv6 fc00:1:2:3:4:5:0:86;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 22;
-    b4-ipv6 fc00:1:2:3:4:5:0:d2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 40;
-    b4-ipv6 fc00:1:2:3:4:5:0:123;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 39;
-    b4-ipv6 fc00:1:2:3:4:5:0:122;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 47;
-    b4-ipv6 fc00:1:2:3:4:5:0:12a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 25;
-    b4-ipv6 fc00:1:2:3:4:5:0:96;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 45;
-    b4-ipv6 fc00:1:2:3:4:5:0:e9;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 39;
-    b4-ipv6 fc00:1:2:3:4:5:0:e3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 51;
-    b4-ipv6 fc00:1:2:3:4:5:0:12e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 43;
-    b4-ipv6 fc00:1:2:3:4:5:0:126;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 12;
-    b4-ipv6 fc00:1:2:3:4:5:0:89;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 49;
-    b4-ipv6 fc00:1:2:3:4:5:0:ed;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 11;
-    b4-ipv6 fc00:1:2:3:4:5:0:106;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 20;
-    b4-ipv6 fc00:1:2:3:4:5:0:d0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 19;
-    b4-ipv6 fc00:1:2:3:4:5:0:10e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 36;
-    b4-ipv6 fc00:1:2:3:4:5:0:11f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 8;
-    b4-ipv6 fc00:1:2:3:4:5:0:103;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 38;
-    b4-ipv6 fc00:1:2:3:4:5:0:121;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 2;
-    b4-ipv6 fc00:1:2:3:4:5:0:7f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 9;
-    b4-ipv6 fc00:1:2:3:4:5:0:104;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 24;
-    b4-ipv6 fc00:1:2:3:4:5:0:95;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 63;
-    b4-ipv6 fc00:1:2:3:4:5:0:bc;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 57;
-    b4-ipv6 fc00:1:2:3:4:5:0:f5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 29;
-    b4-ipv6 fc00:1:2:3:4:5:0:9a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 26;
-    b4-ipv6 fc00:1:2:3:4:5:0:97;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 37;
-    b4-ipv6 fc00:1:2:3:4:5:0:120;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 28;
-    b4-ipv6 fc00:1:2:3:4:5:0:117;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 11;
-    b4-ipv6 fc00:1:2:3:4:5:0:88;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 61;
-    b4-ipv6 fc00:1:2:3:4:5:0:ba;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 1;
-    b4-ipv6 fc00:1:2:3:4:5:0:7e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 5;
-    b4-ipv6 fc00:1:2:3:4:5:0:c1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 13;
-    b4-ipv6 fc00:1:2:3:4:5:0:108;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 42;
-    b4-ipv6 fc00:1:2:3:4:5:0:125;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 48;
-    b4-ipv6 fc00:1:2:3:4:5:0:ec;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 23;
-    b4-ipv6 fc00:1:2:3:4:5:0:94;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 30;
-    b4-ipv6 fc00:1:2:3:4:5:0:9b;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 46;
-    b4-ipv6 fc00:1:2:3:4:5:0:ab;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 34;
-    b4-ipv6 fc00:1:2:3:4:5:0:9f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 22;
-    b4-ipv6 fc00:1:2:3:4:5:0:93;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 63;
-    b4-ipv6 fc00:1:2:3:4:5:0:13a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 9;
-    b4-ipv6 fc00:1:2:3:4:5:0:c5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 16;
-    b4-ipv6 fc00:1:2:3:4:5:0:cc;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 35;
-    b4-ipv6 fc00:1:2:3:4:5:0:df;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 53;
-    b4-ipv6 fc00:1:2:3:4:5:0:f1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 27;
-    b4-ipv6 fc00:1:2:3:4:5:0:116;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 54;
-    b4-ipv6 fc00:1:2:3:4:5:0:131;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 60;
-    b4-ipv6 fc00:1:2:3:4:5:0:f8;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 15;
-    b4-ipv6 fc00:1:2:3:4:5:0:10a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 26;
-    b4-ipv6 fc00:1:2:3:4:5:0:d6;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
     psid 45;
     b4-ipv6 fc00:1:2:3:4:5:0:aa;
-    br 0;
   }
   softwire {
     ipv4 193.5.1.101;
-    padding 0;
-    psid 31;
-    b4-ipv6 fc00:1:2:3:4:5:0:db;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 13;
-    b4-ipv6 fc00:1:2:3:4:5:0:8a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 4;
-    b4-ipv6 fc00:1:2:3:4:5:0:c0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 10;
-    b4-ipv6 fc00:1:2:3:4:5:0:87;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 59;
-    b4-ipv6 fc00:1:2:3:4:5:0:136;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 42;
-    b4-ipv6 fc00:1:2:3:4:5:0:a7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 6;
-    b4-ipv6 fc00:1:2:3:4:5:0:c2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 57;
-    b4-ipv6 fc00:1:2:3:4:5:0:134;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 19;
-    b4-ipv6 fc00:1:2:3:4:5:0:cf;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 17;
-    b4-ipv6 fc00:1:2:3:4:5:0:8e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 62;
-    b4-ipv6 fc00:1:2:3:4:5:0:fa;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 32;
-    b4-ipv6 fc00:1:2:3:4:5:0:9d;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 41;
-    b4-ipv6 fc00:1:2:3:4:5:0:e5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 3;
-    b4-ipv6 fc00:1:2:3:4:5:0:fe;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
     psid 60;
-    b4-ipv6 fc00:1:2:3:4:5:0:b9;
-    br 0;
+    b4-ipv6 fc00:1:2:3:4:5:0:f8;
   }
   softwire {
     ipv4 193.5.1.101;
-    padding 0;
-    psid 55;
-    b4-ipv6 fc00:1:2:3:4:5:0:f3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 50;
-    b4-ipv6 fc00:1:2:3:4:5:0:af;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 56;
-    b4-ipv6 fc00:1:2:3:4:5:0:f4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 52;
-    b4-ipv6 fc00:1:2:3:4:5:0:12f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 58;
-    b4-ipv6 fc00:1:2:3:4:5:0:b7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 33;
-    b4-ipv6 fc00:1:2:3:4:5:0:11c;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 28;
-    b4-ipv6 fc00:1:2:3:4:5:0:d8;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 44;
-    b4-ipv6 fc00:1:2:3:4:5:0:127;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 49;
-    b4-ipv6 fc00:1:2:3:4:5:0:ae;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 12;
-    b4-ipv6 fc00:1:2:3:4:5:0:107;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 14;
-    b4-ipv6 fc00:1:2:3:4:5:0:8b;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 21;
-    b4-ipv6 fc00:1:2:3:4:5:0:92;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 42;
-    b4-ipv6 fc00:1:2:3:4:5:0:e6;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 24;
-    b4-ipv6 fc00:1:2:3:4:5:0:d4;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 5;
-    b4-ipv6 fc00:1:2:3:4:5:0:82;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 54;
-    b4-ipv6 fc00:1:2:3:4:5:0:f2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 15;
-    b4-ipv6 fc00:1:2:3:4:5:0:8c;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 40;
-    b4-ipv6 fc00:1:2:3:4:5:0:a5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 59;
-    b4-ipv6 fc00:1:2:3:4:5:0:f7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 46;
-    b4-ipv6 fc00:1:2:3:4:5:0:129;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 18;
-    b4-ipv6 fc00:1:2:3:4:5:0:10d;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 21;
-    b4-ipv6 fc00:1:2:3:4:5:0:110;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 36;
-    b4-ipv6 fc00:1:2:3:4:5:0:a1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
     psid 18;
     b4-ipv6 fc00:1:2:3:4:5:0:ce;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 23;
-    b4-ipv6 fc00:1:2:3:4:5:0:112;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 53;
-    b4-ipv6 fc00:1:2:3:4:5:0:b2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 47;
-    b4-ipv6 fc00:1:2:3:4:5:0:ac;
-    br 0;
   }
   softwire {
     ipv4 193.5.1.101;
-    padding 0;
-    psid 11;
-    b4-ipv6 fc00:1:2:3:4:5:0:c7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 20;
-    b4-ipv6 fc00:1:2:3:4:5:0:10f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 1;
-    b4-ipv6 fc00:1:2:3:4:5:0:bd;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 19;
-    b4-ipv6 fc00:1:2:3:4:5:0:90;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 48;
-    b4-ipv6 fc00:1:2:3:4:5:0:12b;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 52;
-    b4-ipv6 fc00:1:2:3:4:5:0:f0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 24;
-    b4-ipv6 fc00:1:2:3:4:5:0:113;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 51;
-    b4-ipv6 fc00:1:2:3:4:5:0:b0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 32;
-    b4-ipv6 fc00:1:2:3:4:5:0:dc;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 35;
-    b4-ipv6 fc00:1:2:3:4:5:0:11e;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 50;
-    b4-ipv6 fc00:1:2:3:4:5:0:ee;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 31;
-    b4-ipv6 fc00:1:2:3:4:5:0:11a;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 37;
-    b4-ipv6 fc00:1:2:3:4:5:0:a2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 2;
-    b4-ipv6 fc00:1:2:3:4:5:0:fd;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 58;
-    b4-ipv6 fc00:1:2:3:4:5:0:f6;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 38;
-    b4-ipv6 fc00:1:2:3:4:5:0:e2;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 41;
-    b4-ipv6 fc00:1:2:3:4:5:0:124;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 6;
-    b4-ipv6 fc00:1:2:3:4:5:0:83;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 14;
-    b4-ipv6 fc00:1:2:3:4:5:0:ca;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 57;
-    b4-ipv6 fc00:1:2:3:4:5:0:b6;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 29;
-    b4-ipv6 fc00:1:2:3:4:5:0:118;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 16;
-    b4-ipv6 fc00:1:2:3:4:5:0:8d;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 62;
-    b4-ipv6 fc00:1:2:3:4:5:0:139;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 26;
-    b4-ipv6 fc00:1:2:3:4:5:0:115;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 56;
-    b4-ipv6 fc00:1:2:3:4:5:0:b5;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 33;
-    b4-ipv6 fc00:1:2:3:4:5:0:dd;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 7;
-    b4-ipv6 fc00:1:2:3:4:5:0:84;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 21;
-    b4-ipv6 fc00:1:2:3:4:5:0:d1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 18;
-    b4-ipv6 fc00:1:2:3:4:5:0:8f;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 62;
-    b4-ipv6 fc00:1:2:3:4:5:0:bb;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 27;
-    b4-ipv6 fc00:1:2:3:4:5:0:98;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 3;
-    b4-ipv6 fc00:1:2:3:4:5:0:80;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 12;
-    b4-ipv6 fc00:1:2:3:4:5:0:c8;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 8;
-    b4-ipv6 fc00:1:2:3:4:5:0:85;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 30;
-    b4-ipv6 fc00:1:2:3:4:5:0:119;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 4;
-    b4-ipv6 fc00:1:2:3:4:5:0:ff;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 54;
-    b4-ipv6 fc00:1:2:3:4:5:0:b3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 16;
-    b4-ipv6 fc00:1:2:3:4:5:0:10b;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 37;
-    b4-ipv6 fc00:1:2:3:4:5:0:e1;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 31;
-    b4-ipv6 fc00:1:2:3:4:5:0:9c;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 43;
-    b4-ipv6 fc00:1:2:3:4:5:0:e7;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 25;
-    b4-ipv6 fc00:1:2:3:4:5:0:114;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 15;
-    b4-ipv6 fc00:1:2:3:4:5:0:cb;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 7;
-    b4-ipv6 fc00:1:2:3:4:5:0:102;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 45;
-    b4-ipv6 fc00:1:2:3:4:5:0:128;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.100;
-    padding 0;
-    psid 38;
-    b4-ipv6 fc00:1:2:3:4:5:0:a3;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 46;
-    b4-ipv6 fc00:1:2:3:4:5:0:ea;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 61;
-    b4-ipv6 fc00:1:2:3:4:5:0:138;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 36;
-    b4-ipv6 fc00:1:2:3:4:5:0:e0;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 29;
-    b4-ipv6 fc00:1:2:3:4:5:0:d9;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
     psid 47;
     b4-ipv6 fc00:1:2:3:4:5:0:eb;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 44;
-    b4-ipv6 fc00:1:2:3:4:5:0:e8;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.102;
-    padding 0;
-    psid 53;
-    b4-ipv6 fc00:1:2:3:4:5:0:130;
-    br 0;
-  }
-  softwire {
-    ipv4 193.5.1.101;
-    padding 0;
-    psid 17;
-    b4-ipv6 fc00:1:2:3:4:5:0:cd;
-    br 0;
   }
   softwire {
     ipv4 193.5.1.100;
-    padding 0;
-    psid 59;
-    b4-ipv6 fc00:1:2:3:4:5:0:b8;
-    br 0;
+    psid 33;
+    b4-ipv6 fc00:1:2:3:4:5:0:9e;
   }
   softwire {
     ipv4 193.5.1.101;
-    padding 0;
+    psid 63;
+    b4-ipv6 fc00:1:2:3:4:5:0:fb;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 30;
+    b4-ipv6 fc00:1:2:3:4:5:0:119;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 49;
+    b4-ipv6 fc00:1:2:3:4:5:0:ed;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 9;
+    b4-ipv6 fc00:1:2:3:4:5:0:c5;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 3;
+    b4-ipv6 fc00:1:2:3:4:5:0:fe;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 56;
+    b4-ipv6 fc00:1:2:3:4:5:0:b5;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 51;
+    b4-ipv6 fc00:1:2:3:4:5:0:b0;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 26;
+    b4-ipv6 fc00:1:2:3:4:5:0:d6;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 37;
+    b4-ipv6 fc00:1:2:3:4:5:0:a2;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 44;
+    b4-ipv6 fc00:1:2:3:4:5:0:e8;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 17;
+    b4-ipv6 fc00:1:2:3:4:5:0:8e;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 48;
+    b4-ipv6 fc00:1:2:3:4:5:0:ec;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 39;
+    b4-ipv6 fc00:1:2:3:4:5:0:122;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 5;
+    b4-ipv6 fc00:1:2:3:4:5:0:c1;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 38;
+    b4-ipv6 fc00:1:2:3:4:5:0:121;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 21;
+    b4-ipv6 fc00:1:2:3:4:5:0:d1;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 50;
+    b4-ipv6 fc00:1:2:3:4:5:0:ee;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 35;
+    b4-ipv6 fc00:1:2:3:4:5:0:df;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 55;
+    b4-ipv6 fc00:1:2:3:4:5:0:b4;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 46;
+    b4-ipv6 fc00:1:2:3:4:5:0:ab;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 53;
+    b4-ipv6 fc00:1:2:3:4:5:0:b2;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 58;
+    b4-ipv6 fc00:1:2:3:4:5:0:b7;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 55;
+    b4-ipv6 fc00:1:2:3:4:5:0:f3;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 1;
+    b4-ipv6 fc00:1:2:3:4:5:0:bd;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 61;
+    b4-ipv6 fc00:1:2:3:4:5:0:ba;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 31;
+    b4-ipv6 fc00:1:2:3:4:5:0:9c;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 27;
+    b4-ipv6 fc00:1:2:3:4:5:0:116;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 54;
+    b4-ipv6 fc00:1:2:3:4:5:0:f2;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 24;
+    b4-ipv6 fc00:1:2:3:4:5:0:113;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 11;
+    b4-ipv6 fc00:1:2:3:4:5:0:88;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 34;
+    b4-ipv6 fc00:1:2:3:4:5:0:9f;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 46;
+    b4-ipv6 fc00:1:2:3:4:5:0:129;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 16;
+    b4-ipv6 fc00:1:2:3:4:5:0:cc;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 19;
+    b4-ipv6 fc00:1:2:3:4:5:0:10e;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 63;
+    b4-ipv6 fc00:1:2:3:4:5:0:13a;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 15;
+    b4-ipv6 fc00:1:2:3:4:5:0:8c;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 13;
+    b4-ipv6 fc00:1:2:3:4:5:0:8a;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 40;
+    b4-ipv6 fc00:1:2:3:4:5:0:123;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 2;
+    b4-ipv6 fc00:1:2:3:4:5:0:fd;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 21;
+    b4-ipv6 fc00:1:2:3:4:5:0:110;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 19;
+    b4-ipv6 fc00:1:2:3:4:5:0:cf;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 61;
+    b4-ipv6 fc00:1:2:3:4:5:0:138;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 32;
+    b4-ipv6 fc00:1:2:3:4:5:0:9d;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 14;
+    b4-ipv6 fc00:1:2:3:4:5:0:109;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 25;
+    b4-ipv6 fc00:1:2:3:4:5:0:96;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 20;
+    b4-ipv6 fc00:1:2:3:4:5:0:91;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 59;
+    b4-ipv6 fc00:1:2:3:4:5:0:b8;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 9;
+    b4-ipv6 fc00:1:2:3:4:5:0:104;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 23;
+    b4-ipv6 fc00:1:2:3:4:5:0:d3;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 60;
+    b4-ipv6 fc00:1:2:3:4:5:0:137;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 43;
+    b4-ipv6 fc00:1:2:3:4:5:0:e7;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 13;
+    b4-ipv6 fc00:1:2:3:4:5:0:108;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 33;
+    b4-ipv6 fc00:1:2:3:4:5:0:dd;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 47;
+    b4-ipv6 fc00:1:2:3:4:5:0:12a;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 37;
+    b4-ipv6 fc00:1:2:3:4:5:0:120;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 6;
+    b4-ipv6 fc00:1:2:3:4:5:0:83;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 48;
+    b4-ipv6 fc00:1:2:3:4:5:0:ad;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 30;
+    b4-ipv6 fc00:1:2:3:4:5:0:9b;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 62;
+    b4-ipv6 fc00:1:2:3:4:5:0:bb;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 16;
+    b4-ipv6 fc00:1:2:3:4:5:0:10b;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 50;
+    b4-ipv6 fc00:1:2:3:4:5:0:af;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 42;
+    b4-ipv6 fc00:1:2:3:4:5:0:e6;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 29;
+    b4-ipv6 fc00:1:2:3:4:5:0:118;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 52;
+    b4-ipv6 fc00:1:2:3:4:5:0:b1;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 56;
+    b4-ipv6 fc00:1:2:3:4:5:0:133;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 49;
+    b4-ipv6 fc00:1:2:3:4:5:0:ae;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 53;
+    b4-ipv6 fc00:1:2:3:4:5:0:f1;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 57;
+    b4-ipv6 fc00:1:2:3:4:5:0:134;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 36;
+    b4-ipv6 fc00:1:2:3:4:5:0:a1;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 5;
+    b4-ipv6 fc00:1:2:3:4:5:0:100;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 31;
+    b4-ipv6 fc00:1:2:3:4:5:0:db;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 58;
+    b4-ipv6 fc00:1:2:3:4:5:0:135;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 35;
+    b4-ipv6 fc00:1:2:3:4:5:0:11e;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 42;
+    b4-ipv6 fc00:1:2:3:4:5:0:a7;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 4;
+    b4-ipv6 fc00:1:2:3:4:5:0:ff;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 12;
+    b4-ipv6 fc00:1:2:3:4:5:0:89;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 3;
+    b4-ipv6 fc00:1:2:3:4:5:0:80;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 7;
+    b4-ipv6 fc00:1:2:3:4:5:0:84;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 43;
+    b4-ipv6 fc00:1:2:3:4:5:0:126;
+  }
+  softwire {
+    ipv4 193.5.1.101;
     psid 10;
     b4-ipv6 fc00:1:2:3:4:5:0:c6;
-    br 0;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 60;
+    b4-ipv6 fc00:1:2:3:4:5:0:b9;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 22;
+    b4-ipv6 fc00:1:2:3:4:5:0:d2;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 32;
+    b4-ipv6 fc00:1:2:3:4:5:0:dc;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 23;
+    b4-ipv6 fc00:1:2:3:4:5:0:112;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 41;
+    b4-ipv6 fc00:1:2:3:4:5:0:124;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 19;
+    b4-ipv6 fc00:1:2:3:4:5:0:90;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 37;
+    b4-ipv6 fc00:1:2:3:4:5:0:e1;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 25;
+    b4-ipv6 fc00:1:2:3:4:5:0:d5;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 38;
+    b4-ipv6 fc00:1:2:3:4:5:0:a3;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 23;
+    b4-ipv6 fc00:1:2:3:4:5:0:94;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 40;
+    b4-ipv6 fc00:1:2:3:4:5:0:a5;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 1;
+    b4-ipv6 fc00:1:2:3:4:5:0:7e;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 55;
+    b4-ipv6 fc00:1:2:3:4:5:0:132;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 40;
+    b4-ipv6 fc00:1:2:3:4:5:0:e4;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 15;
+    b4-ipv6 fc00:1:2:3:4:5:0:10a;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 6;
+    b4-ipv6 fc00:1:2:3:4:5:0:c2;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 28;
+    b4-ipv6 fc00:1:2:3:4:5:0:99;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 41;
+    b4-ipv6 fc00:1:2:3:4:5:0:e5;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 7;
+    b4-ipv6 fc00:1:2:3:4:5:0:c3;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 62;
+    b4-ipv6 fc00:1:2:3:4:5:0:fa;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 45;
+    b4-ipv6 fc00:1:2:3:4:5:0:128;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 31;
+    b4-ipv6 fc00:1:2:3:4:5:0:11a;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 13;
+    b4-ipv6 fc00:1:2:3:4:5:0:c9;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 59;
+    b4-ipv6 fc00:1:2:3:4:5:0:f7;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 57;
+    b4-ipv6 fc00:1:2:3:4:5:0:f5;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 11;
+    b4-ipv6 fc00:1:2:3:4:5:0:106;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 46;
+    b4-ipv6 fc00:1:2:3:4:5:0:ea;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 34;
+    b4-ipv6 fc00:1:2:3:4:5:0:11d;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 2;
+    b4-ipv6 fc00:1:2:3:4:5:0:7f;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 30;
+    b4-ipv6 fc00:1:2:3:4:5:0:da;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 45;
+    b4-ipv6 fc00:1:2:3:4:5:0:e9;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 61;
+    b4-ipv6 fc00:1:2:3:4:5:0:f9;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 17;
+    b4-ipv6 fc00:1:2:3:4:5:0:10c;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 29;
+    b4-ipv6 fc00:1:2:3:4:5:0:d9;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 33;
+    b4-ipv6 fc00:1:2:3:4:5:0:11c;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 12;
+    b4-ipv6 fc00:1:2:3:4:5:0:c8;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 4;
+    b4-ipv6 fc00:1:2:3:4:5:0:c0;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 52;
+    b4-ipv6 fc00:1:2:3:4:5:0:f0;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 18;
+    b4-ipv6 fc00:1:2:3:4:5:0:10d;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 3;
+    b4-ipv6 fc00:1:2:3:4:5:0:bf;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 10;
+    b4-ipv6 fc00:1:2:3:4:5:0:105;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 8;
+    b4-ipv6 fc00:1:2:3:4:5:0:85;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 2;
+    b4-ipv6 fc00:1:2:3:4:5:0:be;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 39;
+    b4-ipv6 fc00:1:2:3:4:5:0:a4;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 36;
+    b4-ipv6 fc00:1:2:3:4:5:0:e0;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 32;
+    b4-ipv6 fc00:1:2:3:4:5:0:11b;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 44;
+    b4-ipv6 fc00:1:2:3:4:5:0:127;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 48;
+    b4-ipv6 fc00:1:2:3:4:5:0:12b;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 20;
+    b4-ipv6 fc00:1:2:3:4:5:0:10f;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 14;
+    b4-ipv6 fc00:1:2:3:4:5:0:8b;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 24;
+    b4-ipv6 fc00:1:2:3:4:5:0:95;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 51;
+    b4-ipv6 fc00:1:2:3:4:5:0:12e;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 25;
+    b4-ipv6 fc00:1:2:3:4:5:0:114;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 10;
+    b4-ipv6 fc00:1:2:3:4:5:0:87;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 22;
+    b4-ipv6 fc00:1:2:3:4:5:0:93;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 8;
+    b4-ipv6 fc00:1:2:3:4:5:0:103;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 22;
+    b4-ipv6 fc00:1:2:3:4:5:0:111;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 56;
+    b4-ipv6 fc00:1:2:3:4:5:0:f4;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 27;
+    b4-ipv6 fc00:1:2:3:4:5:0:98;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 63;
+    b4-ipv6 fc00:1:2:3:4:5:0:bc;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 26;
+    b4-ipv6 fc00:1:2:3:4:5:0:115;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 54;
+    b4-ipv6 fc00:1:2:3:4:5:0:b3;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 44;
+    b4-ipv6 fc00:1:2:3:4:5:0:a9;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 50;
+    b4-ipv6 fc00:1:2:3:4:5:0:12d;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 9;
+    b4-ipv6 fc00:1:2:3:4:5:0:86;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 58;
+    b4-ipv6 fc00:1:2:3:4:5:0:f6;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 18;
+    b4-ipv6 fc00:1:2:3:4:5:0:8f;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 28;
+    b4-ipv6 fc00:1:2:3:4:5:0:d8;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 27;
+    b4-ipv6 fc00:1:2:3:4:5:0:d7;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 54;
+    b4-ipv6 fc00:1:2:3:4:5:0:131;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 59;
+    b4-ipv6 fc00:1:2:3:4:5:0:136;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 41;
+    b4-ipv6 fc00:1:2:3:4:5:0:a6;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 12;
+    b4-ipv6 fc00:1:2:3:4:5:0:107;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 35;
+    b4-ipv6 fc00:1:2:3:4:5:0:a0;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 11;
+    b4-ipv6 fc00:1:2:3:4:5:0:c7;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 47;
+    b4-ipv6 fc00:1:2:3:4:5:0:ac;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 24;
+    b4-ipv6 fc00:1:2:3:4:5:0:d4;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 1;
+    b4-ipv6 fc00:1:2:3:4:5:0:fc;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 8;
+    b4-ipv6 fc00:1:2:3:4:5:0:c4;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 14;
+    b4-ipv6 fc00:1:2:3:4:5:0:ca;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 17;
+    b4-ipv6 fc00:1:2:3:4:5:0:cd;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 7;
+    b4-ipv6 fc00:1:2:3:4:5:0:102;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 51;
+    b4-ipv6 fc00:1:2:3:4:5:0:ef;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 6;
+    b4-ipv6 fc00:1:2:3:4:5:0:101;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 62;
+    b4-ipv6 fc00:1:2:3:4:5:0:139;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 28;
+    b4-ipv6 fc00:1:2:3:4:5:0:117;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 16;
+    b4-ipv6 fc00:1:2:3:4:5:0:8d;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 29;
+    b4-ipv6 fc00:1:2:3:4:5:0:9a;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 42;
+    b4-ipv6 fc00:1:2:3:4:5:0:125;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 21;
+    b4-ipv6 fc00:1:2:3:4:5:0:92;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 49;
+    b4-ipv6 fc00:1:2:3:4:5:0:12c;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 57;
+    b4-ipv6 fc00:1:2:3:4:5:0:b6;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 20;
+    b4-ipv6 fc00:1:2:3:4:5:0:d0;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 52;
+    b4-ipv6 fc00:1:2:3:4:5:0:12f;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 26;
+    b4-ipv6 fc00:1:2:3:4:5:0:97;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 36;
+    b4-ipv6 fc00:1:2:3:4:5:0:11f;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 4;
+    b4-ipv6 fc00:1:2:3:4:5:0:81;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 34;
+    b4-ipv6 fc00:1:2:3:4:5:0:de;
+  }
+  softwire {
+    ipv4 193.5.1.100;
+    psid 5;
+    b4-ipv6 fc00:1:2:3:4:5:0:82;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 38;
+    b4-ipv6 fc00:1:2:3:4:5:0:e2;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 15;
+    b4-ipv6 fc00:1:2:3:4:5:0:cb;
+  }
+  softwire {
+    ipv4 193.5.1.101;
+    psid 39;
+    b4-ipv6 fc00:1:2:3:4:5:0:e3;
+  }
+  softwire {
+    ipv4 193.5.1.102;
+    psid 53;
+    b4-ipv6 fc00:1:2:3:4:5:0:130;
   }
 }
 external-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
   ip 10.0.1.1;
   mac 02:aa:aa:aa:aa:aa;
-  mtu 1460;
   next-hop {
     mac 02:99:99:99:99:99;
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
   allow-incoming-icmp false;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
   generate-icmp-errors false;
-  hairpinning true;
   ip fc00::100;
   mac 02:aa:aa:aa:aa:aa;
   mtu 9500;
@@ -1365,6 +981,5 @@ internal-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/snabbvmx/tests/end-to-end/data/snabbvmx-lwaftr-xe1.conf
+++ b/src/program/snabbvmx/tests/end-to-end/data/snabbvmx-lwaftr-xe1.conf
@@ -3,52 +3,39 @@ binding-table {
   psid-map {
     addr 10.10.0.10;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   psid-map {
     addr 10.10.0.0;
     end-addr 10.10.0.1;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
     ipv4 10.10.0.0;
-    padding 0;
     psid 1;
     b4-ipv6 2a02:587:f710::400;
-    br 0;
   }
   softwire {
     ipv4 10.10.0.0;
-    padding 0;
     psid 4;
     b4-ipv6 2a02:587:f710::430;
-    br 0;
   }
   softwire {
     ipv4 10.10.0.0;
-    padding 0;
-    psid 3;
-    b4-ipv6 2a02:587:f710::420;
-    br 0;
-  }
-  softwire {
-    ipv4 10.10.0.0;
-    padding 0;
     psid 2;
     b4-ipv6 2a02:587:f710::410;
-    br 0;
+  }
+  softwire {
+    ipv4 10.10.0.0;
+    psid 3;
+    b4-ipv6 2a02:587:f710::420;
   }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 192.168.10.2;
   mac 02:cf:69:15:81:01;
   mtu 9000;
@@ -57,16 +44,12 @@ external-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   hairpinning false;
   ip fc00:168:10::2;
   mac 02:cf:69:15:81:01;
@@ -76,6 +59,5 @@ internal-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
 }

--- a/src/program/snabbvmx/tests/end-to-end/data/vlan/snabbvmx-lwaftr-xe1.conf
+++ b/src/program/snabbvmx/tests/end-to-end/data/vlan/snabbvmx-lwaftr-xe1.conf
@@ -3,52 +3,39 @@ binding-table {
   psid-map {
     addr 10.10.0.10;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   psid-map {
     addr 10.10.0.0;
     end-addr 10.10.0.1;
     psid-length 6;
-    reserved-ports-bit-count 0;
     shift 10;
   }
   softwire {
     ipv4 10.10.0.0;
-    padding 0;
     psid 1;
     b4-ipv6 2a02:587:f710::400;
-    br 0;
   }
   softwire {
     ipv4 10.10.0.0;
-    padding 0;
     psid 4;
     b4-ipv6 2a02:587:f710::430;
-    br 0;
   }
   softwire {
     ipv4 10.10.0.0;
-    padding 0;
-    psid 3;
-    b4-ipv6 2a02:587:f710::420;
-    br 0;
-  }
-  softwire {
-    ipv4 10.10.0.0;
-    padding 0;
     psid 2;
     b4-ipv6 2a02:587:f710::410;
-    br 0;
+  }
+  softwire {
+    ipv4 10.10.0.0;
+    psid 3;
+    b4-ipv6 2a02:587:f710::420;
   }
 }
 external-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   ip 192.168.10.2;
   mac 02:cf:69:15:81:01;
   mtu 9000;
@@ -57,17 +44,13 @@ external-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1092;
 }
 internal-interface {
-  allow-incoming-icmp true;
   error-rate-limiting {
     packets 600000;
-    period 2;
   }
-  generate-icmp-errors true;
   hairpinning false;
   ip fc00:168:10::2;
   mac 02:cf:69:15:81:01;
@@ -77,7 +60,6 @@ internal-interface {
   }
   reassembly {
     max-fragments-per-packet 40;
-    max-packets 20000;
   }
   vlan-tag 1638;
 }


### PR DESCRIPTION
This PR removes default values from the migrated configurations.  It also found some bugs in the serializers, which I am happy to have caught now!