### PR TITLE
Fix typo(?) in `snabb config` README

### DIFF
--- a/src/program/config/README.md
+++ b/src/program/config/README.md
@@ -232,7 +232,7 @@ Using `snabb config load` has the advantage that any configuration
 error has a corresponding source location.
 
 `snabb config` can also remove part of a configuration, but only on
-configuration that corresponds to YANG schema `leaf` or `leaf-list`
+configuration that corresponds to YANG schema `list` or `leaf-list`
 nodes:
 
 ```


### PR DESCRIPTION
Fixes what I suspect is a typo in the README.