### PR TITLE
Add Hydra mode to the lwaftr loadtest command

### DIFF
--- a/src/program/lwaftr/bench/README
+++ b/src/program/lwaftr/bench/README
@@ -6,7 +6,7 @@ Usage: bench CONF IPV4-IN.PCAP IPV6-IN.PCAP
                              Hydra mode: emit CSV data in the format expected
                              by the Hydra reports. For instance:
 
-                               benchmark,snabb,id,score,unit
+                               benchmark,id,score,unit
 
                              rather than the default:
 

--- a/src/program/lwaftr/csv_stats.lua
+++ b/src/program/lwaftr/csv_stats.lua
@@ -17,15 +17,15 @@ CSVStatsTimer = {}
 --
 -- Hydra mode example:
 --
--- benchmark,snabb,id,score,unit
--- decap_mpps,master,1,3.362784,mpps
--- decap_gbps,master,1,13.720160,gbps
--- encap_mpps,master,1,3.362886,mpps
--- encap_gbps,master,1,15.872824,gbps
--- decap_mpps,master,2,3.407569,mpps
--- decap_gbps,master,2,13.902880,gbps
--- encap_mpps,master,2,3.407569,mpps
--- encap_gbps,master,2,16.083724,gbps
+-- benchmark,id,score,unit
+-- decap_mpps,1,3.362784,mpps
+-- decap_gbps,1,13.720160,gbps
+-- encap_mpps,1,3.362886,mpps
+-- encap_gbps,1,15.872824,gbps
+-- decap_mpps,2,3.407569,mpps
+-- decap_gbps,2,13.902880,gbps
+-- encap_mpps,2,3.407569,mpps
+-- encap_gbps,2,16.083724,gbps
 --
 function CSVStatsTimer:new(filename, hydra_mode)
    local file = filename and io.open(filename, "w") or io.stdout

--- a/src/program/lwaftr/loadtest/README
+++ b/src/program/lwaftr/loadtest/README
@@ -13,6 +13,17 @@ Usage: loadtest [OPTIONS] <PCAP-FILE> <TX-NAME> <RX-NAME> <PCI> [<PCAP-FILE> <TX
                              written. A simple filename or relative pathname
                              will be based on the current directory. Default
                              is "bench.csv".
+  -y, --hydra
+                             Hydra mode: emit CSV data in the format expected
+                             by the Hydra reports. For instance:
+
+                               benchmark,id,score,unit
+
+                             rather than the default:
+
+                               load_gbps,stream,tx_packets,tx_mpps,tx_bytes,
+                                 tx_gbps,rx_packets,rx_mpps,rx_bytes,rx_gbps,
+                                 ingress_drop,lost_packets,lost_percent
   --cpu CPU
                              Bind to the given CPU.
   -h, --help

--- a/src/program/lwaftr/loadtest/loadtest.lua
+++ b/src/program/lwaftr/loadtest/loadtest.lua
@@ -242,28 +242,28 @@ function run(args)
          if hydra_mode then
             -- Hydra reports prefer integers for the X (time) axis.
             -- TX
-            bench_file:write(('%s_tx_packets,%.f,%f,packets\n'):format(
-               stream.tx_name,gbps_bitrate,tx.txpackets))
-            bench_file:write(('%s_tx_mpps,%.f,%f,mpps\n'):format(
-               stream.tx_name,gbps_bitrate,tx_mpps))
-            bench_file:write(('%s_tx_bytes,%.f,%f,bytes\n'):format(
-               stream.tx_name,gbps_bitrate,tx.txbytes))
-            bench_file:write(('%s_tx_gbps,%.f,%f,gbps\n'):format(
-               stream.tx_name,gbps_bitrate,tx_gbps))
+            -- bench_file:write(('%s_tx_packets,%.f,%f,packets\n'):format(
+            --    stream.tx_name,gbps_bitrate,tx.txpackets))
+            -- bench_file:write(('%s_tx_mpps,%.f,%f,mpps\n'):format(
+            --    stream.tx_name,gbps_bitrate,tx_mpps))
+            -- bench_file:write(('%s_tx_bytes,%.f,%f,bytes\n'):format(
+            --    stream.tx_name,gbps_bitrate,tx.txbytes))
+            -- bench_file:write(('%s_tx_gbps,%.f,%f,gbps\n'):format(
+            --    stream.tx_name,gbps_bitrate,tx_gbps))
             -- RX
-            bench_file:write(('%s_rx_packets,%.f,%f,packets\n'):format(
-               stream.tx_name,gbps_bitrate,rx.txpackets))
+            -- bench_file:write(('%s_rx_packets,%.f,%f,packets\n'):format(
+            --    stream.tx_name,gbps_bitrate,rx.txpackets))
             bench_file:write(('%s_rx_mpps,%.f,%f,mpps\n'):format(
                stream.tx_name,gbps_bitrate,rx_mpps))
-            bench_file:write(('%s_rx_bytes,%.f,%f,bytes\n'):format(
-               stream.tx_name,gbps_bitrate,rx.txbytes))
+            -- bench_file:write(('%s_rx_bytes,%.f,%f,bytes\n'):format(
+            --    stream.tx_name,gbps_bitrate,rx.txbytes))
             bench_file:write(('%s_rx_gbps,%.f,%f,gbps\n'):format(
                stream.tx_name,gbps_bitrate,rx_gbps))
             -- Loss
             bench_file:write(('%s_ingress_drop,%.f,%f,packets\n'):format(
                stream.tx_name,gbps_bitrate,drop))
-            bench_file:write(('%s_lost_packets,%.f,%f,packets\n'):format(
-               stream.tx_name,gbps_bitrate,lost_packets))
+            -- bench_file:write(('%s_lost_packets,%.f,%f,packets\n'):format(
+            --    stream.tx_name,gbps_bitrate,lost_packets))
             bench_file:write(('%s_lost_percent,%.f,%f,percentage\n'):format(
                stream.tx_name,gbps_bitrate,lost_percent))
          else

--- a/src/program/lwaftr/loadtest/loadtest.lua
+++ b/src/program/lwaftr/loadtest/loadtest.lua
@@ -58,7 +58,8 @@ function programs.ramp_up(tester, opts)
       tail = tail:and_then(tester.measure,
                            math.min(opts.bitrate, opts.step * step),
                            opts.duration,
-                           opts.bench_file)
+                           opts.bench_file,
+                           opts.hydra)
    end
    head:resolve()
    return tail
@@ -71,7 +72,8 @@ function programs.ramp_down(tester, opts)
       tail = tail:and_then(tester.measure,
                            math.min(opts.bitrate, opts.step * step),
                            opts.duration,
-                           opts.bench_file)
+                           opts.bench_file,
+                           opts.hydra)
    end
    head:resolve()
    return tail
@@ -105,13 +107,14 @@ function parse_args(args)
    function handlers.p(arg)
       opts.program = assert(programs[arg], 'unrecognized program: '..arg)
    end
+   function handlers.y() opts.hydra = true end
    handlers["bench-file"] = function(arg)
       opts.bench_file = arg
    end
    function handlers.h() show_usage(0) end
-   args = lib.dogetopt(args, handlers, "hb:s:D:p:",
+   args = lib.dogetopt(args, handlers, "yhb:s:D:p:",
                        { bitrate="b", step="s", duration="D", help="h",
-                         program="p", cpu=1, ["bench-file"]=1 })
+                         program="p", cpu=1, ["bench-file"]=1, hydra="y" })
    if not opts.step then opts.step = opts.bitrate / 10 end
    assert(opts.bitrate > 0, 'bitrate must be positive')
    assert(opts.step > 0, 'step must be positive')
@@ -211,14 +214,13 @@ function run(args)
    end
 
    function tester.print_counter_diff(
-         before, after, duration, bench_file, gbps_bitrate)
+         before, after, duration, gbps_bitrate, bench_file, hydra_mode)
       local function bitrate(diff)
          -- 7 bytes preamble, 1 start-of-frame, 4 CRC, 12 interpacket gap.
          local overhead = 7 + 1 + 4 + 12
          return (diff.txbytes + diff.txpackets * overhead) * 8 / duration
       end
       for _, stream in ipairs(streams) do
-         bench_file:write(('%f,%s'):format(gbps_bitrate, stream.tx_name))
          print(string.format('  %s:', stream.tx_name))
          local nic_id = stream.nic_tx_id
          local nic_before, nic_after = before[nic_id], after[nic_id]
@@ -233,27 +235,55 @@ function run(args)
          local lost_percent = (tx.txpackets - rx.txpackets) / tx.txpackets * 100
          print(string.format('    TX %d packets (%f MPPS), %d bytes (%f Gbps)',
             tx.txpackets, tx_mpps, tx.txbytes, tx_gbps))
-         bench_file:write((',%d,%f,%d,%f'):format(
-            tx.txpackets, tx_mpps, tx.txbytes, tx_gbps))
          print(string.format('    RX %d packets (%f MPPS), %d bytes (%f Gbps)',
-            rx.txpackets, rx_mpps, rx.txbytes, rx_gbps))
-         bench_file:write((',%d,%f,%d,%f'):format(
             rx.txpackets, rx_mpps, rx.txbytes, rx_gbps))
          print(string.format('    Loss: %d ingress drop + %d packets lost (%f%%)',
             drop, lost_packets, lost_percent))
-         bench_file:write((',%d,%d,%f\n'):format(
-            drop, lost_packets, lost_percent))
+         if hydra_mode then
+            -- Hydra reports prefer integers for the X (time) axis.
+            -- TX
+            bench_file:write(('%s_tx_packets,%.f,%f,packets\n'):format(
+               stream.tx_name,gbps_bitrate,tx.txpackets))
+            bench_file:write(('%s_tx_mpps,%.f,%f,mpps\n'):format(
+               stream.tx_name,gbps_bitrate,tx_mpps))
+            bench_file:write(('%s_tx_bytes,%.f,%f,bytes\n'):format(
+               stream.tx_name,gbps_bitrate,tx.txbytes))
+            bench_file:write(('%s_tx_gbps,%.f,%f,gbps\n'):format(
+               stream.tx_name,gbps_bitrate,tx_gbps))
+            -- RX
+            bench_file:write(('%s_rx_packets,%.f,%f,packets\n'):format(
+               stream.tx_name,gbps_bitrate,rx.txpackets))
+            bench_file:write(('%s_rx_mpps,%.f,%f,mpps\n'):format(
+               stream.tx_name,gbps_bitrate,rx_mpps))
+            bench_file:write(('%s_rx_bytes,%.f,%f,bytes\n'):format(
+               stream.tx_name,gbps_bitrate,rx.txbytes))
+            bench_file:write(('%s_rx_gbps,%.f,%f,gbps\n'):format(
+               stream.tx_name,gbps_bitrate,rx_gbps))
+            -- Loss
+            bench_file:write(('%s_ingress_drop,%.f,%f,packets\n'):format(
+               stream.tx_name,gbps_bitrate,drop))
+            bench_file:write(('%s_lost_packets,%.f,%f,packets\n'):format(
+               stream.tx_name,gbps_bitrate,lost_packets))
+            bench_file:write(('%s_lost_percent,%.f,%f,percentage\n'):format(
+               stream.tx_name,gbps_bitrate,lost_percent))
+         else
+            bench_file:write(('%f,%s,%d,%f,%d,%f,%d,%f,%d,%f,%d,%d,%f\n'):format(
+               gbps_bitrate, stream.tx_name,
+               tx.txpackets, tx_mpps, tx.txbytes, tx_gbps,
+               rx.txpackets, rx_mpps, rx.txbytes, rx_gbps,
+               drop, lost_packets, lost_percent))
+         end
       end
       bench_file:flush()
    end
 
-   function tester.measure(bitrate, duration, bench_file)
+   function tester.measure(bitrate, duration, bench_file, hydra_mode)
       local gbps_bitrate = bitrate/1e9
       local start_counters = tester.record_counters()
       local function report()
          local end_counters = tester.record_counters()
-         tester.print_counter_diff(
-            start_counters, end_counters, duration, bench_file, gbps_bitrate)
+         tester.print_counter_diff(start_counters, end_counters, duration,
+            gbps_bitrate, bench_file, hydra_mode)
       end
       print(string.format('Applying %f Gbps of load.', gbps_bitrate))
       return tester.generate_load(bitrate, duration):
@@ -262,10 +292,12 @@ function run(args)
          and_then(report)
    end
 
-   local function create_bench_file(filename)
+   local function create_bench_file(filename, hydra_mode)
       local bench_file = io.open(filename, "w")
-      bench_file:write("load_gbps,stream,tx_packets,tx_mpps,tx_bytes,tx_gbps"..
-         ",rx_packets,rx_mpps,rx_bytes,rx_gbps,ingress_drop,lost_packets,lost_percent\n")
+      local header = hydra_mode and "benchmark,id,score,unit\n" or
+         "load_gbps,stream,tx_packets,tx_mpps,tx_bytes,tx_gbps,rx_packets"..
+         ",rx_mpps,rx_bytes,rx_gbps,ingress_drop,lost_packets,lost_percent\n"
+      bench_file:write(header)
       bench_file:flush()
       return bench_file
    end
@@ -280,7 +312,7 @@ function run(args)
       engine.main({done=done})
    end
 
-   opts.bench_file = create_bench_file(opts.bench_file)
+   opts.bench_file = create_bench_file(opts.bench_file, opts.hydra)
    engine.busywait = true
    local head = promise.new()
    run_engine(head,

--- a/src/program/lwaftr/run/README
+++ b/src/program/lwaftr/run/README
@@ -21,7 +21,7 @@ Optional arguments:
                                 Hydra mode: emit CSV data in the format expected
                                 by the Hydra reports. For instance:
 
-                                  benchmark,snabb,id,score,unit
+                                  benchmark,id,score,unit
 
                                 rather than the default:
 

--- a/src/program/packetblaster/lwaftr/README
+++ b/src/program/packetblaster/lwaftr/README
@@ -18,10 +18,10 @@ Usage: packetblaster lwaftr [OPTIONS]
 
   --src_mac SOURCE
                         Source MAC-Address
-			Default: 00:00:00:00:00:00
+                        Default: 00:00:00:00:00:00
   --dst_mac DESTINATION
                         Destination MAC-Address
-			Default: 00:00:00:00:00:00
+                        Default: 00:00:00:00:00:00
   --size SIZES
                         A comma separated list of numbers. Send packets of
                         SIZES bytes. The size specifies the lenght of the IPv4 
@@ -83,7 +83,7 @@ Example 1: Measure performance of single stick LWAFTR (handling IPv4 and IPv6
 traffic over a single interface). Packetblaster lwaftr generates 50% IPv4 and
 50% IPv6 encapsulated traffic of IMIX line traffic:
 
-  $ sudo ./snabb packetblaster lwaftr --rate 3.2 --count 1000000000:05:00.0
+  $ sudo ./snabb packetblaster lwaftr --rate 3.2 --count 100000 --pci 0000:05:00.0
   packetblaster lwaftr: Sending 1000000 clients at 3.200 MPPS to 0000:05:00.0
 
   IPv6: 2001:db8:: > 2001:db8:ffff::100: 10.0.0.0:1024 > 8.8.8.8:12345


### PR DESCRIPTION
Add an option to the `lwaftr loadtest` command that changes the format of the CSV benchmark data to the one expected by the Hydra CI integration code.

Includes some unrelated doc fixes.