### PR TITLE
Print out worker info in 'snabb ps'

### DIFF
--- a/src/program/ps/README
+++ b/src/program/ps/README
@@ -3,11 +3,8 @@ Print a list of running Snabb instances.
 
 Available options:
   -h, --help                 Display this message.
-  -p, --PID                  Display processes by their PID instead of name.
 
-The default output format is one identifier by line. If the --p or --pid flag is
-used then the it will ignore any name defined and list just the PID.  More
-options can be added in the future.
+The default output format is one identifier by line.
 
-The identifier is either the name (preferentially) or, if one is not defined,
-the PID of the process is used.
+An identifier is a Snabb instance PID. If a name is defined for the PID,
+its value is printed on a second column.

--- a/src/program/ps/ps.lua
+++ b/src/program/ps/ps.lua
@@ -60,6 +60,9 @@ local function compute_snabb_instances()
          table.insert(pids, instance)
       end
    end
+   table.sort(pids, function(a, b)
+      return tonumber(a.pid) < tonumber(b.pid)
+   end)
    return pids
 end
 

--- a/src/program/ps/ps.lua
+++ b/src/program/ps/ps.lua
@@ -17,12 +17,9 @@ end
 
 local function parse_args (args)
    local opt = {}
-   local preferpid = false
    function opt.h (arg) usage(0) end
-   function opt.p (arg) preferpid = true end
-   args = lib.dogetopt(args, opt, "hp", {help='h', pid='p'})
+   args = lib.dogetopt(args, opt, "h", {help='h'})
    if #args ~= 0 then usage(1) end
-   return preferpid
 end
 
 local function appname_resolver()
@@ -67,20 +64,16 @@ local function compute_snabb_instances()
 end
 
 function run (args)
-   local preferpid = parse_args (args)
+   parse_args(args)
    local instances = compute_snabb_instances()
    for _, instance in ipairs(instances) do
-      if preferpid then
-         print(instance.pid)
+      -- Check instance is a worker.
+      if instance.leader then
+         print("  \\- "..instance.pid.."   worker for "..instance.leader)
       else
+         io.write(instance.pid)
          if instance.name then
-            io.write(instance.name)
-         else
-            io.write(instance.pid)
-         end
-         -- Check instance is a worker.
-         if instance.leader then
-            io.write(("\tWorker for PID %s"):format(instance.leader))
+            io.write("\t["..instance.name.."]")
          end
          io.write("\n")
       end


### PR DESCRIPTION
When listing PIDs with `snabb ps`, print out additional information about whether a PID is a worker. Example:

```
$ sudo ./snabb ps
19402
20362
20364   Worker for PID 20362
20806
22046
```

Fixes #651 