### PR TITLE
Wait for complete change sets before committing in follower

### DIFF
--- a/src/apps/config/action_codec.lua
+++ b/src/apps/config/action_codec.lua
@@ -12,7 +12,7 @@ local shm = require("core.shm")
 local action_names = { 'unlink_output', 'unlink_input', 'free_link',
                        'new_link', 'link_output', 'link_input', 'stop_app',
                        'start_app', 'reconfig_app',
-                       'call_app_method_with_blob' }
+                       'call_app_method_with_blob', 'commit' }
 local action_codes = {}
 for i, name in ipairs(action_names) do action_codes[name] = i end
 
@@ -69,6 +69,9 @@ function actions.call_app_method_with_blob (codec, appname, methodname, blob)
    local methodname = codec:string(methodname)
    local blob = codec:blob(blob)
    return codec:finish(appname, methodname, blob)
+end
+function actions.commit (codec)
+   return codec:finish()
 end
 
 local public_names = {}
@@ -238,5 +241,6 @@ function selftest ()
    test_action({'start_app', {appname, class, arg}})
    test_action({'reconfig_app', {appname, class, arg}})
    test_action({'call_app_method_with_blob', {appname, methodname, blob}})
+   test_action({'commit', {}})
    print('selftest: ok')
 end

--- a/src/apps/config/follower.lua
+++ b/src/apps/config/follower.lua
@@ -54,7 +54,7 @@ end
 
 function Follower:handle_actions_from_leader()
    local channel = self.channel
-   for i=1,10 do
+   for i=1,4 do
       local buf, len = channel:peek_message()
       if not buf then break end
       local action = action_codec.decode(buf, len)

--- a/src/apps/config/support.lua
+++ b/src/apps/config/support.lua
@@ -171,6 +171,7 @@ local function add_restarts(actions, app_graph, to_restart)
          table.insert(actions, {'link_input', {ta, tl, linkspec}})
       end
    end
+   table.insert(actions, {'commit', {}})
    return actions
 end
 

--- a/src/apps/config/support/snabb-softwire-v1.lua
+++ b/src/apps/config/support/snabb-softwire-v1.lua
@@ -22,6 +22,7 @@ local function add_softwire_entry_actions(app_graph, entries)
       local args = {'lwaftr', 'add_softwire_entry', blob}
       table.insert(ret, {'call_app_method_with_blob', args})
    end
+   table.insert(ret, {'commit', {}})
    return ret
 end
 
@@ -44,7 +45,7 @@ local function remove_softwire_entry_actions(app_graph, path)
    local key = path_mod.prepare_table_lookup(
       grammar.keys, grammar.key_ctype, path[#path].query)
    local args = {'lwaftr', 'remove_softwire_entry', key}
-   return {{'call_app_method_with_blob', args}}
+   return {{'call_app_method_with_blob', args}, {'commit', {}}}
 end
 
 local function compute_config_actions(old_graph, new_graph, to_restart,

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -19,14 +19,24 @@ local uint16_ptr_t = ffi.typeof('uint16_t*')
 local uint32_ptr_t = ffi.typeof('uint32_t*')
 local uint64_ptr_t = ffi.typeof('uint64_t*')
 
+local entry_types = {}
 local function make_entry_type(key_type, value_type)
-   return ffi.typeof([[struct {
+   local cache = entry_types[key_type]
+   if cache then
+      cache = cache[value_type]
+      if cache then return cache end
+   else
+      entry_types[key_type] = {}
+   end
+   local ret = ffi.typeof([[struct {
          uint32_t hash;
          $ key;
          $ value;
       } __attribute__((packed))]],
       key_type,
       value_type)
+   entry_types[key_type][value_type] = ret
+   return ret
 end
 
 local function make_entries_type(entry_type)


### PR DESCRIPTION
This PR fixes #647.  It also makes the follower less thirsty, just processing up to 4 messages per breath.  It also fixes a bug in ctable, which occured when sending binding table updates to the leader -- it would parse those updates as a ctable, which would generate a type, which would eventually overflow.  Fixed by caching.