### PR TITLE
Remove mandatory statement for list keys

### DIFF
--- a/src/lib/yang/snabb-softwire-v1.yang
+++ b/src/lib/yang/snabb-softwire-v1.yang
@@ -276,7 +276,6 @@ module snabb-softwire-v1 {
 
         leaf addr {
           type inet:ipv4-address;
-          mandatory true;
           description
            "Public IPv4 address managed by the lwAFTR.";
         }
@@ -331,14 +330,12 @@ module snabb-softwire-v1 {
 
         leaf ipv4 {
           type inet:ipv4-address;
-          mandatory true;
           description
            "Public IPv4 address of the softwire.";
         }
 
         leaf psid {
           type uint16;
-          mandatory true;
           description
            "Port set ID.";
         }


### PR DESCRIPTION
Leafs that are part of a list key are implicitly mandatory,

The patch also check a leaf that is part of a key doesn't occur more than once.