### PR TITLE
Add basic error reporting to snabb-softwire-v1

### DIFF
--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -490,7 +490,7 @@ function Leader:rpc_set_config (args)
       return self:handle_rpc_update_config(args, 'set', compute_set_config_fn)
    end
    local success, response = pcall(setter)
-   if success then return response else  return {status=1, error=response} end
+   if success then return response else return {status=1, error=response} end
 end
 
 function Leader:rpc_add_config (args)
@@ -542,9 +542,9 @@ function Leader:rpc_get_state (args)
       local printer = path_printer_for_schema_by_name(self.schema_name, args.path)
       local s = {}
       for _, follower in pairs(self.followers) do
-            for k,v in pairs(state.show_state(self.schema_name, follower.pid, args.path)) do
+         for k,v in pairs(state.show_state(self.schema_name, follower.pid, args.path)) do
             s[k] = v
-            end
+         end
       end
       return {state=printer(s, yang.string_output_file())}
    end

--- a/src/lib/yang/snabb-config-leader-v1.yang
+++ b/src/lib/yang/snabb-config-leader-v1.yang
@@ -7,9 +7,18 @@ module snabb-config-leader-v1 {
   description
    "RPC interface for ConfigLeader Snabb app.";
 
+  revision 2016-12-20 {
+    description "Add basic error reporting.";
+  }
+
   revision 2016-11-12 {
     description
      "Initial revision.";
+  }
+
+  grouping error-reporting {
+    leaf status { type uint8; default 0; }
+    leaf error { type string; }
   }
 
   rpc describe {
@@ -31,6 +40,7 @@ module snabb-config-leader-v1 {
       leaf path { type string; default "/"; }
     }
     output {
+      uses error-reporting;
       leaf config { type string; }
     }
   }
@@ -42,6 +52,9 @@ module snabb-config-leader-v1 {
       leaf path { type string; default "/"; }
       leaf config { type string; mandatory true; }
     }
+    output {
+      uses error-reporting;
+    }
   }
 
   rpc add-config {
@@ -51,6 +64,9 @@ module snabb-config-leader-v1 {
       leaf path { type string; mandatory true; }
       leaf config { type string; mandatory true; }
     }
+    output {
+      uses error-reporting;
+    }
   }
 
   rpc remove-config {
@@ -58,6 +74,9 @@ module snabb-config-leader-v1 {
       leaf schema { type string; mandatory true; }
       leaf revision { type string; }
       leaf path { type string; mandatory true; }
+    }
+    output {
+      uses error-reporting;
     }
   }
 
@@ -68,6 +87,7 @@ module snabb-config-leader-v1 {
       leaf path { type string; default "/"; }
     }
     output {
+      uses error-reporting;
       leaf state { type string; }
     }
   }
@@ -76,6 +96,9 @@ module snabb-config-leader-v1 {
     input {
       leaf schema { type string; mandatory true; }
       leaf revision { type string; }
+    }
+    output {
+      uses error-reporting;
     }
   }
 }

--- a/src/program/config/add/add.lua
+++ b/src/program/config/add/add.lua
@@ -13,5 +13,5 @@ function run(args)
         config = common.serialize_config(
            args.value, args.schema_name, args.path) })
    -- The reply is empty.
-   main.exit(0)
+   common.print_and_exit(response)
 end

--- a/src/program/config/common.lua
+++ b/src/program/config/common.lua
@@ -141,3 +141,12 @@ function call_leader(instance_id, method, args)
    socket:close()
    return parse_reply(reply)
 end
+
+function print_and_exit(response, response_prop)
+   if response.error then
+      print(response.error)
+   elseif response_prop then
+      print(response[response_prop])
+   end
+   main.exit(response.status)
+end

--- a/src/program/config/get/get.lua
+++ b/src/program/config/get/get.lua
@@ -9,6 +9,5 @@ function run(args)
       args.instance_id, 'get-config',
       { schema = args.schema_name, revision = args.revision_date,
         path = args.path })
-   print(response.config)
-   main.exit(0)
+   common.print_and_exit(response, "config")
 end

--- a/src/program/config/get_state/get_state.lua
+++ b/src/program/config/get_state/get_state.lua
@@ -4,11 +4,10 @@ module(..., package.seeall)
 local common = require("program.config.common")
 
 function run(args)
-   args = common.parse_command_line(args, {command='get-state', with_path=true})
-    local response = common.call_leader(
-      args.instance_id, 'get-state',
+	args = common.parse_command_line(args, {command='get-state', with_path=true})
+	local response = common.call_leader(
+   	args.instance_id, 'get-state',
       { schema = args.schema_name, revision = args.revision_date,
         path = args.path })
-   print(response.state)
-   main.exit(0)
+	common.print_and_exit(response, "state")
 end

--- a/src/program/config/load/load.lua
+++ b/src/program/config/load/load.lua
@@ -11,5 +11,5 @@ function run(args)
       { schema = args.schema_name, revision = args.revision_date,
         config = common.serialize_config(args.config, args.schema_name) })
    -- The reply is empty.
-   main.exit(0)
+   common.print_and_exit(response)
 end

--- a/src/program/config/remove/remove.lua
+++ b/src/program/config/remove/remove.lua
@@ -11,5 +11,5 @@ function run(args)
       { schema = args.schema_name, revision = args.revision_date,
         path = args.path })
    -- The reply is empty.
-   main.exit(0)
+   common.print_and_exit(response)
 end

--- a/src/program/config/set/set.lua
+++ b/src/program/config/set/set.lua
@@ -13,5 +13,5 @@ function run(args)
         config = common.serialize_config(
            args.value, args.schema_name, args.path) })
    -- The reply is empty.
-   main.exit(0)
+   common.print_and_exit(response)
 end


### PR DESCRIPTION
This adds basic error reporting to the `snabb config` commands. If an error occurred, you used to see a long meaningless traceback with a `short read` error. This now catches any error created in the config process and sends it back to the config command to display with an appropriate error code.

This version can be seen by deliberately creating an error, examples of these would be:

**get command**: getting a non-existent path e.g. `/snabb-softwire/binding-table/br`
**get-state command**: getting a non-existent path e.g. `/softwire-state/non-existent-counter`
**add command**: adding a softwire which has the same keys as an existing one.
**remove command**: removing a non-existent softwire

_certain commands are difficult to produce errors with should as `set` as they do almost all their validation inside the config command so giving it invalid data will likely be caught at this stage._

This will give the user of the command more immediate feedback and hopefully help them correct the error (presuming it's not a bug).