### PR TITLE
Salt ctable hashing

### DIFF
--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -12,7 +12,7 @@ local ctable = require('lib.ctable')
 local cltable = require('lib.cltable')
 
 local MAGIC = "yangconf"
-local VERSION = 0x00002000
+local VERSION = 0x00003000
 
 local header_t = ffi.typeof([[
 struct {


### PR DESCRIPTION
This should avoid quadratic behaviour when copying ctables.
Fixes https://github.com/Igalia/snabb/issues/654
Note that this serializes the salt; loads are a raw slurp that does not go
quadratic, and must share salt. The issue is only when copying a ctable.