### PR TITLE
Snabb softwire support

### DIFF
--- a/src/apps/config/follower.lua
+++ b/src/apps/config/follower.lua
@@ -33,7 +33,14 @@ function Follower:handle_actions_from_leader()
       local buf, len = channel:peek_message()
       if not buf then break end
       local action = action_codec.decode(buf, len)
-      app.apply_config_actions({action})
+      local name, args = unpack(action)
+      if name == 'call_app_method_with_blob' then
+         local callee, method, blob = unpack(args)
+         local obj = assert(app.app_table[callee])
+         assert(obj[method])(obj, blob)
+      else
+         app.apply_config_actions({action})
+      end
       channel:discard_message(len)
       if action[1] == 'start_app' or action[1] == 'reconfig_app' then
          should_flush = true

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -257,7 +257,7 @@ local function path_adder_for_grammar(grammar, path)
             local ctab = getter(config)
             for entry in subconfig:iterate() do
                if ctab:lookup_ptr(entry.key) ~= nil then
-                  error('already-existing entry', entry.key)
+                  error('already-existing entry')
                end
             end
             for entry in subconfig:iterate() do

--- a/src/apps/config/support/snabb-softwire-v1.lua
+++ b/src/apps/config/support/snabb-softwire-v1.lua
@@ -1,0 +1,11 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+module(..., package.seeall)
+local app = require('core.app')
+
+local function compute_config_actions(old_graph, new_graph, verb, path, arg)
+   return app.compute_config_actions(old_graph, new_graph)
+end
+
+function get_config_support()
+   return { compute_config_actions = compute_config_actions }
+end

--- a/src/apps/config/support/snabb-softwire-v1.lua
+++ b/src/apps/config/support/snabb-softwire-v1.lua
@@ -1,9 +1,53 @@
 -- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 module(..., package.seeall)
+local ffi = require('ffi')
 local app = require('core.app')
+local lib = require('core.lib')
+local data = require('lib.yang.data')
+local yang = require('lib.yang.yang')
+local path_mod = require('lib.yang.path')
+
+local function add_softwire_entry_actions(app_graph, entries)
+   assert(app_graph.apps['lwaftr'])
+   local ret = {}
+   for entry in entries:iterate() do
+      local blob = entries.entry_type()
+      ffi.copy(blob, entry, ffi.sizeof(blob))
+      local args = {'lwaftr', 'add_softwire_entry', blob}
+      table.insert(ret, {'call_app_method_with_blob', args})
+   end
+   return ret
+end
+
+local softwire_grammar
+local function get_softwire_grammar()
+   if not softwire_grammar then
+      local schema = yang.load_schema_by_name('snabb-softwire-v1')
+      local grammar = data.data_grammar_from_schema(schema)
+      softwire_grammar =
+         assert(grammar.members['binding-table'].members['softwire'])
+   end
+   return softwire_grammar
+end
+
+local function remove_softwire_entry_actions(app_graph, path)
+   assert(app_graph.apps['lwaftr'])
+   path = path_mod.parse_path(path)
+   local grammar = get_softwire_grammar()
+   local key = path_mod.prepare_table_lookup(
+      grammar.keys, grammar.key_ctype, path[#path].query)
+   local args = {'lwaftr', 'remove_softwire_entry', key}
+   return {{'call_app_method_with_blob', args}}
+end
 
 local function compute_config_actions(old_graph, new_graph, verb, path, arg)
-   return app.compute_config_actions(old_graph, new_graph)
+   if verb == 'add' and path == '/binding-table/softwire' then
+      return add_softwire_entry_actions(new_graph, arg)
+   elseif verb == 'remove' and path:match('^/binding%-table/softwire') then
+      return remove_softwire_entry_actions(new_graph, path)
+   else
+      return app.compute_config_actions(old_graph, new_graph)
+   end
 end
 
 function get_config_support()

--- a/src/apps/config/support/snabb-softwire-v1.lua
+++ b/src/apps/config/support/snabb-softwire-v1.lua
@@ -2,7 +2,6 @@
 module(..., package.seeall)
 local ffi = require('ffi')
 local app = require('core.app')
-local lib = require('core.lib')
 local data = require('lib.yang.data')
 local yang = require('lib.yang.yang')
 local path_mod = require('lib.yang.path')

--- a/src/apps/lwaftr/binding_table.lua
+++ b/src/apps/lwaftr/binding_table.lua
@@ -149,6 +149,20 @@ function BindingTable.new(psid_map, br_addresses, softwires)
    return setmetatable(ret, {__index=BindingTable})
 end
 
+function BindingTable:add_softwire_entry(entry_blob)
+   local entry = self.softwires.entry_type()
+   assert(ffi.sizeof(entry) == ffi.sizeof(entry_blob))
+   ffi.copy(entry, entry_blob, ffi.sizeof(entry_blob))
+   self.softwires:add(entry.key, entry.value)
+end
+
+function BindingTable:remove_softwire_entry(entry_key_blob)
+   local entry = self.softwires.entry_type()
+   assert(ffi.sizeof(entry.key) == ffi.sizeof(entry_key_blob))
+   ffi.copy(entry.key, entry_key_blob, ffi.sizeof(entry_key_blob))
+   self.softwires:remove(entry.key)
+end
+
 local lookup_key = softwire_key_t()
 function BindingTable:lookup(ipv4, port)
    local psid = self:lookup_psid(ipv4, port)

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -265,6 +265,16 @@ function LwAftr:new(conf)
    return o
 end
 
+-- The following two methods are called by apps.config.follower in
+-- reaction to binding table changes, via
+-- apps/config/support/snabb-softwire-v1.lua.
+function LwAftr:add_softwire_entry(entry_blob)
+   self.binding_table:add_softwire_entry(entry_blob)
+end
+function LwAftr:remove_softwire_entry(entry_key_blob)
+   self.binding_table:remove_softwire_entry(entry_key_blob)
+end
+
 local function decrement_ttl(pkt)
    local ipv4_header = get_ethernet_payload(pkt)
    local chksum = bnot(ntohs(rd16(ipv4_header + o_ipv4_checksum)))


### PR DESCRIPTION
This PR adds support for fast binding table updates.  Here are two example "snabb config" invocations that take the fast path:

```
./snabb config add 930 '/binding-table/softwire' '{ ipv4 1.2.3.4; psid 0; b4-ipv6 127:22:33:44:55:66:77:128; }'
./snabb config remove 930 '/binding-table/softwire[ipv4=1.2.3.4][psid=0]'
```

The fast path is, there is a hook in the process of translating an app-graph change to a set of config actions that a schema can use to compile that change specially.  The hook also gets some information about what was the origin of that change, e.g. was it a load, an add, a remove, etc, and what path.  The useful thing is to compile a change to a remove method call onto a Snabb app, and we add support for this special config action. For the lwaftr we compile add/remove to the softwires table into remote method calls onto the lwaftr app.