### PR TITLE
Remove padding leaf in YANG model

### DIFF
--- a/src/lib/yang/snabb-softwire-v1.yang
+++ b/src/lib/yang/snabb-softwire-v1.yang
@@ -354,13 +354,6 @@ module snabb-softwire-v1 {
          "Port set ID.";
       }
 
-      leaf padding {
-        type uint16 { range 0..0; }
-        default 0;
-        description
-         "Reserved bytes.";
-      }
-
       leaf br {
         type uint32;
         default 0;

--- a/src/lib/yang/snabb-softwire-v1.yang
+++ b/src/lib/yang/snabb-softwire-v1.yang
@@ -338,7 +338,7 @@ module snabb-softwire-v1 {
     }
 
     list softwire {
-      key "ipv4 psid padding";
+      key "ipv4 psid";
 
       leaf ipv4 {
         type inet:ipv4-address;


### PR DESCRIPTION
AFAIK this is a reserved value so there is little point in exposing it in the YANG model as there is no situation when it should be user configurable.

pyang failed on this leaf since a range of 0..0 is not allowed (according to their interpretation of the YANG RFC at lesat). Removing the leaf naturally fixes this.

Part of #636