### PR TITLE
Fix -h and --help for the ps program

### DIFF
--- a/src/program/ps/ps.lua
+++ b/src/program/ps/ps.lua
@@ -18,7 +18,7 @@ local function parse_args (args)
    local preferpid = false
    function opt.h (arg) usage(0) end
    function opt.p (arg) preferpid = true end
-   args = lib.dogetopt(args, opt, "h:p", {help='h', pid='p'})
+   args = lib.dogetopt(args, opt, "hp", {help='h', pid='p'})
    if #args ~= 0 then usage(1) end
    return preferpid
 end


### PR DESCRIPTION
There was an issue with the call to dogetopt where the help
option expected an argument, of course, this isn't the case.