### PR TITLE
Snabb config testing with lwaftr

### DIFF
--- a/src/program/lwaftr/tests/config/selftest.sh
+++ b/src/program/lwaftr/tests/config/selftest.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+./program/lwaftr/tests/config/test-config-get.sh
+./program/lwaftr/tests/config/test-config-set.sh
+./program/lwaftr/tests/config/test-config-add.sh
+./program/lwaftr/tests/config/test-config-remove.sh
+./program/lwaftr/tests/config/test-config-get-state.sh

--- a/src/program/lwaftr/tests/config/test-config-add.sh
+++ b/src/program/lwaftr/tests/config/test-config-add.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+## This adds a softwire section and then checks it can be got
+## back and that all the values are as they should be.
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+# Load the tools to be able to test stuff.
+BASEDIR="`pwd`"
+cd "`dirname \"$0\"`"
+source tools.sh
+cd $BASEDIR
+
+# Come up with a name for the lwaftr
+SNABB_NAME="`random_name`"
+
+# Start the bench command.
+start_lwaftr_bench $SNABB_NAME
+
+# IP to test with.
+TEST_SOFTWIRE="{ ipv4 1.2.3.4; psid 72; b4-ipv6 ::1; br 1; }"
+./snabb config add "$SNABB_NAME" "/softwire-config/binding-table/softwire" "$TEST_SOFTWIRE"
+
+# Check it can get this just fine
+./snabb config get $SNABB_NAME /softwire-config/binding-table/softwire[ipv4=1.2.3.4][psid=72] &> /dev/null
+assert_equal $? 0
+
+# Test that the b4-ipv4 is correct
+ADDED_B4_IPV4="`./snabb config get $SNABB_NAME /softwire-config/binding-table/softwire[ipv4=1.2.3.4][psid=72]/b4-ipv6`"
+assert_equal "$ADDED_B4_IPV4" "::1"
+
+stop_lwaftr_bench

--- a/src/program/lwaftr/tests/config/test-config-get-state.sh
+++ b/src/program/lwaftr/tests/config/test-config-get-state.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+## This makes verious quries to snabb config get-state to try and verify
+## that it will run and produce values. The script has no way of
+## validating the acuracy of the values but it'll check it works.
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+# Load the tools to be able to test stuff.
+BASEDIR="`pwd`"
+cd "`dirname \"$0\"`"
+source tools.sh
+cd $BASEDIR
+
+# Come up with a name for the lwaftr
+SNABB_NAME="`random_name`"
+
+# Start the bench command.
+start_lwaftr_bench $SNABB_NAME
+
+# Selecting a few at random which should have non-zero results
+IN_IPV4="`snabb config get-state $SNABB_NAME /softwire-state/in-ipv4-bytes`"
+if [[ "$IN_IPV4" == "0" ]]; then
+	produce_error "Counter should not show zero."
+fi
+
+OUT_IPV4="`snabb config get-state $SNABB_NAME /softwire-state/out-ipv4-bytes`"
+if [[ "$IN_IPV4" == "0" ]]; then
+	produce_error "Counter should not show zero."
+fi
+
+./snabb config get-state "$SNABB_NAME" /
+assert_equal "$?" "0"

--- a/src/program/lwaftr/tests/config/test-config-get-state.sh
+++ b/src/program/lwaftr/tests/config/test-config-get-state.sh
@@ -33,3 +33,5 @@ fi
 
 ./snabb config get-state "$SNABB_NAME" /
 assert_equal "$?" "0"
+
+stop_lwaftr_bench

--- a/src/program/lwaftr/tests/config/test-config-get.sh
+++ b/src/program/lwaftr/tests/config/test-config-get.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+## This tests querying from a known config, the test is obviously
+## dependent on the values in the test data files used, however this
+## allows for testing basic "getting". It performs numerous gets which
+## on different paths.
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+# Load the tools to be able to test stuff.
+BASEDIR="`pwd`"
+cd "`dirname \"$0\"`"
+source tools.sh
+cd $BASEDIR
+
+# Come up with a name for the lwaftr
+SNABB_NAME="`random_name`"
+
+# Start the bench command.
+start_lwaftr_bench $SNABB_NAME
+
+# Check we can get a known value from the config.
+INTERNAL_IP="`./snabb config get $SNABB_NAME /softwire-config/internal-interface/ip`"
+assert_equal "$INTERNAL_IP" "8:9:a:b:c:d:e:f"
+
+EXTERNAL_IP="`./snabb config get $SNABB_NAME /softwire-config/external-interface/ip`"
+assert_equal "$EXTERNAL_IP" "10.10.10.10"
+
+BT_B4_IPV6="`./snabb config get $SNABB_NAME /softwire-config/binding-table/softwire[ipv4=178.79.150.233][psid=7850]/b4-ipv6`"
+assert_equal "$BT_B4_IPV6" "127:11:12:13:14:15:16:128"
+
+# Finally test getting a value from the ietf-softwire schema
+IETF_PATH="/softwire-config/binding/br/br-instances/br-instance[id=1]/binding-table/binding-entry[binding-ipv6info=127:22:33:44:55:66:77:128]/binding-ipv4-addr"
+BINDING_IPV4="`./snabb config get --schema=ietf-softwire $SNABB_NAME $IETF_PATH`"
+assert_equal "$?" "0"
+assert_equal "$BINDING_IPV4" "178.79.150.15"
+
+stop_lwaftr_bench

--- a/src/program/lwaftr/tests/config/test-config-remove.sh
+++ b/src/program/lwaftr/tests/config/test-config-remove.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+## This adds a softwire section and then checks it can be got
+## back and that all the values are as they should be.
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+# Load the tools to be able to test stuff.
+BASEDIR="`pwd`"
+cd "`dirname \"$0\"`"
+source tools.sh
+cd $BASEDIR
+
+# Come up with a name for the lwaftr
+SNABB_NAME="`random_name`"
+
+# Start the bench command.
+start_lwaftr_bench $SNABB_NAME
+
+# Firstly lets verify that the thing we want to remove actually exists
+./snabb config get "$SNABB_NAME" /softwire-config/binding-table/softwire[ipv4=178.79.150.2][psid=7850]/ &> /dev/null
+assert_equal "$?" "0"
+
+# Then lets remove it
+./snabb config remove "$SNABB_NAME" /softwire-config/binding-table/softwire[ipv4=178.79.150.2][psid=7850]/ &> /dev/null
+assert_equal "$?" "0"
+
+# Then lets verify we can't find it
+./snabb config get "$SNABB_NAME" /softwire-config/binding-table/softwire[ipv4=178.79.150.2][psid=7850]/ &> /dev/null || true
+assert_equal "$?" "0"
+
+stop_lwaftr_bench

--- a/src/program/lwaftr/tests/config/test-config-set.sh
+++ b/src/program/lwaftr/tests/config/test-config-set.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+## This checks you can set values, it'll then perform a get to
+## verify the value set is the value that is got too.
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+# Load the tools to be able to test stuff.
+BASEDIR="`pwd`"
+cd "`dirname \"$0\"`"
+source tools.sh
+cd $BASEDIR
+
+# Come up with a name for the lwaftr
+SNABB_NAME="`random_name`"
+
+# Start the bench command.
+start_lwaftr_bench $SNABB_NAME
+
+# IP to test with.
+TEST_IPV4="208.118.235.148"
+./snabb config set "$SNABB_NAME" "/softwire-config/external-interface/ip" "$TEST_IPV4"
+SET_IP="`./snabb config get \"$SNABB_NAME\" \"/softwire-config/external-interface/ip\"`"
+assert_equal "$SET_IP" "$TEST_IPV4"
+
+# Set a value in a list
+TEST_IPV6="::1"
+TEST_IPV4="178.79.150.15"
+TEST_PSID="0"
+./snabb config set "$SNABB_NAME" "/softwire-config/binding-table/softwire[ipv4=$TEST_IPV4][psid=$TEST_PSID]/b4-ipv6" "$TEST_IPV6"
+SET_IP="`./snabb config get \"$SNABB_NAME\" \"/softwire-config/binding-table/softwire[ipv4=$TEST_IPV4][psid=$TEST_PSID]/b4-ipv6\"`"
+assert_equal "$SET_IP" "$TEST_IPV6"
+
+# Check that the value above I just set is the same in the IETF schema
+# We actually need to look this up backwards, lets just check the same
+# IPv4 address was used as was used to set it above.
+IETF_PATH="/softwire-config/binding/br/br-instances/br-instance[id=1]/binding-table/binding-entry[binding-ipv6info=::1]/binding-ipv4-addr"
+IPV4_ADDR="`./snabb config get --schema=ietf-softwire $SNABB_NAME $IETF_PATH`"
+assert_equal "$IPV4_ADDR" "$TEST_IPV4"
+
+# Also check the portset, the IPv4 address alone isn't unique
+IETF_PATH="/softwire-config/binding/br/br-instances/br-instance[id=1]/binding-table/binding-entry[binding-ipv6info=::1]/port-set/psid"
+PSID="`./snabb config get --schema=ietf-softwire $SNABB_NAME $IETF_PATH`"
+assert_equal "$PSID" "$TEST_PSID"
+
+# Stop the lwaftr process.
+stop_lwaftr_bench

--- a/src/program/lwaftr/tests/config/tools.sh
+++ b/src/program/lwaftr/tests/config/tools.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+function produce_error {
+    (>&2 echo $1)
+    exit 1
+}
+
+function random_name {
+    cat /dev/urandom | tr -dc 'a-z' | fold -w 20 | head -n 1
+}
+
+
+# Takes two paremters and checks their equality.
+# It takes an optional third argument which will
+# be displayed if it fails the equality check.
+# e.g.
+#  $ assert_equal "yellow "cat"       -> error
+#  $ assert_equal "banana" "banana"   -> nothing (valid)
+function assert_equal {
+    if [[ -z "$2" ]]; then
+	produce_error "assert_equals: Not enough arguments."
+	exit 1
+    fi
+    if [[ "$1" == "$2" ]]; then
+	return
+    else
+	if [[ "$3" == "" ]]; then
+	    produce_error "Assert error: $1 != $2"
+	else
+	    produce_error "Assert error: $3"
+	fi
+    fi
+}
+
+# This starts the lwaftr process. The process should end when the script
+# ends however, if something goes wrong and it doesn't end correctly, a
+# duration is set to prevent it running indefinitely.
+function start_lwaftr_bench {
+    ./snabb lwaftr bench --reconfigurable --bench-file /dev/null --name "$1" \
+	                 --duration 20 \
+                         program/lwaftr/tests/data/icmp_on_fail.conf \
+                         program/lwaftr/tests/benchdata/ipv{4,6}-0550.pcap &> /dev/null &
+
+    # This isn't ideal but it takes a little time for the lwaftr to properly start
+    # TODO: make this better?
+    sleep 2
+}
+
+function stop_lwaftr_bench {
+    # Get the job number for lwaftr bench
+    local jobid="`jobs | grep -i \"lwaftr bench\" | awk '{print $1}' | tr -d '[]+'`"
+    kill -15 "%$jobid"
+    # Wait until it's shutdown.
+    wait &> /dev/null
+}

--- a/src/program/lwaftr/tests/config/tools.sh
+++ b/src/program/lwaftr/tests/config/tools.sh
@@ -42,7 +42,6 @@ function start_lwaftr_bench {
                          program/lwaftr/tests/benchdata/ipv{4,6}-0550.pcap &> /dev/null &
 
     # This isn't ideal but it takes a little time for the lwaftr to properly start
-    # TODO: make this better?
     sleep 2
 }
 


### PR DESCRIPTION
This introduces a bunch of front-end tests which run the snabb config commands we have at the moment (get, get-state, set, add and remove) and do its best to verify the data. The tests a a bunch of shell scripts with a helper file which contains code to do assets, start the lwaftr and ensure it closes too.

This runs as part of the make test testsuite in snabb. This should hopefully help us catch more bugs.

PTAL @wingo @kbara