### PR TITLE
Exit nicely if couldn't set affinity for a core

### DIFF
--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -92,7 +92,8 @@ function bind_to_cpu (cpu)
    if not cpu then return unbind_cpu() end
    assert(not bound_cpu, "already bound")
 
-   assert(S.sched_setaffinity(0, cpu))
+   assert(S.sched_setaffinity(0, cpu),
+      ("Couldn't set affinity for cpu %s"):format(cpu))
    local cpu_and_node = S.getcpu()
    assert(cpu_and_node.cpu == cpu)
    bound_cpu = cpu
@@ -120,9 +121,8 @@ function bind_to_numa_node (node)
 end
 
 function prevent_preemption(priority)
-   if not S.sched_setscheduler(0, "fifo", priority or 1) then
-      fatal('Failed to enable real-time scheduling.  Try running as root.')
-   end
+   assert(S.sched_setscheduler(0, "fifo", priority or 1),
+      'Failed to enable real-time scheduling.  Try running as root.')
 end
 
 function selftest ()

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -481,7 +481,8 @@ function apply_scheduling(opts)
 
    opts = lib.parse(opts, apply_scheduling_opts)
    if opts.cpu then
-      numa.bind_to_cpu(opts.cpu)
+      local success, err = pcall(numa.bind_to_cpu, opts.cpu)
+      if not success then fatal(err) end
       print("Bound data plane to CPU:", opts.cpu)
    end
    numa.check_affinity_for_pci_addresses(opts.pci_addrs)


### PR DESCRIPTION
Replace assert for error check when setting a CPU affinity. It may fail if trying to set affinity for a non-existent CPU. For instance:

```
$ sudo ./snabb lwaftr run -v --cpu 12 --conf lwaftr-migrated.conf --v4 82:00.0 --v6 82:00.1
lwaftr-migrated.conf: loading compiled configuration from lwaftr-migrated.o
lwaftr-migrated.conf: compiled configuration lwaftr-migrated.o is up to date.
Couldn't set affinity for cpu 12: Invalid argument
```

In addition, the patch adds function `fatal` which was used in `prevent_preemption, but it was missing in `lib/numa.lua`.