### PR TITLE
Parse empty string

### DIFF
--- a/src/lib/yang/parser.lua
+++ b/src/lib/yang/parser.lua
@@ -122,8 +122,8 @@ function Parser:skip_whitespace()
       if self:check("*") then
          self:skip_c_comment()
       else
-	 self:consume("/")
-	 self:take_while('[^\n]')
+         self:consume("/")
+         self:take_while('[^\n]')
       end
       self:take_while('%s')
    end
@@ -154,21 +154,21 @@ function Parser:parse_qstring(quote)
       result = result..self:take_while("[^"..terminators.."]")
       if self:check(quote) then break end
       if self:check("\n") then
-	 while self.column < start_column do
-	    if not self:check(" ") and not self:check("\t") then break end
-	 end
-	 result = result.."\n"
-	 if self.column > start_column then
-	    result = result..string.rep(" ", self.column-start_column)
-	 end
+         while self.column < start_column do
+            if not self:check(" ") and not self:check("\t") then break end
+         end
+         result = result.."\n"
+         if self.column > start_column then
+            result = result..string.rep(" ", self.column-start_column)
+         end
       elseif self:check("\\") then
-	 if self:check("n") then result = result.."\n"
-	 elseif self:check("t") then result = result.."\t"
-	 elseif self:check('"') then result = result..'"'
-	 elseif self:check("\\") then result = result.."\\"
-	 else
-	    result = result.."\\"
-	 end
+         if self:check("n") then result = result.."\n"
+         elseif self:check("t") then result = result.."\t"
+         elseif self:check('"') then result = result..'"'
+         elseif self:check("\\") then result = result.."\\"
+         else
+            result = result.."\\"
+         end
 
       end
    end
@@ -232,7 +232,7 @@ function Parser:parse_statement_list()
    while true do
       self:skip_whitespace()
       if self:is_eof() or self:peek() == "}" then
-	 break
+         break
       end
       table.insert(statements, self:parse_statement())
    end
@@ -399,9 +399,9 @@ function selftest()
    test_module("type/** hellooo */string;", {{keyword="type", argument="string"}})
    test_module('type "hello\\pq";', {{keyword="type", argument="hello\\pq"}})
    test_module(lines("leaf port {", "type number;", "}"), {{keyword="leaf",
-	argument="port", statements={{keyword="type", argument="number"}}}})
+   argument="port", statements={{keyword="type", argument="number"}}}})
    test_module(lines("leaf port {", "type;", "}"), {{keyword="leaf",
-	argument="port", statements={{keyword="type"}}}})
+   argument="port", statements={{keyword="type"}}}})
 
    parse(require('lib.yang.ietf_inet_types_yang'))
    parse(require('lib.yang.ietf_yang_types_yang'))

--- a/src/lib/yang/parser.lua
+++ b/src/lib/yang/parser.lua
@@ -145,7 +145,6 @@ end
 
 function Parser:parse_qstring(quote)
    local start_column = self.column
-   self:check(quote)
    local terminators = "\n"..quote
    if quote == '"' then terminators = terminators.."\\" end
 
@@ -398,6 +397,7 @@ function selftest()
    test_module("// foo bar;\nleaf port;", {{keyword="leaf", argument="port"}})
    test_module("type/** hellooo */string;", {{keyword="type", argument="string"}})
    test_module('type "hello\\pq";', {{keyword="type", argument="hello\\pq"}})
+   test_module('description "";', {{keyword="description"}})
    test_module(lines("leaf port {", "type number;", "}"), {{keyword="leaf",
    argument="port", statements={{keyword="type", argument="number"}}}})
    test_module(lines("leaf port {", "type;", "}"), {{keyword="leaf",

--- a/src/lib/yang/parser.lua
+++ b/src/lib/yang/parser.lua
@@ -168,7 +168,6 @@ function Parser:parse_qstring(quote)
          else
             result = result.."\\"
          end
-
       end
    end
    self:check(quote)
@@ -177,7 +176,7 @@ function Parser:parse_qstring(quote)
    if not self:check("+") then return result end
    self:skip_whitespace()
 
-   -- Strings can be concaternated together with a +
+   -- Strings can be concatenated together with a +
    if self:check("'") then
       return result..self:parse_qstring("'")
    elseif self:check('"') then


### PR DESCRIPTION
There's an error parsing a qstring that is empty. For instance:

```
module ietf-alarms-x733 {
    typedef event-type  {
        type enumeration {
            enum other {
                value 1;
                description
                    "";
            }
        }
    }
}
```

The parser gets stuck in an infinite loop. The reason is that there's an extra `self:check` in `parse_qstring`. Function `check` moves the cursor one position if its argument matches. Since the opening quote was already consumed before calling `parse_qstring`, the extra `check` call consumes the closing quote. The extra `check` call was harmless if the string was non-empty since the cursor doesn't move forward.