### PR TITLE
Elaborate MTU description and add range and units

### DIFF
--- a/src/lib/yang/snabb-softwire-v1.yang
+++ b/src/lib/yang/snabb-softwire-v1.yang
@@ -154,8 +154,13 @@ module snabb-softwire-v1 {
       leaf mtu {
         type uint16;
         default 1460;
+        range "68..max";
+        units "bytes";
         description
-         "Maximum packet size to send on the IPv4 interface.";
+         "Maximum packet size to send on the IPv4 interface.
+         Including IP header but excluding low layer protocols, like
+         overhead of Ethernet header.";
+
       }
 
       uses traffic-filters;
@@ -204,8 +209,12 @@ module snabb-softwire-v1 {
       leaf mtu {
         type uint16;
         default 1500;
+        range "1280..max";
+        units "bytes";
         description
-         "Maximum packet size to sent on the IPv6 interface.";
+         "Maximum packet size to send on the IPv6 interface. 
+         Including IP header but excluding low layer protocols, like
+         overhead of Ethernet header.";
       }
 
       uses traffic-filters;


### PR DESCRIPTION
I extended the description to clarify that this is IP MTU including the IP header but not accounting for lower layer protocols. I think this is what is actually meant but I will admit I have not run through the code to check.

Added units.. perhaps obvious but doesn't hurt. Last but not least we now have a range on the MTU - always good with some sanity checking. What would happen if someone tries to configure with MTU=3 or something silly small?

Part of #636.