### PR TITLE
Respond to ping6 packets in on-a-stick mode

### DIFF
--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -121,12 +121,15 @@ function parse_args(args)
    end
 end
 
--- Requires a V4V6 splitter iff:
---   Always when running in on-a-stick mode, except if v4_vlan_tag != v6_vlan_tag.
+-- Requires a V4V6 splitter if running in on-a-stick mode and VLAN tag values
+-- are the same for the internal and external interfaces.
 local function requires_splitter (opts, conf)
-   if not opts["on-a-stick"] then return false end
-   if not conf.vlan_tagging then return true end
-   return conf.v4_vlan_tag == conf.v6_vlan_tag
+   if opts["on-a-stick"] then
+      local internal_interface = conf.softwire_config.internal_interface
+      local external_interface = conf.softwire_config.external_interface
+      return internal_interface.vlan_tag == external_interface.vlan_tag
+   end
+   return false
 end
 
 function run(args)

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -215,7 +215,7 @@ function load_on_a_stick(c, conf, args)
          pciaddr = pciaddr,
          vmdq=internal_interface.vlan_tag,
          vlan=internal_interface.vlan_tag,
-         macaddr = ethernet:ntop(conf.internal_interface.mac)})
+         macaddr = ethernet:ntop(internal_interface.mac)})
 
       link_source(c, v4_nic_name..'.tx', v6_nic_name..'.tx')
       link_sink(c, v4_nic_name..'.rx', v6_nic_name..'.rx')

--- a/src/program/lwaftr/tests/data/lwaftr-vlan.conf
+++ b/src/program/lwaftr/tests/data/lwaftr-vlan.conf
@@ -1,0 +1,49 @@
+softwire-config {
+  binding-table {
+    br-address fc00::100;
+    psid-map {
+      addr 193.5.1.100;
+      end-addr 193.5.63.101;
+      psid-length 6;
+      shift 10;
+    }
+    softwire {
+      ipv4 193.5.17.1;
+      psid 44;
+      b4-ipv6 fc00:1:2:3:4:5:3:d84c;
+    }
+  }
+  external-interface {
+    allow-incoming-icmp false;
+    error-rate-limiting {
+      packets 600000;
+    }
+    generate-icmp-errors false;
+    ip 10.0.1.1;
+    mac 02:aa:aa:aa:aa:aa;
+    next-hop {
+      mac 02:99:99:99:99:99;
+    }
+    reassembly {
+      max-fragments-per-packet 40;
+    }
+    vlan-tag 164;
+  }
+  internal-interface {
+    allow-incoming-icmp false;
+    error-rate-limiting {
+      packets 600000;
+    }
+    generate-icmp-errors false;
+    ip fe80::100;
+    mac 02:aa:aa:aa:aa:aa;
+    mtu 9500;
+    next-hop {
+      mac 02:99:99:99:99:99;
+    }
+    reassembly {
+      max-fragments-per-packet 40;
+    }
+    vlan-tag 125;
+  }
+}

--- a/src/program/lwaftr/tests/hw/selftest.sh
+++ b/src/program/lwaftr/tests/hw/selftest.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-./program/lwaftr/tests/hw/test_ping_on_a_stick.sh

--- a/src/program/lwaftr/tests/hw/selftest.sh
+++ b/src/program/lwaftr/tests/hw/selftest.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./program/lwaftr/tests/hw/test_ping_on_a_stick.sh

--- a/src/program/lwaftr/tests/hw/test_ping_on_a_stick.sh
+++ b/src/program/lwaftr/tests/hw/test_ping_on_a_stick.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+SKIPPED_CODE=43
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+if [[ -z "$SNABB_PCI0" ]]; then
+    echo "SNABB_PCI0 not defined"
+    exit $SKIPPED_CODE
+fi
+
+if [[ -z "$SNABB_PCI1" ]]; then
+    echo "SNABB_PCI1 not defined"
+    exit $SKIPPED_CODE
+fi
+
+function fatal {
+    local msg=$1
+    echo "Error: $msg"
+    exit 1
+}
+
+function iface_by_pciaddr {
+    local pciaddr=$1
+    echo $(lshw -c network -businfo | grep "pci@$pciaddr" | awk '{print $2}')
+}
+
+function bind_card {
+    local pciaddr=$1
+
+    # Check is bound.
+    if [[ -L "/sys/bus/pci/drivers/ixgbe/$pciaddr" ]]; then
+        echo $(iface_by_pciaddr $pciaddr)
+    fi
+
+    # Bind card and return iface name.
+    echo $pciaddr | sudo tee /sys/bus/pci/drivers/ixgbe/bind &> /dev/null
+    if [[ $? -eq 0 ]]; then
+        iface=$(ls /sys/bus/pci/devices/$pciaddr/net)
+        echo $iface
+    fi
+}
+
+function test_ping_to_internal_interface {
+    local out=$(ping6 -c 1 -I "$IFACE.v6" "$INTERNAL_IP")
+    local count=$(echo "$out" | grep -o -c " 0% packet loss")
+    if [[ $count -eq 1 ]]; then
+        echo "Success: Ping to internal interface"
+    else
+        fatal "Couldn't ping to internal interface"
+    fi
+}
+
+function test_ping_to_external_interface {
+    local out=$(ping -c 1 -I "$IFACE.v4" "$EXTERNAL_IP")
+    local count=$(echo "$out" | grep -o -c " 0% packet loss")
+    if [[ $count -eq 1 ]]; then
+        echo "Success: Ping to external interface"
+    else
+        fatal "Couldn't ping to internal interface"
+    fi
+
+}
+
+function cleanup {
+    sudo tmux kill-session -t $lwaftr_session
+    local pids=$(ps aux | grep $SNABB_PCI0 | grep -v grep | awk '{print $2}')
+    for pid in ${pids[@]}; do
+        kill $pid
+    done
+}
+
+trap cleanup EXIT HUP INT QUIT TERM
+
+LWAFTR_CONF=lwaftr-migrated.conf
+EXTERNAL_IP=10.0.1.1
+INTERNAL_IP=fe80::100
+IPV4_ADDRESS=10.0.1.2/24
+IPV6_ADDRESS=fe80::101/64
+VLAN_V4_TAG=164
+VLAN_V6_TAG=125
+
+# Bind SNABB_PCI1 to kernel.
+IFACE=$(bind_card $SNABB_PCI1)
+if [[ -z "$IFACE" ]]; then
+    fatal "Couldn't bind card $SNABB_PCI1"
+else
+    ip li set up dev $IFACE
+    sleep 1
+fi
+
+# Run lwAFTR in on-a-stick mode.
+lwaftr_session=lwaftr-session-$$
+tmux new-session -d -n "lwaftr" -s $lwaftr_session "sudo ./snabb lwaftr run --conf $LWAFTR_CONF --on-a-stick $SNABB_PCI0" | tee lwaftr.log
+
+# Create VLAN V4 interface.
+ip li delete "$IFACE.v4" &> /dev/null
+ip link add link $IFACE name "$IFACE.v4" type vlan id $VLAN_V4_TAG
+ip addr add $IPV4_ADDRESS dev "$IFACE.v4" 
+sleep 3
+
+# Create VLAN V6 interface.
+ip li delete "$IFACE.v6" &> /dev/null
+ip link add link $IFACE name "$IFACE.v6" type vlan id $VLAN_V6_TAG
+ip addr add $IPV6_ADDRESS dev "$IFACE.v6" 
+sleep 3
+
+test_ping_to_internal_interface
+test_ping_to_external_interface

--- a/src/program/lwaftr/tests/hw/test_ping_on_a_stick.sh
+++ b/src/program/lwaftr/tests/hw/test_ping_on_a_stick.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# set -x
+
 SKIPPED_CODE=43
 
 if [[ $EUID -ne 0 ]]; then
@@ -75,7 +77,7 @@ function cleanup {
 
 trap cleanup EXIT HUP INT QUIT TERM
 
-LWAFTR_CONF=lwaftr-migrated.conf
+LWAFTR_CONF=program/lwaftr/tests/data/lwaftr-vlan.conf
 EXTERNAL_IP=10.0.1.1
 INTERNAL_IP=fe80::100
 IPV4_ADDRESS=10.0.1.2/24


### PR DESCRIPTION
Fixes #709.

The lwAFTR was ignoring VLAN tag settings when running in on-a-stick mode. That can be inferred from #709 stacktrace:

```
apps/lwaftr/ipv6_apps.lua:145: Could not resolve IPv6 address: 2003:1b0b:fffd:831::1
stack traceback:
	core/main.lua:149: in function <core/main.lua:147>
```

To confirm that, I run a ping6 test with VLAN tags to the lwAFTR in on-a-stick mode. Indeed, there were no replies. 

The problem was that a function necessary for VLAN set up in on-a-stick mode was using the former configuration naming. Fixed.