### PR TITLE
Fix killer bug in leader: write beyond array end

### DIFF
--- a/src/apps/config/action_codec.lua
+++ b/src/apps/config/action_codec.lua
@@ -116,7 +116,9 @@ local function encoder()
    end
    function encoder:string(str)
       self:uint32(#str)
-      table.insert(self.out, ffi.new('uint8_t[?]', #str, str))
+      local buf = ffi.new('uint8_t[?]', #str)
+      ffi.copy(buf, str, #str)
+      table.insert(self.out, buf)
    end
    function encoder:blob(blob)
       self:uint32(ffi.sizeof(blob))

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -607,7 +607,7 @@ function Leader:handle_calls_from_peers()
             assert(type(reply) == 'string')
             reply = #reply..'\n'..reply
             peer.state = 'reply'
-            peer.buf = ffi.new('uint8_t[?]', #reply, reply)
+            peer.buf = ffi.new('uint8_t[?]', #reply+1, reply)
             peer.pos = 0
             peer.len = #reply
          else

--- a/src/program/config/listen/listen.lua
+++ b/src/program/config/listen/listen.lua
@@ -151,7 +151,7 @@ local function buffered_output()
    function ret:write(str) table.insert(self.buf, str) end
    function ret:flush_to_fd(fd)
       local str = table.concat(self.buf)
-      local bytes = ffi.new('uint8_t[?]', #str, str)
+      local bytes = ffi.cast('const char*', str)
       local written = 0
       while written < #str do
          local wrote = assert(S.write(fd, bytes + written, #str - written))


### PR DESCRIPTION
Thanks to @takikawa for tracking this one down.  So it turns out it's not an early free but rather corruption.  Quoth http://luajit.org/ext_ffi_semantics.html in "Initializers":

> Byte arrays may also be initialized with a Lua string. This copies the whole string plus a terminating zero-byte. The copy stops early only if the array has a known, fixed size.

I was thinking that `ffi.new('uint8_t[?]', #str, str)` would make an array with "known, fixed size".  But I think that characteristic applies to the type, and is `uint8_t[?]` fixed, even when given its length?  I thought so.  I was wrong; you can't do this:

```lua
local buf = ffi.typeof('uint8_t[?]', #str)(str)
```

But you can do this:

```lua
local buf = ffi.typeof('uint8_t[$]', #str)(str)
```

Using the `$` makes an array type with fixed size.  The `[?]` makes a variable-length array (VLA).

So this bug was that LuaJIT was writing a zero byte beyond the array, and that was corrupting the GC metadata (probably the header for the next object).  Putting all buffers in an array mitigated the bug by never requiring that the data be collected.  The real fix tho is to stop writing beyond the end of data :)