### PR TITLE
Property-based test: lwaftr run does not crash with get

### DIFF
--- a/src/program/lwaftr/tests/propbased/genyang.lua
+++ b/src/program/lwaftr/tests/propbased/genyang.lua
@@ -8,5 +8,8 @@ function generate_yang(pid)
 end
 
 function run_yang(yang_cmd)
-   return io.popen(yang_cmd):read("*a")
+   local f = io.popen(yang_cmd)
+   local result = f:read("*a")
+   f:close()
+   return result
 end

--- a/src/program/lwaftr/tests/propbased/genyang.lua
+++ b/src/program/lwaftr/tests/propbased/genyang.lua
@@ -1,0 +1,12 @@
+module(..., package.seeall)
+
+--local S = require("syscall")
+--local snabb_cmd = ("/proc/%d/exe"):format(S.getpid())
+
+function generate_yang(pid)
+   return string.format("./snabb config get %s /", pid)
+end
+
+function run_yang(yang_cmd)
+   return io.popen(yang_cmd):read("*a")
+end

--- a/src/program/lwaftr/tests/propbased/prop_nocrash.lua
+++ b/src/program/lwaftr/tests/propbased/prop_nocrash.lua
@@ -1,0 +1,43 @@
+#!/usr/bin/env luajit
+module(..., package.seeall)
+
+local genyang = require("program.lwaftr.tests.propbased.genyang")
+local S = require("syscall")
+local run_pid
+local current_cmd
+
+function property()
+   current_cmd = genyang.generate_yang(run_pid)
+   local results = (genyang.run_yang(current_cmd))
+   if string.match("Could not connect to config leader socket on Snabb instance",
+                   results) then
+      print("Launching snabb run failed, or we've crashed it!")
+      return false
+   end
+end
+
+function print_extra_information()
+   print("The command was:", current_cmd)
+end
+
+function handle_prop_args(prop_args)
+   if #prop_args ~= 1 then
+      print("Usage: snabb quickcheck prop_nocrash PCI_ADDR")
+      os.exit(1)
+   end
+
+   -- TODO: validate the address
+   local pci_addr = prop_args[1]
+
+   local pid = S.fork()
+   if pid == 0 then
+      local cmdline = {"snabb", "lwaftr", "run", "-D", "2", "--conf",
+          "program/lwaftr/tests/data/icmp_on_fail.conf", "--reconfigurable", 
+          "--on-a-stick", pci_addr}
+      -- FIXME: preserve the environment
+      S.execve(("/proc/%d/exe"):format(S.getpid()), cmdline, {})
+   else
+      run_pid = pid
+      S.sleep(0.1)
+   end
+end

--- a/src/program/lwaftr/tests/propbased/prop_nocrash.lua
+++ b/src/program/lwaftr/tests/propbased/prop_nocrash.lua
@@ -38,6 +38,6 @@ function handle_prop_args(prop_args)
       S.execve(("/proc/%d/exe"):format(S.getpid()), cmdline, {})
    else
       run_pid = pid
-      S.sleep(0.1)
+      S.sleep(1)
    end
 end

--- a/src/program/lwaftr/tests/propbased/prop_nocrash.lua
+++ b/src/program/lwaftr/tests/propbased/prop_nocrash.lua
@@ -31,7 +31,7 @@ function handle_prop_args(prop_args)
 
    local pid = S.fork()
    if pid == 0 then
-      local cmdline = {"snabb", "lwaftr", "run", "-D", "2", "--conf",
+      local cmdline = {"snabb", "lwaftr", "run", "-D", "20", "--conf",
           "program/lwaftr/tests/data/icmp_on_fail.conf", "--reconfigurable", 
           "--on-a-stick", pci_addr}
       -- FIXME: preserve the environment

--- a/src/program/lwaftr/tests/propbased/selftest.sh
+++ b/src/program/lwaftr/tests/propbased/selftest.sh
@@ -4,6 +4,6 @@ set -e
 
 SKIPPED_CODE=43
 
-if [ -z $SNABB_PCI0 0 ]; then exit SKIPPED_CODE; fi
+if [ -z $SNABB_PCI0 ]; then exit SKIPPED_CODE; fi
 
 ./snabb quickcheck program.lwaftr.tests.propbased.prop_nocrash $SNABB_PCI0

--- a/src/program/lwaftr/tests/propbased/selftest.sh
+++ b/src/program/lwaftr/tests/propbased/selftest.sh
@@ -4,6 +4,6 @@ set -e
 
 SKIPPED_CODE=43
 
-if [ -z $SNABB_PCI0 ]; then exit SKIPPED_CODE; fi
+if [ -z $SNABB_PCI0 ]; then exit $SKIPPED_CODE; fi
 
 ./snabb quickcheck program.lwaftr.tests.propbased.prop_nocrash $SNABB_PCI0

--- a/src/program/lwaftr/tests/propbased/selftest.sh
+++ b/src/program/lwaftr/tests/propbased/selftest.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+SKIPPED_CODE=43
+
+if [ -z $SNABB_PCI0 0 ]; then exit SKIPPED_CODE; fi
+
+./snabb quickcheck program.lwaftr.tests.propbased.prop_nocrash $SNABB_PCI0

--- a/src/program/quickcheck/quickcheck.lua
+++ b/src/program/quickcheck/quickcheck.lua
@@ -1,0 +1,123 @@
+module(...,package.seeall)
+
+local utils = require('program.quickcheck.utils')
+
+local program_name = 'snabb quickcheck'
+
+local seed, iterations, prop_name, prop_args, prop, prop_info
+
+-- Due to limitations of Lua 5.1, finding if a command failed is convoluted.
+local function find_gitrev()
+   local fd = io.popen('git rev-parse HEAD 2>/dev/null ; echo -n "$?"')
+   local cmdout = fd:read("*all")
+   fd:close() -- Always true in 5.1, with Lua or LuaJIT
+   local _, _, git_ret = cmdout:find("(%d+)$")
+   git_ret = tonumber(git_ret)
+   if git_ret ~= 0 then -- Probably not in a git repo
+      return nil
+   else
+      local _, _, sha1 = cmdout:find("(%x+)")
+      return sha1
+   end
+end
+
+local function print_gitrev_if_available()
+   local rev = find_gitrev()
+   if rev then print(("Git revision %s"):format(rev)) end
+end
+
+local function rerun_usage(i)
+   print(("Rerun as: %s --seed=%s --iterations=%s %s %s"):
+         format(program_name, seed, i + 1,
+                prop_name, table.concat(prop_args, " ")))
+end
+
+function initialize(options)
+   seed, iterations, prop_name, prop_args =
+      options.seed, options.iterations, options.prop_name, options.prop_args
+
+   if not seed then
+      seed = math.floor(utils.gmtime() * 1e6) % 10^9
+      print("Using time as seed: "..seed)
+   end
+   math.randomseed(assert(tonumber(seed)))
+
+   if not iterations then iterations = 100 end
+
+   if not prop_name then
+      error("No property name specified")
+   end
+
+   prop = require(prop_name)
+   if prop.handle_prop_args then
+      prop_info = prop.handle_prop_args(prop_args)
+   else
+      assert(#prop_args == 0,
+             "Property does not take options "..prop_name)
+      prop_info = nil
+   end
+end
+
+function initialize_from_command_line(args)
+   local options = {}
+   while #args >= 1 and args[1]:match("^%-%-") do
+      local arg, _, val = table.remove(args, 1):match("^%-%-([^=]*)(=(.*))$")
+      assert(arg)
+      if arg == 'seed' then options.seed = assert(tonumber(val))
+      elseif arg == 'iterations' then options.iterations = assert(tonumber(val))
+      else error("Unknown argument: " .. arg) end
+   end
+   if #args < 1 then
+      print("Usage: " ..
+               program_name ..
+               " [--seed=SEED]" ..
+               " [--iterations=ITERATIONS]" ..
+               " property_file [property_specific_args]")
+      os.exit(1)
+   end
+   options.prop_name = table.remove(args, 1)
+   options.prop_args = args
+   initialize(options)
+end
+
+function run(args)
+   initialize_from_command_line(args)
+   if not prop then
+      error("Call initialize() or initialize_from_command_line() first")
+   end
+
+   for i = 1,iterations do
+      -- Wrap property and its arguments in a 0-arity function for xpcall
+      local wrap_prop = function() return prop.property(prop_info) end
+      local propgen_ok, expected, got = xpcall(wrap_prop, debug.traceback)
+      if not propgen_ok then
+          print(("Crashed generating properties on run %s."):format(i))
+          if prop.print_extra_information then
+             print("Attempting to print extra information; it may be wrong.")
+             if not pcall(prop.print_extra_information)
+                then print("Something went wrong printing extra info.")
+             end
+          end
+          print("Traceback (this is reliable):")
+          print(expected) -- This is an error code and traceback in this case
+          rerun_usage(i)
+          os.exit(1)
+      end
+      if not utils.equals(expected, got) then
+          print_gitrev_if_available()
+          print("The property was falsified.")
+          -- If the property file has extra info available, show it
+          if prop.print_extra_information then
+             prop.print_extra_information()
+          else
+             print('Expected:')
+             utils.pp(expected)
+             print('Got:')
+             utils.pp(got)
+          end
+          rerun_usage(i)
+          os.exit(1)
+      end
+   end
+   print(iterations.." iterations succeeded.")
+end

--- a/src/program/quickcheck/utils.lua
+++ b/src/program/quickcheck/utils.lua
@@ -1,0 +1,116 @@
+module(...,package.seeall)
+
+local S = require("syscall")
+
+function gmtime()
+   local tv = S.gettimeofday()
+   local secs = tonumber(tv.tv_sec)
+   secs = secs + tonumber(tv.tv_usec) * 1e-6
+   return secs
+end
+
+function concat(a, b)
+   local ret = {}
+   for _, v in ipairs(a) do table.insert(ret, v) end
+   for _, v in ipairs(b) do table.insert(ret, v) end
+   return ret
+end
+
+function equals(expected, actual)
+   if type(expected) ~= type(actual) then return false end
+   if type(expected) == 'table' then
+      for k, v in pairs(expected) do
+         if not equals(v, actual[k]) then return false end
+      end
+      for k, _ in pairs(actual) do
+         if expected[k] == nil then return false end
+      end
+      return true
+   else
+      return expected == actual
+   end
+end
+
+function is_array(x)
+   if type(x) ~= 'table' then return false end
+   if #x == 0 then return false end
+   for k,v in pairs(x) do
+      if type(k) ~= 'number' then return false end
+      -- Restrict to unsigned 32-bit integer keys.
+      if k < 0 or k >= 2^32 then return false end
+      -- Array indices are integers.
+      if k - math.floor(k) ~= 0 then return false end
+      -- Negative zero is not a valid array index.
+      if 1 / k < 0 then return false end
+   end
+   return true
+end
+
+function pp(expr, indent, suffix)
+   indent = indent or ''
+   suffix = suffix or ''
+   if type(expr) == 'number' then
+      print(indent..expr..suffix)
+   elseif type(expr) == 'string' then
+      print(indent..'"'..expr..'"'..suffix)
+   elseif type(expr) == 'boolean' then
+      print(indent..(expr and 'true' or 'false')..suffix)
+   elseif is_array(expr) then
+      assert(#expr > 0)
+      if #expr == 1 then
+         if type(expr[1]) == 'table' then
+            print(indent..'{')
+            pp(expr[1], indent..'  ', ' }'..suffix)
+         else
+            print(indent..'{ "'..expr[1]..'" }'..suffix)
+         end
+      else
+         if type(expr[1]) == 'table' then
+            print(indent..'{')
+            pp(expr[1], indent..'  ', ',')
+         else
+            print(indent..'{ "'..expr[1]..'",')
+         end
+         indent = indent..'  '
+         for i=2,#expr-1 do pp(expr[i], indent, ',') end
+         pp(expr[#expr], indent, ' }'..suffix)
+      end
+   elseif type(expr) == 'table' then
+      if #expr == 0 then
+         print(indent .. '{}')
+      else
+         error('unimplemented')
+      end
+   else
+      error("unsupported type "..type(expr))
+   end
+   return expr
+end
+
+function assert_equals(expected, actual)
+   if not equals(expected, actual) then
+      pp(expected)
+      pp(actual)
+      error('not equal')
+   end
+end
+
+function choose(choices)
+   local idx = math.random(#choices)
+   return choices[idx]
+end
+
+function choose_with_index(choices)
+   local idx = math.random(#choices)
+   return choices[idx], idx
+end
+
+function selftest ()
+   print("selftest: pf.utils")
+   local tab = { 1, 2, 3 }
+   assert_equals({ 1, 2, 3, 1, 2, 3 }, concat(tab, tab))
+   local gu1 = gmtime()
+   local gu2 = gmtime()
+   assert(gu1, gu2)
+   print("OK")
+end


### PR DESCRIPTION
This adds a first property based test. The property is that the lwaftr
does not crash with a 'snabb config get' command run repeatedly.

This is a first step towards resolving #631 .

Use: ```SNABB_PCI0=82:00.1 ./program/lwaftr/tests/propbased/selftest.sh```

Note that this is currently reporting crashes, for instance after 14 or 23 iterations.