### PR TITLE
Have br-address be ordered-by user

### DIFF
--- a/src/lib/yang/snabb-softwire-v1.yang
+++ b/src/lib/yang/snabb-softwire-v1.yang
@@ -335,6 +335,7 @@ module snabb-softwire-v1 {
       type inet:ipv6-address;
       description
        "B4-facing address of an lwAFTR.";
+      ordered-by user;
     }
 
     list softwire {
@@ -366,7 +367,7 @@ module snabb-softwire-v1 {
         default 0;
         description
          "The B4-facing address of the lwAFTR for this softwire, as
-          a zero-based index into br-addresses.";
+          a zero-based index into br-address.";
       }
 
       leaf b4-ipv6 {


### PR DESCRIPTION
The br-address list must be ordered-by user since we have the "br" leaf under softwire that is supposed to reference into br-address through a zero-based index. Overall this is a tricky solution since such zero-based index isn't really a part of YANG but rather the programming language used to hold the instance data. Thus, when we set the software/br leaf we rely on the order in which it exists, to avoid the list being resorted we have to specify that it is to be ordered-by user.

Part of #636.