### PR TITLE
Fixleadergroup

### DIFF
--- a/src/core/worker.lua
+++ b/src/core/worker.lua
@@ -24,6 +24,7 @@ end
 
 -- Start a named worker to execute the given Lua code (a string).
 function start (name, luacode)
+   shm.mkdir(shm.resolve("group"))
    local pid = S.fork()
    if pid == 0 then
       -- First we perform some initialization functions and then we

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -56,8 +56,8 @@ function run(args)
 
    local graph = config.new()
    if opts.reconfigurable then
-      setup.reconfigurable_multi(setup.load_bench, graph, conf,
-                                 inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
+      setup.reconfigurable(setup.load_bench, graph, conf,
+                           inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
    else
       setup.load_bench(graph, conf, inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
    end

--- a/src/program/lwaftr/selftest.sh
+++ b/src/program/lwaftr/selftest.sh
@@ -37,7 +37,6 @@ echo "Testing snabb lwaftr run"
 sudo ./snabb lwaftr run -D 0.1 --conf ${TDIR}/icmp_on_fail.conf \
     --on-a-stick "$SNABB_PCI0"
 
-# Keep the following test at 1 second; 0.1 can hide problems, empirically
 echo "Testing snabb lwaftr run --reconfigurable"
-sudo ./snabb lwaftr run -D 1 --reconfigurable \
+sudo ./snabb lwaftr run -D 0.1 --reconfigurable \
     --conf ${TDIR}/icmp_on_fail.conf --on-a-stick "$SNABB_PCI0"

--- a/src/program/lwaftr/selftest.sh
+++ b/src/program/lwaftr/selftest.sh
@@ -37,6 +37,7 @@ echo "Testing snabb lwaftr run"
 sudo ./snabb lwaftr run -D 0.1 --conf ${TDIR}/icmp_on_fail.conf \
     --on-a-stick "$SNABB_PCI0"
 
+# This needs to be 1 second, not 0.1 second, or it can mask DMA/setup problems
 echo "Testing snabb lwaftr run --reconfigurable"
-sudo ./snabb lwaftr run -D 0.1 --reconfigurable \
+sudo ./snabb lwaftr run -D 1 --reconfigurable \
     --conf ${TDIR}/icmp_on_fail.conf --on-a-stick "$SNABB_PCI0"

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -467,7 +467,7 @@ function load_soak_test_on_a_stick (c, conf, inv4_pcap, inv6_pcap)
    link_sink(c, unpack(sinks))
 end
 
-function reconfigurable_multi(f, graph, conf, ...)
+function reconfigurable(f, graph, conf, ...)
    local args = {...}
    local function setup_fn(conf)
       local graph = config.new()
@@ -498,19 +498,4 @@ function reconfigurable_multi(f, graph, conf, ...)
               { setup_fn = setup_fn, initial_configuration = conf,
                 follower_pids = { follower_pid },
                 schema_name = 'snabb-softwire-v1'})
-end
-
-function reconfigurable_uni(f, graph, conf, ...)
-   local args = {...}
-   local function setup_fn(conf)
-      local graph = config.new()
-      f(graph, conf, unpack(args))
-      return graph
-   end
-
-   config.app(graph, 'leader', leader.Leader,
-              { setup_fn = setup_fn, initial_configuration = conf,
-                follower_pids = { S.getpid() },
-                schema_name = 'snabb-softwire-v1'})
-   config.app(graph, "follower", follower.Follower, {})
 end


### PR DESCRIPTION
Add ```shm.mkdir(shm.resolve("group"))``` before launching a worker, so that using physical Intel cards in a worker process after a worker sets up a symlink in a child process does not break.
This supercedes #627 