### PR TITLE
Add CSV output to the lwaftr loadtest command

### DIFF
--- a/src/program/lwaftr/loadtest/README
+++ b/src/program/lwaftr/loadtest/README
@@ -8,6 +8,11 @@ Usage: loadtest [OPTIONS] <PCAP-FILE> <TX-NAME> <RX-NAME> <PCI> [<PCAP-FILE> <TX
                              Linger on each step for DURATION seconds.
   -p PROGRAM, --program PROGRAM
                              Use workload PROGRAM.
+  --bench-file FILENAME
+                             The file or path name to which benchmark data is
+                             written. A simple filename or relative pathname
+                             will be based on the current directory. Default
+                             is "bench.csv".
   --cpu CPU
                              Bind to the given CPU.
   -h, --help
@@ -37,10 +42,11 @@ The default workload program is ramp_up_down.
 
 Packets received on the network interfaces are counted and recorded,
 and the corresponding incoming and outgoing packet rates are written
-to standard output in CSV format, suitable for passing to a graphing
-program.  The TX-NAME values are used to label the columns.  The
-RX-NAME values indicate interfaces on which we should be looking for a
-response.  Packets sent but not received will be counted as loss.
+to standard output in human-readable format, and also to a file in CSV
+format, suitable for passing to a graphing program.  The TX-NAME values
+are used to label the columns.  The RX-NAME values indicate interfaces
+on which we should be looking for a response.  Packets sent but not
+received will be counted as loss.
 
 Examples:
   loadtest cap1.pcap tx tx 01:00.0

--- a/src/program/lwaftr/loadtest/loadtest.lua
+++ b/src/program/lwaftr/loadtest/loadtest.lua
@@ -57,7 +57,8 @@ function programs.ramp_up(tester, opts)
    for step = 1, math.ceil(opts.bitrate / opts.step) do
       tail = tail:and_then(tester.measure,
                            math.min(opts.bitrate, opts.step * step),
-                           opts.duration)
+                           opts.duration,
+                           opts.bench_file)
    end
    head:resolve()
    return tail
@@ -69,7 +70,8 @@ function programs.ramp_down(tester, opts)
    for step = math.ceil(opts.bitrate / opts.step), 1, -1 do
       tail = tail:and_then(tester.measure,
                            math.min(opts.bitrate, opts.step * step),
-                           opts.duration)
+                           opts.duration,
+                           opts.bench_file)
    end
    head:resolve()
    return tail
@@ -82,7 +84,8 @@ end
 
 function parse_args(args)
    local handlers = {}
-   local opts = { bitrate = 10e9, duration = 5, program=programs.ramp_up_down }
+   local opts = { bitrate = 10e9, duration = 5, program=programs.ramp_up_down,
+      bench_file = 'bench.csv' }
    local cpu
    function handlers.b(arg)
       opts.bitrate = assert(tonumber(arg), 'bitrate must be a number')
@@ -102,10 +105,13 @@ function parse_args(args)
    function handlers.p(arg)
       opts.program = assert(programs[arg], 'unrecognized program: '..arg)
    end
+   handlers["bench-file"] = function(arg)
+      opts.bench_file = arg
+   end
    function handlers.h() show_usage(0) end
    args = lib.dogetopt(args, handlers, "hb:s:D:p:",
                        { bitrate="b", step="s", duration="D", help="h",
-                         program="p", cpu=1 })
+                         program="p", cpu=1, ["bench-file"]=1 })
    if not opts.step then opts.step = opts.bitrate / 10 end
    assert(opts.bitrate > 0, 'bitrate must be positive')
    assert(opts.step > 0, 'step must be positive')
@@ -198,48 +204,70 @@ function run(args)
          ret[stream.nic_tx_id] = {
             tx = read_counters(tx_nic.input.rx),
             rx = read_counters(rx_nic.output.tx),
-	    drop = rx_nic:ingress_packet_drops()
+            drop = rx_nic:ingress_packet_drops()
          }
       end
       return ret
    end
 
-   function tester.print_counter_diff(before, after, duration)
+   function tester.print_counter_diff(
+         before, after, duration, bench_file, gbps_bitrate)
       local function bitrate(diff)
          -- 7 bytes preamble, 1 start-of-frame, 4 CRC, 12 interpacket gap.
          local overhead = 7 + 1 + 4 + 12
          return (diff.txbytes + diff.txpackets * overhead) * 8 / duration
       end
       for _, stream in ipairs(streams) do
+         bench_file:write(('%f,%s'):format(gbps_bitrate, stream.tx_name))
          print(string.format('  %s:', stream.tx_name))
          local nic_id = stream.nic_tx_id
          local nic_before, nic_after = before[nic_id], after[nic_id]
          local tx = diff_counters(nic_before.tx, nic_after.tx)
+         local tx_mpps = tx.txpackets / duration / 1e6
+         local tx_gbps = bitrate(tx) / 1e9
          local rx = diff_counters(nic_before.rx, nic_after.rx)
+         local rx_mpps = rx.txpackets / duration / 1e6
+         local rx_gbps = bitrate(rx) / 1e9
          local drop = tonumber(nic_after.drop - nic_before.drop)
+         local lost_packets = (tx.txpackets - rx.txpackets) - drop
+         local lost_percent = (tx.txpackets - rx.txpackets) / tx.txpackets * 100
          print(string.format('    TX %d packets (%f MPPS), %d bytes (%f Gbps)',
-                             tx.txpackets, tx.txpackets / duration / 1e6,
-                             tx.txbytes, bitrate(tx) / 1e9))
+            tx.txpackets, tx_mpps, tx.txbytes, tx_gbps))
+         bench_file:write((',%d,%f,%d,%f'):format(
+            tx.txpackets, tx_mpps, tx.txbytes, tx_gbps))
          print(string.format('    RX %d packets (%f MPPS), %d bytes (%f Gbps)',
-                             rx.txpackets, rx.txpackets / duration / 1e6,
-                             rx.txbytes, bitrate(rx) / 1e9))
+            rx.txpackets, rx_mpps, rx.txbytes, rx_gbps))
+         bench_file:write((',%d,%f,%d,%f'):format(
+            rx.txpackets, rx_mpps, rx.txbytes, rx_gbps))
          print(string.format('    Loss: %d ingress drop + %d packets lost (%f%%)',
-                             drop, (tx.txpackets - rx.txpackets) - drop,
-                             (tx.txpackets - rx.txpackets) / tx.txpackets * 100))
+            drop, lost_packets, lost_percent))
+         bench_file:write((',%d,%d,%f\n'):format(
+            drop, lost_packets, lost_percent))
       end
+      bench_file:flush()
    end
 
-   function tester.measure(bitrate, duration)
+   function tester.measure(bitrate, duration, bench_file)
+      local gbps_bitrate = bitrate/1e9
       local start_counters = tester.record_counters()
       local function report()
          local end_counters = tester.record_counters()
-         tester.print_counter_diff(start_counters, end_counters, duration)
+         tester.print_counter_diff(
+            start_counters, end_counters, duration, bench_file, gbps_bitrate)
       end
-      print(string.format('Applying %f Gbps of load.', bitrate/1e9))
+      print(string.format('Applying %f Gbps of load.', gbps_bitrate))
       return tester.generate_load(bitrate, duration):
          -- Wait 2ms for packets in flight to arrive
          and_then(promise.Wait, 0.002):
          and_then(report)
+   end
+
+   local function create_bench_file(filename)
+      local bench_file = io.open(filename, "w")
+      bench_file:write("load_gbps,stream,tx_packets,tx_mpps,tx_bytes,tx_gbps"..
+         ",rx_packets,rx_mpps,rx_bytes,rx_gbps,ingress_drop,lost_packets,lost_percent\n")
+      bench_file:flush()
+      return bench_file
    end
 
    local function run_engine(head, tail)
@@ -252,6 +280,7 @@ function run(args)
       engine.main({done=done})
    end
 
+   opts.bench_file = create_bench_file(opts.bench_file)
    engine.busywait = true
    local head = promise.new()
    run_engine(head,

--- a/src/program/lwaftr/loadtest/promise.lua
+++ b/src/program/lwaftr/loadtest/promise.lua
@@ -12,6 +12,8 @@ local function curry(f, ...)
    if #curried_args == 0 then return f end
    return function(...)
       local args = { ... }
+      -- Prepend the curried args to the passed ones, in the correct order:
+      -- if curried_args == (A, B), args == (C, D) -> (B, C, D) -> (A, B, C, D)
       for i=#curried_args, 1, -1 do
          table.insert(args, 1, curried_args[i])
       end

--- a/src/program/lwaftr/transient/transient.lua
+++ b/src/program/lwaftr/transient/transient.lua
@@ -64,7 +64,7 @@ function parse_args(args)
    function handlers.h() show_usage(0) end
    args = lib.dogetopt(args, handlers, "hb:s:D:p:",
                        { bitrate="b", step="s", duration="D", period="p",
-                         ["bench-file"]=0, help="h" })
+                         ["bench-file"]=1, help="h" })
    if not opts.step then opts.step = opts.bitrate / 10 end
    assert(opts.bitrate > 0, 'bitrate must be positive')
    assert(opts.step > 0, 'step must be positive')


### PR DESCRIPTION
The `lwaftr loadtest` command currently only prints human-readable data to stdout: add data output to a CSV file in machine-readable format.