### PR TITLE
Incrementally lex and parse data

### DIFF
--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -219,7 +219,8 @@ function CTable:insert(hash, key, value, updates_allowed)
 
    local entries = self.entries
    local scale = self.scale
-   local start_index = hash_to_index(hash, self.scale)
+   -- local start_index = hash_to_index(hash, self.scale)
+   local start_index = floor(hash*self.scale + 0.5)
    local index = start_index
 
    while entries[index].hash < hash do

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -223,6 +223,15 @@ function CTable:insert(hash, key, value, updates_allowed)
    local start_index = floor(hash*self.scale + 0.5)
    local index = start_index
 
+   -- Fast path.
+   if entries[index].hash == HASH_MAX and updates_allowed ~= 'required' then
+      self.occupancy = self.occupancy + 1
+      entries[index].hash = hash
+      entries[index].key = key
+      entries[index].value = value
+      return index
+   end
+
    while entries[index].hash < hash do
       index = index + 1
    end

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -35,7 +35,7 @@ end
 
 -- hash := [0,HASH_MAX); scale := size/HASH_MAX
 local function hash_to_index(hash, scale)
-   return floor(hash*scale + 0.5)
+   return floor(hash*scale)
 end
 
 local function make_equal_fn(key_type)
@@ -222,7 +222,7 @@ function CTable:insert(hash, key, value, updates_allowed)
    local entries = self.entries
    local scale = self.scale
    -- local start_index = hash_to_index(hash, self.scale)
-   local start_index = floor(hash*self.scale + 0.5)
+   local start_index = floor(hash*self.scale)
    local index = start_index
 
    -- Fast path.

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -111,6 +111,7 @@ function new(params)
    ctab.hash_fn = params.hash_fn or compute_hash_fn(params.key_type)
    ctab.equal_fn = make_equal_fn(params.key_type)
    ctab.size = 0
+   ctab.max_displacement = 0
    ctab.occupancy = 0
    ctab.max_occupancy_rate = params.max_occupancy_rate
    ctab.min_occupancy_rate = params.min_occupancy_rate
@@ -149,6 +150,7 @@ function CTable:resize(size)
    assert(size >= (self.occupancy / self.max_occupancy_rate))
    local old_entries = self.entries
    local old_size = self.size
+   local old_max_displacement = self.max_displacement
 
    -- Allocate double the requested number of entries to make sure there
    -- is sufficient displacement if all hashes map to the last bucket.
@@ -161,7 +163,7 @@ function CTable:resize(size)
    self.occupancy_lo = floor(self.size * self.min_occupancy_rate)
    for i=0,self.size*2-1 do self.entries[i].hash = HASH_MAX end
 
-   for i=0,old_size*2-1 do
+   for i=0,old_size+old_max_displacement-1 do
       if old_entries[i].hash ~= HASH_MAX then
          self:insert(old_entries[i].hash, old_entries[i].key, old_entries[i].value)
       end

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -262,12 +262,14 @@ local function scalar_parser(keyword, argument_type, default, mandatory)
 end
 
 local function ctable_builder(key_t, value_t)
-   local res = ctable.new({ key_type=key_t, value_type=value_t })
+   local res = ctable.new({ key_type=key_t, value_type=value_t,
+                            max_occupancy_rate = 0.4 })
    local builder = {}
-   local counter = 0
+   -- Uncomment for progress counters.
+   -- local counter = 0
    function builder:add(key, value)
-      counter = counter + 1
-      if counter % 1000 == 0 then print('ctable add', counter) end
+      -- counter = counter + 1
+      -- if counter % 1000 == 0 then print('ctable add', counter) end
       res:add(key, value)
    end
    function builder:finish() return res end

--- a/src/lib/yang/parser.lua
+++ b/src/lib/yang/parser.lua
@@ -30,7 +30,7 @@ module(..., package.seeall)
 
 local lib = require('core.lib')
 
-local Parser = {}
+Parser = {}
 function Parser.new(str, filename)
    local ret = {pos=1, str=str, filename=filename, line=1, column=0, line_pos=1}
    ret = setmetatable(ret, {__index = Parser})

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -30,7 +30,9 @@ function tointeger(str, what, min, max)
       if res > 0 then
          error('invalid numeric value for '..what..': '..str)
       end
-      if min then check(min <= 0 and min <= res) end
+      if min and not (min <= 0 and min <= res) then
+         error('invalid numeric value for '..what..': '..str)
+      end
    else
       -- Only compare min and res if both are positive, otherwise if min
       -- is a negative int64_t then the comparison will treat it as a


### PR DESCRIPTION
Instead of building an AST, then parsing that AST, incrementally parse
as we go.  This should prevent the creation of large intermediate data
structures when parsing 100-MB files that could push us over LuaJIT's 1G
limit.

Fixes #624; I can load the 1M-element table with this patch.  However it takes 4 minutes to compile the damn thing!!!!  Needs further optimization.