### PR TITLE
Remove yang padding node

### DIFF
--- a/src/apps/lwaftr/binding_table.lua
+++ b/src/apps/lwaftr/binding_table.lua
@@ -77,7 +77,6 @@ psid_map_value_t = ffi.typeof[[
 softwire_key_t = ffi.typeof[[
    struct {
       uint32_t ipv4;       // Public IPv4 address of this softwire (host-endian).
-      uint16_t padding;    // Zeroes.
       uint16_t psid;       // Port set ID.
    } __attribute__((packed))
 ]]

--- a/src/lib/yang/snabb-softwire-v1.yang
+++ b/src/lib/yang/snabb-softwire-v1.yang
@@ -327,7 +327,7 @@ module snabb-softwire-v1 {
       }
 
       list softwire {
-        key "ipv4 psid padding";
+        key "ipv4 psid";
 
         leaf ipv4 {
           type inet:ipv4-address;

--- a/src/lib/yang/snabb-softwire-v1.yang
+++ b/src/lib/yang/snabb-softwire-v1.yang
@@ -343,13 +343,6 @@ module snabb-softwire-v1 {
            "Port set ID.";
         }
 
-        leaf padding {
-          type uint16 { range 0..0; }
-          default 0;
-          description
-           "Reserved bytes.";
-        }
-
         leaf br {
           type uint32;
           default 1;


### PR DESCRIPTION
Based on https://github.com/Igalia/snabb/pull/679/files by Kristian Larsson.
His rationale: 'pyang failed on this leaf since a range of 0..0 is not allowed'