### PR TITLE
Support query by name

### DIFF
--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -6,6 +6,7 @@ local S = require("syscall")
 local bit = require("bit")
 local ffi = require("ffi")
 local lib = require("core.lib")
+local shm = require("core.shm")
 
 local band = bit.band
 local cast = ffi.cast
@@ -115,4 +116,14 @@ function nic_exists(pci_addr)
    local devices="/sys/bus/pci/devices"
    return dir_exists(("%s/%s"):format(devices, pci_addr)) or
       dir_exists(("%s/0000:%s"):format(devices, pci_addr))
+end
+
+function get_pid_by_name (name)
+   for _, program in pairs(shm.children("/by-name")) do
+      if name == program then
+         local fq = engine.named_program_root .. "/" .. program
+         local piddir = S.readlink(fq)
+         return lib.basename(piddir)
+      end
+   end
 end

--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -6,7 +6,6 @@ local S = require("syscall")
 local bit = require("bit")
 local ffi = require("ffi")
 local lib = require("core.lib")
-local shm = require("core.shm")
 
 local band = bit.band
 local cast = ffi.cast
@@ -116,14 +115,4 @@ function nic_exists(pci_addr)
    local devices="/sys/bus/pci/devices"
    return dir_exists(("%s/%s"):format(devices, pci_addr)) or
       dir_exists(("%s/0000:%s"):format(devices, pci_addr))
-end
-
-function get_pid_by_name (name)
-   for _, program in pairs(shm.children("/by-name")) do
-      if name == program then
-         local fq = engine.named_program_root .. "/" .. program
-         local piddir = S.readlink(fq)
-         return lib.basename(piddir)
-      end
-   end
 end

--- a/src/program/lwaftr/monitor/README
+++ b/src/program/lwaftr/monitor/README
@@ -1,22 +1,27 @@
 Usage:
-    monitor ACTION|IPV4_ADDRESS [PID]
+    monitor IPV4_ADDRESS [PID]
 
-    -h, --help
-                                Print usage information.
+Options:
+
+    -n, --name    <name>    Name of snabb process.
+    -h, --help              Print usage information.
 
 Arguments:
 
-    ACTION                      Action to perform: 'none' or 'all'
-    IPV4_ADDRESS                IPv4 address to mirror
-    PID                         PID value of Snabb process.
+    IPV4_ADDRESS            IPv4 address to mirror.
+    PID                     PID value of Snabb process.
 
 Sets the value of 'v4v6_mirror' counter to IPV4_ADDRESS.  The 'v4v6_mirror'
 counter is defined for all lwAFTR instances running in mirroring mode.
 Matching packets will be mirrored to the tap interface set by the original
 lwAFTR process.
 
-When action is 'none' IPV4_ADDRESS is set to '0.0.0.0'. When ACTION is 'all'
-IPV4_ADDRESS is set to '255.255.255.255'.
+It is possible to query a process by name, passing the flag --name.
+
+IPV4_ADDRESS can take two special values:
+
+- 'none', which is equivalent to '0.0.0.0'.
+- 'all', which is equivalent to '255.255.255.255'.
 
 PID value is used to retrieve the lwAFTR instance.  If PID is not set, the
 most recent active lwAFTR instance for which 'v4v6_mirror' is defined is used.

--- a/src/program/lwaftr/monitor/monitor.lua
+++ b/src/program/lwaftr/monitor/monitor.lua
@@ -8,7 +8,7 @@ local lwutil = require("apps.lwaftr.lwutil")
 local shm = require("core.shm")
 local top = require("program.top.top")
 
-local fatal, get_pid_by_name = lwutil.fatal, lwutil.get_pid_by_name
+local fatal = lwutil.fatal
 local select_snabb_instance = top.select_snabb_instance
 
 local long_opts = {
@@ -75,7 +75,8 @@ end
 function run (args)
    local opts, address, pid = parse_args(args)
    if opts.name then
-      pid = get_pid_by_name(opts.name)
+      local programs = engine.enumerate_named_programs(opts.name)
+      pid = programs[opts.name]
       if not pid then
          fatal(("Couldn't find process with name '%s'"):format(opts.name))
       end

--- a/src/program/lwaftr/monitor/monitor.lua
+++ b/src/program/lwaftr/monitor/monitor.lua
@@ -6,11 +6,14 @@ local lib = require("core.lib")
 local lwtypes = require("apps.lwaftr.lwtypes")
 local lwutil = require("apps.lwaftr.lwutil")
 local shm = require("core.shm")
+local top = require("program.top.top")
 
-local fatal = lwutil.fatal
+local fatal, get_pid_by_name = lwutil.fatal, lwutil.get_pid_by_name
+local select_snabb_instance = top.select_snabb_instance
 
 local long_opts = {
-   help = "h"
+   help = "h",
+   name = "n",
 }
 
 local MIRROR_NOTHING = "0.0.0.0"
@@ -23,64 +26,24 @@ end
 
 local function parse_args (args)
    local handlers = {}
+   local opts = {}
    function handlers.h ()
       usage(0)
    end
-   args = lib.dogetopt(args, handlers, "h", long_opts)
+   function handlers.n (arg)
+      opts.name = assert(arg)
+   end
+   args = lib.dogetopt(args, handlers, "hn:", long_opts)
    if #args < 1 or #args > 2 then usage(1) end
-
-   -- Return address and pid.
-   if #args == 1 then
-      local maybe_pid = tonumber(args[1])
-      if maybe_pid then
-         return MIRROR_NOTHING, maybe_pid
-      end
-      return args[1]
-   end
-   return args[1], args[2]
-end
-
-local function find_pid_by_id (id)
-   for _, pid in ipairs(shm.children("/")) do
-      local path = "/"..pid.."/nic/id"
-      if shm.exists(path) then
-         local lwaftr_id = shm.open(path, lwtypes.lwaftr_id_type)
-         if ffi.string(lwaftr_id.value) == id then
-            return pid
-         end
-      end
-   end
+   return opts, unpack(args)
 end
 
 local function find_mirror_path (pid)
-   -- Check process has v4v6_mirror defined.
-   if pid then
-      -- Pid is an id.
-      if not tonumber(pid) then
-         pid = find_pid_by_id(pid)
-         if not pid then
-            fatal("Invalid lwAFTR id '%s'"):format(pid)
-         end
-      end
-      -- Pid exists?
-      if not shm.exists("/"..pid) then
-         fatal(("No Snabb instance with pid '%d'"):format(pid))
-      end
-      -- Check process has v4v6_mirror defined.
-      local path = "/"..pid.."/v4v6_mirror"
-      if not shm.exists(path) then
-         fatal(("lwAFTR process '%d' is not running in mirroring mode"):format(pid))
-      end
-      return path, pid
+   local path = "/"..pid.."/v4v6_mirror"
+   if not shm.exists(path) then
+      fatal(("lwAFTR process '%d' is not running in mirroring mode"):format(pid))
    end
-
-   -- Return first process which has v4v6_mirror defined.
-   for _, pid in ipairs(shm.children("/")) do
-      local path = "/"..pid.."/v4v6_mirror"
-      if shm.exists(path) then
-         return path, pid
-      end
-   end
+   return path, pid
 end
 
 local function set_mirror_address (address, path)
@@ -91,10 +54,8 @@ local function set_mirror_address (address, path)
 
    -- Validate address.
    if address == "none" then
-      print("Monitor none")
       address = MIRROR_NOTHING
    elseif address == "all" then
-      print("Monitor all")
       address = MIRROR_EVERYTHING
    else
       if not ipv4:pton(address) then
@@ -107,19 +68,19 @@ local function set_mirror_address (address, path)
    local v4v6_mirror = shm.open(path, "struct { uint32_t ipv4; }")
    v4v6_mirror.ipv4 = ipv4_num
    shm.unmap(v4v6_mirror)
+
+   return address
 end
 
 function run (args)
-   local address, pid = parse_args(args)
-   local path, pid_number = find_mirror_path(pid)
-   if not path then
-      fatal("Couldn't find lwAFTR process running in mirroring mode")
+   local opts, address, pid = parse_args(args)
+   if opts.name then
+      pid = get_pid_by_name(opts.name)
+      if not pid then
+         fatal(("Couldn't find process with name '%s'"):format(opts.name))
+      end
    end
-
-   set_mirror_address(address, path)
-   io.write(("Mirror address set to '%s'"):format(address))
-   if not tonumber(pid) then
-      io.write((" in PID '%d'"):format(pid_number))
-   end
-   io.write("\n")
+   local path, pid = find_mirror_path(top.select_snabb_instance(pid))
+   address = set_mirror_address(address, path)
+   print(("Mirror address set to '%s' in PID '%s'"):format(address, pid))
 end

--- a/src/program/lwaftr/query/README
+++ b/src/program/lwaftr/query/README
@@ -1,20 +1,18 @@
 Usage:
-  query [OPTIONS] [<id>] [<counter-name>]
+  query [OPTIONS] [<pid>] [<counter-name>]
 
 Options:
 
-  -h, --help                    Print usage information.
-  -l, --list-all                List all available counter names.
+  -n, --name        <name>    Name of snabb process.
+  -h, --help                  Print usage information.
+  -l, --list-all              List all available counter names.
 
 Display current statistics from lwAFTR counters for a running Snabb instance
-with <id>.  <id> can be either a PID or a string ID:
+with <pid>.
 
-   * If it is a PID, <id> should exists at /var/run/snabb/<id>.
-   * If it is a string ID, <id> should match the value defined
-     in /var/run/snabb/*/nic/id.
-
-If <pid> is not supplied and there is only one Snabb instance, "query" will
-connect to that instance.
+If <pid> is empty and there is only one Snabb instance, "query" will
+connect to that instance.  It is possible to query a process by name, passing
+the flag --name.
 
 If <counter-name> is set, only counters partially matching <counter-name> are
 listed.

--- a/src/program/lwaftr/query/query.lua
+++ b/src/program/lwaftr/query/query.lua
@@ -10,7 +10,7 @@ local top = require("program.top.top")
 
 local select_snabb_instance = top.select_snabb_instance
 local keys, fatal = lwutil.keys, lwutil.fatal
-local named_program_root = engine.named_program_root
+local get_pid_by_name = lwutil.get_pid_by_name
 
 -- Get the counter dir from the code.
 local counters_dir = lwcounter.counters_dir
@@ -27,16 +27,6 @@ end
 
 local function is_counter_name (name)
    return lwcounter.counter_names[name] ~= nil
-end
-
-local function get_pid_by_name (name)
-   for _, program in pairs(shm.children("/by-name")) do
-      if name == program then
-         local fq = named_program_root .. "/" .. program
-         local piddir = S.readlink(fq)
-         return lib.basename(piddir)
-      end
-   end
 end
 
 function parse_args (raw_args)

--- a/src/program/snabbvmx/lwaftr/lwaftr.lua
+++ b/src/program/snabbvmx/lwaftr/lwaftr.lua
@@ -138,10 +138,7 @@ function run(args)
 
    intel10g.ring_buffer_size(ring_buffer_size)
 
-   if id then
-      local lwaftr_id = shm.create("nic/id", lwtypes.lwaftr_id_type)
-      lwaftr_id.value = id
-   end
+   if id then engine.claim_name(id) end
 
    local vlan = false
    local mtu = DEFAULT_MTU

--- a/src/program/snabbvmx/query/query.lua
+++ b/src/program/snabbvmx/query/query.lua
@@ -98,15 +98,22 @@ local function print_counters (pid, dir)
   print(("   </%s>"):format(dir))
 end
 
+local named_program_root = engine.named_program_root
+
+function get_name_by_pid (pid)
+   local fq = named_program_root .. "/" .. pid
+   local namedir = S.readlink(fq)
+   return lib.basename(namedir)
+end
+
 function run (raw_args)
    parse_args(raw_args)
    print("<snabb>")
    local pids = {}
    local pids_name = {}
    for _, pid in ipairs(shm.children("/")) do
-     if shm.exists("/"..pid.."/nic/id") then
-       local lwaftr_id = shm.open("/"..pid.."/nic/id", lwtypes.lwaftr_id_type)
-       local instance_id_name = ffi.string(lwaftr_id.value)
+     if shm.exists("/"..pid.."/name") then
+       local instance_id_name = get_name_by_pid(pid)
        local instance_id = instance_id_name and instance_id_name:match("(%d+)")
        if instance_id then
          pids[instance_id] = pid

--- a/src/program/snabbvmx/query/query.lua
+++ b/src/program/snabbvmx/query/query.lua
@@ -31,7 +31,6 @@ local function parse_args (raw_args)
    local args = lib.dogetopt(raw_args, handlers, "h",
                              { help="h" })
    if #args > 0 then show_usage(1) end
-   return nil
 end
 
 local function read_counters (tree, app_name)
@@ -98,12 +97,10 @@ local function print_counters (pid, dir)
   print(("   </%s>"):format(dir))
 end
 
-local named_program_root = engine.named_program_root
-
-function get_name_by_pid (pid)
-   local fq = named_program_root .. "/" .. pid
-   local namedir = S.readlink(fq)
-   return lib.basename(namedir)
+local function transpose (t)
+   local ret = {}
+   for k, v in pairs(t) do ret[v] = k end
+   return ret
 end
 
 function run (raw_args)
@@ -111,9 +108,11 @@ function run (raw_args)
    print("<snabb>")
    local pids = {}
    local pids_name = {}
+   local named_programs = transpose(engine.enumerate_named_programs())
+
    for _, pid in ipairs(shm.children("/")) do
      if shm.exists("/"..pid.."/name") then
-       local instance_id_name = get_name_by_pid(pid)
+       local instance_id_name = named_programs[tonumber(pid)]
        local instance_id = instance_id_name and instance_id_name:match("(%d+)")
        if instance_id then
          pids[instance_id] = pid

--- a/src/program/snabbvmx/top/README
+++ b/src/program/snabbvmx/top/README
@@ -1,12 +1,15 @@
 Usage:
   top [OPTIONS] [<pid>]
 
-  -h, --help
-                             Print usage information.
+Options:
+  -n, --name   <name>   Query by process name.
+  -h, --help            Print usage information.
 
-Display realtime lwaftr statistics for a running lwaftr Snabb Switch
+Display realtime lwaftr statistics for a running Snabb's lwaftr
 instance with <pid>. If <pid> is not supplied and there is only one Snabb
 Switch instance, top will connect to that instance.
+
+It is possible to query a process by name, passing the flag --name.
 
 Example output:
 

--- a/src/program/snabbvmx/top/top.lua
+++ b/src/program/snabbvmx/top/top.lua
@@ -10,36 +10,14 @@ local shm = require("core.shm")
 local top = require("program.top.top")
 
 local C = ffi.C
-local fatal = lwutil.fatal
+local fatal, get_pid_by_name = lwutil.fatal, lwutil.get_pid_by_name
 
 local long_opts = {
-   help = "h"
+   help = "h",
+   name = "n"
 }
 
 local function clearterm () io.write('\027[2J') end
-
-local function select_snabb_instance_by_id (target_id)
-   local pids = shm.children("/")
-   for _, pid in ipairs(pids) do
-      local path = "/"..pid.."/nic/id"
-      if shm.exists(path) then
-         local lwaftr_id = shm.open(path, lwtypes.lwaftr_id_type)
-         if ffi.string(lwaftr_id.value) == target_id then
-            return pid
-         end
-      end
-   end
-   print(("Couldn't find instance with id '%s'"):format(target_id))
-   main.exit(1)
-end
-
-local function select_snabb_instance (id)
-   if not id or tonumber(id) then
-      return top.select_snabb_instance(id)
-   else
-      return select_snabb_instance_by_id(id)
-   end
-end
 
 local counter_names = (function ()
    local counters = {
@@ -207,17 +185,27 @@ end
 
 local function parse_args (args)
    local handlers = {}
+   local opts = {}
    function handlers.h ()
       show_usage(0)
    end
-   args = lib.dogetopt(args, handlers, "h", long_opts)
+   function handlers.n (arg)
+      opts.name = assert(arg)
+   end
+   args = lib.dogetopt(args, handlers, "hn:", long_opts)
    if #args > 1 then show_usage(1) end
-   return args[1]
+   return opts, args[1]
 end
 
 function run (args)
-   local target_pid = parse_args(args)
-   local instance_tree = "/"..select_snabb_instance(target_pid)
+   local opts, target_pid = parse_args(args)
+   if opts.name then
+      target_pid = get_pid_by_name(opts.name)
+      if not target_pid then
+         fatal(("Couldn't find process with name '%s'"):format(opts.name))
+      end
+   end
+   local instance_tree = "/" .. top.select_snabb_instance(target_pid)
    if not has_lwaftr_app(instance_tree) then
       fatal("Selected instance doesn't include lwaftr app")
    end

--- a/src/program/snabbvmx/top/top.lua
+++ b/src/program/snabbvmx/top/top.lua
@@ -10,7 +10,7 @@ local shm = require("core.shm")
 local top = require("program.top.top")
 
 local C = ffi.C
-local fatal, get_pid_by_name = lwutil.fatal, lwutil.get_pid_by_name
+local fatal = lwutil.fatal
 
 local long_opts = {
    help = "h",
@@ -200,7 +200,8 @@ end
 function run (args)
    local opts, target_pid = parse_args(args)
    if opts.name then
-      target_pid = get_pid_by_name(opts.name)
+      local programs = engine.enumerate_named_programs(opts.name)
+      target_pid = programs[opts.name]
       if not target_pid then
          fatal(("Couldn't find process with name '%s'"):format(opts.name))
       end

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -47,6 +47,7 @@ function select_snabb_instance (pid)
    local instances = compute_snabb_instances()
 
    if pid then
+      pid = tostring(pid)
       -- Try to use given pid
       for _, instance in ipairs(instances) do
          if instance == pid then return pid end


### PR DESCRIPTION
Allows to select a snabb instance by name in `lwaftr query`.

Before `lwaftr query` had an ad-hoc implementation that allowed to select a Snabb instance by name. Only SnabbVMX used this mechanism. When SnabbVMX was called passing the --id argument, it stored an instance id in a counter called 'nic/id'.

A PID in `lwaftr query` could be either a PID or an SnabbVMX's ID. In case of being an ID, its value was compared to the value stored in 'nic/id'.

This PR adds proper support for querying by name using the standard mechanism (search instance name in `/by-name` folder). Additionally, the PR reworks other subcommands that used the former implementation.

Fixes #623.