### PR TITLE
Make lwaftr run --reconfigurable uniprocess

### DIFF
--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -56,8 +56,8 @@ function run(args)
 
    local graph = config.new()
    if opts.reconfigurable then
-      setup.reconfigurable(setup.load_bench, graph, conf,
-                           inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
+      setup.reconfigurable_multi(setup.load_bench, graph, conf,
+                                 inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
    else
       setup.load_bench(graph, conf, inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
    end

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -43,16 +43,7 @@ function parse_args(args)
       if not cpu or cpu ~= math.floor(cpu) or cpu < 0 then
          fatal("Invalid cpu number: "..arg)
       end
-
-      if opts.reconfigurable then
-         S.setenv("SNABB_TARGET_CPU", tostring(cpu), true)
-         local wanted_node = numa.cpu_get_numa_node(cpu)
-         numa.bind_to_numa_node(wanted_node)
-         print("Bound to numa node:", wanted_node)
-      else
-         print("Bound to CPU:", cpu)
-         numa.bind_to_cpu(cpu)
-      end
+      numa.bind_to_cpu(cpu)
    end
    handlers['real-time'] = function(arg)
       if not S.sched_setscheduler(0, "fifo", 1) then
@@ -163,7 +154,7 @@ function run(args)
       setup_fn, setup_args = setup.load_phy, { 'inetNic', v4, 'b4sideNic', v6 }
    end
    if opts.reconfigurable then
-      setup.reconfigurable(setup_fn, c, conf, unpack(setup_args))
+      setup.reconfigurable_uni(setup_fn, c, conf, unpack(setup_args))
    else
       setup_fn(c, conf, unpack(setup_args))
    end

--- a/src/program/lwaftr/selftest.sh
+++ b/src/program/lwaftr/selftest.sh
@@ -37,6 +37,7 @@ echo "Testing snabb lwaftr run"
 sudo ./snabb lwaftr run -D 0.1 --conf ${TDIR}/icmp_on_fail.conf \
     --on-a-stick "$SNABB_PCI0"
 
+# Keep the following test at 1 second; 0.1 can hide problems, empirically
 echo "Testing snabb lwaftr run --reconfigurable"
-sudo ./snabb lwaftr run -D 0.1 --reconfigurable \
+sudo ./snabb lwaftr run -D 1 --reconfigurable \
     --conf ${TDIR}/icmp_on_fail.conf --on-a-stick "$SNABB_PCI0"

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -467,7 +467,7 @@ function load_soak_test_on_a_stick (c, conf, inv4_pcap, inv6_pcap)
    link_sink(c, unpack(sinks))
 end
 
-function reconfigurable(f, graph, conf, ...)
+function reconfigurable_multi(f, graph, conf, ...)
    local args = {...}
    local function setup_fn(conf)
       local graph = config.new()
@@ -498,4 +498,19 @@ function reconfigurable(f, graph, conf, ...)
               { setup_fn = setup_fn, initial_configuration = conf,
                 follower_pids = { follower_pid },
                 schema_name = 'snabb-softwire-v1'})
+end
+
+function reconfigurable_uni(f, graph, conf, ...)
+   local args = {...}
+   local function setup_fn(conf)
+      local graph = config.new()
+      f(graph, conf, unpack(args))
+      return graph
+   end
+
+   config.app(graph, 'leader', leader.Leader,
+              { setup_fn = setup_fn, initial_configuration = conf,
+                follower_pids = { S.getpid() },
+                schema_name = 'snabb-softwire-v1'})
+   config.app(graph, "follower", follower.Follower, {})
 end


### PR DESCRIPTION
Snabb lwaftr run is currently broken with multiprocess leader/follower setups, for durations over 0.1 second. This patch makes it run in one process until that can be fixed.