### PR TITLE
Remove mandatory statement for list keys

### DIFF
--- a/src/lib/yang/snabb-softwire-v1.yang
+++ b/src/lib/yang/snabb-softwire-v1.yang
@@ -287,7 +287,6 @@ module snabb-softwire-v1 {
 
       leaf addr {
         type inet:ipv4-address;
-        mandatory true;
         description
          "Public IPv4 address managed by the lwAFTR.";
       }
@@ -342,14 +341,12 @@ module snabb-softwire-v1 {
 
       leaf ipv4 {
         type inet:ipv4-address;
-        mandatory true;
         description
          "Public IPv4 address of the softwire.";
       }
 
       leaf psid {
         type uint16;
-        mandatory true;
         description
          "Port set ID.";
       }


### PR DESCRIPTION
List keys are implicitly mandatory so no need to declare it an extra time.

Part of #636.