### PR TITLE
Remove br addresses

### DIFF
--- a/src/apps/lwaftr/binding_table.lua
+++ b/src/apps/lwaftr/binding_table.lua
@@ -273,7 +273,7 @@ function selftest()
    local function load_str(str)
       local yang = require('lib.yang.yang')
       local data = require('lib.yang.data')
-      local schema = yang.load_schema_by_name('snabb-softwire-v1')
+      local schema = yang.load_schema_by_name('snabb-softwire-v2')
       local grammar = data.data_grammar_from_schema(schema)
       local subgrammar = assert(grammar.members['softwire-config'])
       local subgrammar = assert(subgrammar.members['binding-table'])
@@ -288,17 +288,17 @@ function selftest()
       br-address 8:9:a:b:c:d:e:f;
       br-address 1E:1:1:1:1:1:1:af;
       br-address 1E:2:2:2:2:2:2:af;
-      softwire { ipv4 178.79.150.233; psid 80; b4-ipv6 127:2:3:4:5:6:7:128; br 1; }
-      softwire { ipv4 178.79.150.233; psid 2300; b4-ipv6 127:11:12:13:14:15:16:128; }
-      softwire { ipv4 178.79.150.233; psid 2700; b4-ipv6 127:11:12:13:14:15:16:128; }
-      softwire { ipv4 178.79.150.233; psid 4660; b4-ipv6 127:11:12:13:14:15:16:128; }
-      softwire { ipv4 178.79.150.233; psid 7850; b4-ipv6 127:11:12:13:14:15:16:128; }
-      softwire { ipv4 178.79.150.233; psid 22788; b4-ipv6 127:11:12:13:14:15:16:128; }
-      softwire { ipv4 178.79.150.233; psid 54192; b4-ipv6 127:11:12:13:14:15:16:128; }
-      softwire { ipv4 178.79.150.15; psid 0; b4-ipv6 127:22:33:44:55:66:77:128; }
-      softwire { ipv4 178.79.150.15; psid 1; b4-ipv6 127:22:33:44:55:66:77:128;}
-      softwire { ipv4 178.79.150.2; psid 7850; b4-ipv6 127:24:35:46:57:68:79:128; br 2; }
-      softwire { ipv4 178.79.150.3; psid 4; b4-ipv6 127:14:25:36:47:58:69:128; br 3; }
+      softwire { ipv4 178.79.150.233; psid 80; b4-ipv6 127:2:3:4:5:6:7:128; br-address 8:9:a:b:c:d:e:f; }
+      softwire { ipv4 178.79.150.233; psid 2300; b4-ipv6 127:11:12:13:14:15:16:128; br-address 8:9:a:b:c:d:e:f; }
+      softwire { ipv4 178.79.150.233; psid 2700; b4-ipv6 127:11:12:13:14:15:16:128; br-address 8:9:a:b:c:d:e:f; }
+      softwire { ipv4 178.79.150.233; psid 4660; b4-ipv6 127:11:12:13:14:15:16:128; br-address 8:9:a:b:c:d:e:f; }
+      softwire { ipv4 178.79.150.233; psid 7850; b4-ipv6 127:11:12:13:14:15:16:128; br-address 8:9:a:b:c:d:e:f; }
+      softwire { ipv4 178.79.150.233; psid 22788; b4-ipv6 127:11:12:13:14:15:16:128; br-address 8:9:a:b:c:d:e:f; }
+      softwire { ipv4 178.79.150.233; psid 54192; b4-ipv6 127:11:12:13:14:15:16:128; br-address 8:9:a:b:c:d:e:f; }
+      softwire { ipv4 178.79.150.15; psid 0; b4-ipv6 127:22:33:44:55:66:77:128; br-address 8:9:a:b:c:d:e:f; }
+      softwire { ipv4 178.79.150.15; psid 1; b4-ipv6 127:22:33:44:55:66:77:128; br-address 8:9:a:b:c:d:e:f; }
+      softwire { ipv4 178.79.150.2; psid 7850; b4-ipv6 127:24:35:46:57:68:79:128; br-address 1E:1:1:1:1:1:1:af; }
+      softwire { ipv4 178.79.150.3; psid 4; b4-ipv6 127:14:25:36:47:58:69:128; br-address 1E:2:2:2:2:2:2:af; }
    ]])
 
    local ipv4_pton = require('lib.yang.util').ipv4_pton

--- a/src/apps/lwaftr/binding_table.lua
+++ b/src/apps/lwaftr/binding_table.lua
@@ -285,9 +285,6 @@ function selftest()
       psid-map { addr 178.79.150.15; psid-length 4; shift 12; }
       psid-map { addr 178.79.150.2; psid-length 16; }
       psid-map { addr 178.79.150.3; psid-length 6; }
-      br-address 8:9:a:b:c:d:e:f;
-      br-address 1E:1:1:1:1:1:1:af;
-      br-address 1E:2:2:2:2:2:2:af;
       softwire { ipv4 178.79.150.233; psid 80; b4-ipv6 127:2:3:4:5:6:7:128; br-address 8:9:a:b:c:d:e:f; }
       softwire { ipv4 178.79.150.233; psid 2300; b4-ipv6 127:11:12:13:14:15:16:128; br-address 8:9:a:b:c:d:e:f; }
       softwire { ipv4 178.79.150.233; psid 2700; b4-ipv6 127:11:12:13:14:15:16:128; br-address 8:9:a:b:c:d:e:f; }
@@ -309,20 +306,20 @@ function selftest()
    local function assert_lookup(ipv4, port, ipv6, br)
       local val = assert(lookup(ipv4, port))
       assert(ffi.C.memcmp(ipv6_protocol:pton(ipv6), val.b4_ipv6, 16) == 0)
-      assert(val.br == br)
+      assert(ffi.C.memcmp(ipv6_protocol:pton(br), val.br_address, 16) == 0)
    end
-   assert_lookup('178.79.150.233', 80, '127:2:3:4:5:6:7:128', 1)
+   assert_lookup('178.79.150.233', 80, '127:2:3:4:5:6:7:128', '8:9:a:b:c:d:e:f')
    assert(lookup('178.79.150.233', 79) == nil)
    assert(lookup('178.79.150.233', 81) == nil)
-   assert_lookup('178.79.150.15', 80, '127:22:33:44:55:66:77:128', 1)
-   assert_lookup('178.79.150.15', 4095, '127:22:33:44:55:66:77:128', 1)
-   assert_lookup('178.79.150.15', 4096, '127:22:33:44:55:66:77:128', 1)
-   assert_lookup('178.79.150.15', 8191, '127:22:33:44:55:66:77:128', 1)
+   assert_lookup('178.79.150.15', 80, '127:22:33:44:55:66:77:128', '8:9:a:b:c:d:e:f')
+   assert_lookup('178.79.150.15', 4095, '127:22:33:44:55:66:77:128', '8:9:a:b:c:d:e:f')
+   assert_lookup('178.79.150.15', 4096, '127:22:33:44:55:66:77:128', '8:9:a:b:c:d:e:f')
+   assert_lookup('178.79.150.15', 8191, '127:22:33:44:55:66:77:128', '8:9:a:b:c:d:e:f')
    assert(lookup('178.79.150.15', 8192) == nil)
-   assert_lookup('178.79.150.2', 7850, '127:24:35:46:57:68:79:128', 2)
+   assert_lookup('178.79.150.2', 7850, '127:24:35:46:57:68:79:128', '1E:1:1:1:1:1:1:af')
    assert(lookup('178.79.150.3', 4095) == nil)
-   assert_lookup('178.79.150.3', 4096, '127:14:25:36:47:58:69:128', 3)
-   assert_lookup('178.79.150.3', 5119, '127:14:25:36:47:58:69:128', 3)
+   assert_lookup('178.79.150.3', 4096, '127:14:25:36:47:58:69:128', '1E:2:2:2:2:2:2:af')
+   assert_lookup('178.79.150.3', 5119, '127:14:25:36:47:58:69:128', '1E:2:2:2:2:2:2:af')
    assert(lookup('178.79.150.3', 5120) == nil)
    assert(lookup('178.79.150.4', 7850) == nil)
 
@@ -343,21 +340,6 @@ function selftest()
          i = i + 1
       end
       assert(i == #psid_map_iter + 1)
-   end
-
-   do
-      local br_address_iter = {
-         '8:9:a:b:c:d:e:f',
-         '1E:1:1:1:1:1:1:af',
-         '1E:2:2:2:2:2:2:af'
-      }
-      local i = 1
-      for ipv6 in map:iterate_br_addresses() do
-         local expected = ipv6_protocol:pton(br_address_iter[i])
-         assert(ffi.C.memcmp(expected, ipv6, 16) == 0)
-         i = i + 1
-      end
-      assert(i == #br_address_iter + 1)
    end
 
    print('ok')

--- a/src/apps/lwaftr/conf.lua
+++ b/src/apps/lwaftr/conf.lua
@@ -11,7 +11,7 @@ function load_lwaftr_config(filename)
    -- v4_vlan_tag=required_if('v4_vlan_tag', 'vlan_tagging'),
    -- v6_vlan_tag=required_if('v6_vlan_tag', 'vlan_tagging'),
    return yang.load_configuration(filename,
-                                  {schema_name='snabb-softwire-v1'})
+                                  {schema_name='snabb-softwire-v2'})
 end
 
 function selftest()

--- a/src/apps/lwaftr/dump.lua
+++ b/src/apps/lwaftr/dump.lua
@@ -7,7 +7,7 @@ local CONF_FILE_DUMP = "/tmp/lwaftr-%d.conf"
 function dump_configuration(lwstate)
    local dest = (CONF_FILE_DUMP):format(os.time())
    print(("Dump lwAFTR configuration: '%s'"):format(dest))
-   yang.print_data_for_schema_by_name('snabb-softwire-v1', lwstate.conf,
+   yang.print_data_for_schema_by_name('snabb-softwire-v2', lwstate.conf,
                                       io.open(dest, 'w'))
 end
 

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -268,7 +268,7 @@ end
 
 -- The following two methods are called by apps.config.follower in
 -- reaction to binding table changes, via
--- apps/config/support/snabb-softwire-v1.lua.
+-- apps/config/support/snabb-softwire-v2.lua.
 function LwAftr:add_softwire_entry(entry_blob)
    self.binding_table:add_softwire_entry(entry_blob)
 end

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -237,7 +237,7 @@ local function init_transmit_icmpv4_reply (rate_limiting)
    end
 end
 
-LwAftr = { yang_schema = 'snabb-softwire-v1' }
+LwAftr = { yang_schema = 'snabb-softwire-v2' }
 
 function LwAftr:new(conf)
    if conf.debug then debug = true end

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -1028,7 +1028,7 @@ function selftest()
 
    load_schema_by_name('ietf-yang-types')
    load_schema_by_name('ietf-softwire')
-   load_schema_by_name('snabb-softwire-v1')
+   load_schema_by_name('snabb-softwire-v2')
 
    local inherit_config_schema = [[module config-inheritance {
       namespace cs;

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -1,0 +1,730 @@
+module snabb-softwire-v1 {
+  namespace snabb:lwaftr;
+  prefix softwire;
+
+  import ietf-inet-types { prefix inet; }
+  import ietf-yang-types { prefix yang; }
+
+  organization "Igalia, S.L.";
+  contact "Jessica Tallon <tsyesika@igalia.com>";
+  description
+   "Configuration for the Snabb Switch lwAFTR.";
+
+  revision 2016-11-04 {
+    description
+     "Initial revision.";
+  }
+
+  container softwire-config {
+    description
+     "Configuration for Snabb lwaftr.";
+
+    grouping traffic-filters {
+      description
+       "Ingress and egress filters describing the set of packets
+        that should be allowed to pass, as pflang filters.  pflang
+        is the language of tcpdump, libpcap and other tools.  Note
+        that if VLAN tagging is enabled, the filters run on packets
+        after VLAN tags have been stripped off.";
+      leaf ingress-filter {
+        type string;
+        description
+         "Filter for incoming traffic.  Packets that do not match
+          the filter will be silently dropped.";
+      }
+      leaf egress-filter {
+        type string;
+        description
+         "Filter for outgoing traffic.  Packets that do not match
+          the filter will be silently dropped.";
+      }
+    }
+
+    grouping icmp-policy {
+      description
+       "The lwAFTR can be configured to allow or drop incoming ICMP
+        messages, and to generate outgoing ICMP error messages or
+        not.";
+
+      leaf allow-incoming-icmp {
+        type boolean;
+        default true;
+        description
+         "Whether to allow incoming ICMP packets.";
+      }
+
+      leaf generate-icmp-errors {
+        type boolean;
+        default true;
+        description
+         "Whether to generate outgoing ICMP error messages.";
+      }
+    }
+
+    grouping vlan-tagging {
+      description
+       "802.1Q Ethernet tagging.";
+
+      leaf vlan-tag {
+        type uint16 {
+          range 0..4095;
+        }
+        description
+         "802.1Q Ethernet VLAN tag for this interface.";
+      }
+    }
+
+    grouping error-rate-limiting {
+      description
+       "These settings limit the rate of ICMP error message
+        transmission.";
+
+      container error-rate-limiting {
+        leaf packets {
+          type uint32;
+          description
+           "The number of ICMP error messages which can be sent within
+            the specified time period.";
+        }
+
+        leaf period {
+          type uint32 { range 1..max; }
+          default 2;
+          description
+           "The time period given in seconds.";
+        }
+      }
+    }
+
+    grouping reassembly {
+      description
+       "These settings limit the resources devoted to reassembling
+        fragmented packets.";
+
+      container reassembly {
+        leaf max-fragments-per-packet {
+          type uint32 { range 1..max; }
+          default 20;
+          description
+           "The maximum number of fragments per reassembled packet.
+            Attempts to reassemble a packet using more fragments than
+            this threshold will fail and the reassembly data will be
+            discarded.";
+        }
+
+        leaf max-packets {
+          type uint32;
+          default 20000;
+          description
+           "The maximum number of concurrent reassembly attempts.  If
+            this limit is reached, an additional reassembly will cause
+            random eviction of an ongoing reassembly. Note that this
+            setting directly affects memory usage; the memory buffer
+            allocated to reassembly is this maximum number of
+            reassemblies times 25 kilobytes each.";
+        }
+      }
+    }
+
+
+
+    container external-interface {
+      description
+       "Configuration for the external, internet-facing IPv4
+        interface.";
+
+      leaf ip {
+        type inet:ipv4-address;
+        mandatory true;
+        description
+         "L3 Address of the internet-facing network interface.  Used
+          when generating error messages and responding to ICMP echo
+          requests.";
+      }
+      leaf mac {
+        type yang:mac-address;
+        mandatory true;
+        description
+         "MAC address of the internet-facing NIC.";
+      }
+      leaf mtu {
+        type uint16;
+        default 1460;
+        description
+         "Maximum packet size to send on the IPv4 interface.";
+      }
+
+      uses traffic-filters;
+      uses icmp-policy;
+      uses vlan-tagging;
+      uses error-rate-limiting;
+      uses reassembly;
+
+      container next-hop {
+        leaf ip {
+          type inet:ipv4-address;
+          description
+           "IPv4 address of the next hop for the internet-facing NIC.
+            The lwAFTR will resolve this to a MAC address using ARP.";
+        }
+        leaf mac {
+          type yang:mac-address;
+          description
+           "Statically configured MAC address of the next hop for the
+            internet-facing NIC.";
+        }
+      }
+    }
+
+    container internal-interface {
+      description
+       "Configuration for the internal IPv6 interface.";
+
+      leaf ip {
+        type inet:ipv6-address;
+        mandatory true;
+        description
+         "L3 Address of the internal-facing network interface.  Used
+          when generating error messages and responding to ICMP echo
+          requests.";
+      }
+      leaf mac {
+        type yang:mac-address;
+        mandatory true;
+        description
+         "MAC address of the internal-facing NIC.";
+      }
+      leaf mtu {
+        type uint16;
+        default 1500;
+        description
+         "Maximum packet size to sent on the IPv6 interface.";
+      }
+
+      uses traffic-filters;
+      uses icmp-policy;
+      uses vlan-tagging;
+      uses error-rate-limiting;
+      uses reassembly;
+
+      container next-hop {
+        leaf ip {
+          type inet:ipv6-address;
+          description
+           "IPv6 address of the next hop for the internal-facing NIC.
+            The lwAFTR will resolve this to a MAC address using NDP.";
+        }
+        leaf mac {
+          type yang:mac-address;
+          description
+           "Statically configured MAC address of the next hop for the
+            internal-facing NIC.";
+        }
+      }
+
+      leaf hairpinning {
+        type boolean;
+        default true;
+        description
+         "Indicates whether to support hairpinning of traffic between
+          two B4s.";
+      }
+    }
+
+    container binding-table {
+      description
+       "A collection of softwires (tunnels), along with a description
+        of the IPv4 and IPv6 addresses handled by the lwAFTR.";
+
+      list psid-map {
+        description
+         "The set of IPv4 addresses managed by the lwAFTR, along with
+          the way in which those IPv4 addresses share ports.  A PSID map
+          entry associates a PSID length, shift, and
+          reserved-ports-bit-count with each IPv4 address served by
+          the lwAFTR.
+
+          The lightweight 4-over-6 architecture supports sharing of
+          IPv4 addresses by partitioning the space of TCP/UDP/ICMP
+          ports into disjoint \"port sets\".  Each softwire associated
+          with an IPv4 address corresponds to a different set of ports
+          on that address.  The way that the ports are partitioned is
+          specified in RFC 7597:  each address has an associated set
+          of parameters that specifies how to compute a \"port set
+          identifier\" (PSID) from a given port.
+
+                               0                   1
+                               0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+                              +-----------+-----------+-------+
+                Ports in      |     A     |    PSID   |   j   |
+             the CE port set  |    > 0    |           |       |
+                              +-----------+-----------+-------+
+                              |  a bits   |  k bits   |m bits |
+
+               Figure 2: Structure of a Port-Restricted Port Field
+
+            Source: http://tools.ietf.org/html/rfc7597#section-5.1
+
+          We find the specification's names to be a bit obtuse, so we
+          refer to them using the following names:
+
+            a bits = reserved-ports-bit-count.
+            k bits = psid-length.
+            m bits = shift.";
+
+        key addr;
+
+        leaf addr {
+          type inet:ipv4-address;
+          mandatory true;
+          description
+           "Public IPv4 address managed by the lwAFTR.";
+        }
+
+        leaf end-addr {
+          type inet:ipv4-address;
+          description
+           "If present, this PSID map entry applies to all addresses
+            between 'addr' and this address, inclusive.";
+        }
+
+        leaf psid-length {
+          type uint8 { range 0..16; }
+          mandatory true;
+          description
+           "The number of bits devoted to the PSID in the port map.
+            If the psid-length is N, then the IPv4 address will be
+            shared 2^N ways.  Note that psid-length, shift, and
+            reserved-ports-bit-count must add up to 16.";
+        }
+
+        leaf shift {
+          type uint8 { range 0..16; }
+          description
+           "Given an incoming port, one can obtain the PSID by
+            shifting the port right by 'shift' bits and then masking
+            off the lowest 'psid-length' bits.  Defaults to 16 -
+            psid-length.  Note that psid-length, shift, and
+            reserved-ports-bit-count must add up to 16.";
+        }
+
+        leaf reserved-ports-bit-count {
+          type uint8 { range 0..16; }
+          default 0;
+          description
+           "Reserve the lowest 2^N ports so that they map to no
+            softwire.  This can be useful to prevent the low 1024
+            ports (for example) from being mapped to customers.  Note
+            that psid-length and shift must add up to less than or
+            equal to 16.";
+        }
+      }
+
+      list softwire {
+        key "ipv4 psid padding";
+
+        leaf ipv4 {
+          type inet:ipv4-address;
+          mandatory true;
+          description
+           "Public IPv4 address of the softwire.";
+        }
+
+        leaf psid {
+          type uint16;
+          mandatory true;
+          description
+           "Port set ID.";
+        }
+
+        leaf padding {
+          type uint16 { range 0..0; }
+          default 0;
+          description
+           "Reserved bytes.";
+        }
+
+        leaf br-address {
+          type inet:ipv6-address;
+          description
+           "The B4-facing address of the lwAFTR for this softwire.";
+        }
+
+        leaf b4-ipv6 {
+          type inet:ipv6-address;
+          mandatory true;
+          description
+           "B4 address.";
+        }
+      }
+    }
+  }
+
+  container softwire-state {
+    description "State data about lwaftr.";
+    config false;
+
+    leaf drop-all-ipv4-iface-bytes {
+      type yang:zero-based-counter64;
+      description
+        "All dropped packets and bytes that came in over IPv4 interfaces,
+         whether or not they actually IPv4 (they only include data about
+         packets that go in/out over the wires, excluding internally generated
+         ICMP packets).";
+    }
+    leaf drop-all-ipv4-iface-packets {
+      type yang:zero-based-counter64;
+      description
+        "All dropped packets and bytes that came in over IPv4 interfaces,
+         whether or not they actually IPv4 (they only include data about
+         packets that go in/out over the wires, excluding internally generated
+         ICMP packets).";
+    }
+    leaf drop-all-ipv6-iface-bytes {
+      type yang:zero-based-counter64;
+      description
+        "All dropped packets and bytes that came in over IPv6 interfaces,
+         whether or not they actually IPv6 (they only include data about packets
+         that go in/out over the wires, excluding internally generated ICMP
+         packets).";
+    }
+    leaf drop-all-ipv6-iface-packets {
+      type yang:zero-based-counter64;
+      description
+        "All dropped packets and bytes that came in over IPv6 interfaces,
+         whether or not they actually IPv6 (they only include data about packets
+         that go in/out over the wires, excluding internally generated ICMP
+         packets).";
+    }
+    leaf drop-bad-checksum-icmpv4-bytes {
+      type yang:zero-based-counter64;
+      description "ICMPv4 packets dropped because of a bad checksum.";
+    }
+    leaf drop-bad-checksum-icmpv4-packets {
+      type yang:zero-based-counter64;
+      description "ICMPv4 packets dropped because of a bad checksum.";
+    }
+    leaf drop-in-by-policy-icmpv4-bytes {
+      type yang:zero-based-counter64;
+      description "Incoming ICMPv4 packets dropped because of current policy.";
+    }
+    leaf drop-in-by-policy-icmpv4-packets {
+      type yang:zero-based-counter64;
+      description "Incoming ICMPv4 packets dropped because of current policy.";
+    }
+    leaf drop-in-by-policy-icmpv6-bytes {
+      type yang:zero-based-counter64;
+      description "Incoming ICMPv6 packets dropped because of current policy.";
+    }
+    leaf drop-in-by-policy-icmpv6-packets {
+      type yang:zero-based-counter64;
+      description "Incoming ICMPv6 packets dropped because of current policy.";
+    }
+    leaf drop-in-by-rfc7596-icmpv4-bytes {
+      type yang:zero-based-counter64;
+      description
+        "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
+    }
+    leaf drop-in-by-rfc7596-icmpv4-packets {
+      type yang:zero-based-counter64;
+      description
+        "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
+    }
+    leaf drop-ipv4-frag-disabled {
+      type yang:zero-based-counter64;
+      description
+        "If fragmentation is disabled, the only potentially non-zero IPv4
+         fragmentation counter is drop-ipv4-frag-disabled. If fragmentation is
+         enabled, it will always be zero.";
+    }
+    leaf drop-ipv4-frag-invalid-reassembly {
+      type yang:zero-based-counter64;
+      description
+        "Two or more IPv4 fragments were received, and reassembly was started,
+         but was invalid and dropped. Causes include multiple fragments claiming
+         they are the last fragment, overlapping fragment offsets, or the packet
+         was being reassembled from too many fragments (the setting is
+         max_fragments_per_reassembly_packet, and the default is that no packet
+         should be reassembled from more than 40).";
+    }
+    leaf drop-ipv4-frag-random-evicted {
+      type yang:zero-based-counter64;
+      description
+        "Reassembling an IPv4 packet from fragments was in progress, but the
+         configured amount of packets to reassemble at once was exceeded, so one
+         was dropped at random. Consider increasing the setting
+         max_ipv4_reassembly_packets.";
+    }
+    leaf drop-ipv6-frag-disabled {
+      type yang:zero-based-counter64;
+      description
+        "If fragmentation is disabled, the only potentially non-zero IPv6
+         fragmentation counter is drop-ipv6-frag-disabled. If fragmentation is
+         enabled, it will always be zero.";
+    }
+    leaf drop-ipv6-frag-invalid-reassembly {
+      type yang:zero-based-counter64;
+      description
+        "Two or more IPv6 fragments were received, and reassembly was started,
+         but was invalid and dropped. Causes include multiple fragments claiming
+         they are the last fragment, overlapping fragment offsets, or the packet
+         was being reassembled from too many fragments (the setting is
+         max_fragments_per_reassembly_packet, and the default is that no packet
+         should be reassembled from more than 40).";
+    }
+    leaf drop-ipv6-frag-random-evicted {
+      type yang:zero-based-counter64;
+      description
+        "Reassembling an IPv6 packet from fragments was in progress, but the
+        configured amount of packets to reassemble at once was exceeded, so one
+        was dropped at random. Consider increasing the setting
+        max_ipv6_reassembly_packets.";
+    }
+    leaf drop-misplaced-not-ipv4-bytes {
+      type yang:zero-based-counter64;
+      description "Non-IPv4 packets incoming on the IPv4 link.";
+    }
+    leaf drop-misplaced-not-ipv4-packets {
+      type yang:zero-based-counter64;
+      description "Non-IPv4 packets incoming on the IPv4 link.";
+    }
+    leaf drop-misplaced-not-ipv6-bytes {
+      type yang:zero-based-counter64;
+      description "Non-IPv6 packets incoming on IPv6 link.";
+    }
+    leaf drop-misplaced-not-ipv6-packets {
+      type yang:zero-based-counter64;
+      description "Non-IPv6 packets incoming on IPv6 link.";
+    }
+    leaf drop-no-dest-softwire-ipv4-bytes {
+      type yang:zero-based-counter64;
+      description
+        "No matching destination softwire in the binding table; incremented
+         whether or not the reason was RFC7596.";
+    }
+    leaf drop-no-dest-softwire-ipv4-packets {
+      type yang:zero-based-counter64;
+      description
+        "No matching destination softwire in the binding table; incremented
+         whether or not the reason was RFC7596.";
+    }
+    leaf drop-no-source-softwire-ipv6-bytes {
+      type yang:zero-based-counter64;
+      description
+        "No matching source softwire in the binding table; incremented whether
+         or not the reason was RFC7596.";
+    }
+    leaf drop-no-source-softwire-ipv6-packets {
+      type yang:zero-based-counter64;
+      description
+        "No matching source softwire in the binding table; incremented whether
+         or not the reason was RFC7596.";
+    }
+    leaf drop-out-by-policy-icmpv4-packets {
+      type yang:zero-based-counter64;
+      description
+        "Internally generated ICMPv4 error packets dropped because of current
+         policy.";
+    }
+    leaf drop-out-by-policy-icmpv6-packets {
+      type yang:zero-based-counter64;
+      description
+        "Internally generated ICMPv6 packets dropped because of current
+         policy.";
+    }
+    leaf drop-over-mtu-but-dont-fragment-ipv4-bytes {
+      type yang:zero-based-counter64;
+      description
+        "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
+         flag was set.";
+    }
+    leaf drop-over-mtu-but-dont-fragment-ipv4-packets {
+      type yang:zero-based-counter64;
+      description
+        "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
+         flag was set.";
+    }
+    leaf drop-over-rate-limit-icmpv6-bytes {
+      type yang:zero-based-counter64;
+      description
+        "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
+    }
+    leaf drop-over-rate-limit-icmpv6-packets {
+      type yang:zero-based-counter64;
+      description
+        "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
+    }
+    leaf drop-over-time-but-not-hop-limit-icmpv6-bytes {
+      type yang:zero-based-counter64;
+      description
+        "Packet's time limit was exceeded, but the hop limit was not.";
+    }
+    leaf drop-over-time-but-not-hop-limit-icmpv6-packets {
+      type yang:zero-based-counter64;
+      description
+        "Packet's time limit was exceeded, but the hop limit was not.";
+    }
+    leaf drop-too-big-type-but-not-code-icmpv6-bytes {
+      type yang:zero-based-counter64;
+      description
+        "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
+         acceptable one for this type.";
+    }
+    leaf drop-too-big-type-but-not-code-icmpv6-packets {
+      type yang:zero-based-counter64;
+      description
+        "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
+         acceptable one for this type.";
+    }
+    leaf drop-ttl-zero-ipv4-bytes {
+      type yang:zero-based-counter64;
+      description "IPv4 packets dropped because their TTL was zero.";
+    }
+    leaf drop-ttl-zero-ipv4-packets {
+      type yang:zero-based-counter64;
+      description "IPv4 packets dropped because their TTL was zero.";
+    }
+    leaf drop-unknown-protocol-icmpv6-bytes {
+      type yang:zero-based-counter64;
+      description "Packets with an unknown ICMPv6 protocol.";
+    }
+    leaf drop-unknown-protocol-icmpv6-packets {
+      type yang:zero-based-counter64;
+      description "Packets with an unknown ICMPv6 protocol.";
+    }
+    leaf drop-unknown-protocol-ipv6-bytes {
+      type yang:zero-based-counter64;
+      description "Packets with an unknown IPv6 protocol.";
+    }
+    leaf drop-unknown-protocol-ipv6-packets {
+      type yang:zero-based-counter64;
+      description "Packets with an unknown IPv6 protocol.";
+    }
+    leaf hairpin-ipv4-bytes {
+      type yang:zero-based-counter64;
+      description "IPv4 packets going to a known b4 (hairpinned).";
+    }
+    leaf hairpin-ipv4-packets {
+      type yang:zero-based-counter64;
+      description "IPv4 packets going to a known b4 (hairpinned).";
+    }
+    leaf in-ipv4-bytes {
+      type yang:zero-based-counter64;
+      description "All valid outgoing IPv4 packets.";
+    }
+    leaf in-ipv4-frag-needs-reassembly {
+      type yang:zero-based-counter64;
+      description "An IPv4 fragment was received.";
+    }
+    leaf in-ipv4-frag-reassembled {
+      type yang:zero-based-counter64;
+      description "A packet was successfully reassembled from IPv4 fragments.";
+    }
+    leaf in-ipv4-frag-reassembly-unneeded {
+      type yang:zero-based-counter64;
+      description
+        "An IPv4 packet which was not a fragment was received - consequently,
+         it did not need to be reassembled. This should be the usual case.";
+    }
+    leaf in-ipv4-packets {
+      type yang:zero-based-counter64;
+      description "All valid outgoing IPv4 packets.";
+    }
+    leaf in-ipv6-bytes {
+      type yang:zero-based-counter64;
+      description "All valid outgoing IPv4 packets.";
+    }
+    leaf in-ipv6-frag-needs-reassembly {
+      type yang:zero-based-counter64;
+      description "An IPv6 fragment was received.";
+    }
+    leaf in-ipv6-frag-reassembled {
+      type yang:zero-based-counter64;
+      description "A packet was successfully reassembled from IPv6 fragments.";
+    }
+    leaf in-ipv6-frag-reassembly-unneeded {
+      type yang:zero-based-counter64;
+      description
+        "An IPv6 packet which was not a fragment was received - consequently, it
+         did not need to be reassembled. This should be the usual case.";
+    }
+    leaf in-ipv6-packets {
+      type yang:zero-based-counter64;
+      description "All valid outgoing IPv4 packets.";
+    }
+    leaf ingress-packet-drops {
+      type yang:zero-based-counter64;
+      description "Packets dropped due to ingress filters.";
+    }
+    leaf memuse-ipv4-frag-reassembly-buffer {
+      type yang:zero-based-counter64;
+      description
+        "The amount of memory being used by the statically sized data structure
+         for reassembling IPv4 fragments. This is directly proportional to the
+        setting max_ipv4_reassembly_packets.";
+    }
+    leaf memuse-ipv6-frag-reassembly-buffer {
+      type yang:zero-based-counter64;
+      description
+        "The amount of memory being used by the statically sized data structure
+         for reassembling IPv6 fragments. This is directly proportional to the
+         setting max_ipv6_reassembly_packets.";
+    }
+    leaf out-icmpv4-bytes {
+      type yang:zero-based-counter64;
+      description "Internally generated ICMPv4 packets.";
+    }
+    leaf out-icmpv4-packets {
+      type yang:zero-based-counter64;
+      description "Internally generated ICMPv4 packets.";
+    }
+    leaf out-icmpv6-bytes {
+      type yang:zero-based-counter64;
+      description "Internally generted ICMPv6 error packets.";
+    }
+    leaf out-icmpv6-packets {
+      type yang:zero-based-counter64;
+      description "Internally generted ICMPv6 error packets.";
+    }
+    leaf out-ipv4-bytes {
+      type yang:zero-based-counter64;
+      description "Valid outgoing IPv4 packets.";
+    }
+    leaf out-ipv4-frag {
+      type yang:zero-based-counter64;
+      description
+        "An outgoing packet exceeded the configured IPv4 MTU, so needed to be
+         fragmented. This may happen, but should be unusual.";
+    }
+    leaf out-ipv4-frag-not {
+      type yang:zero-based-counter64;
+      description
+        "An outgoing packet was small enough to pass through unfragmented - this
+         should be the usual case.";
+    }
+    leaf out-ipv4-packets {
+      type yang:zero-based-counter64;
+      description "Valid outgoing IPv4 packets.";
+    }
+    leaf out-ipv6-bytes {
+      type yang:zero-based-counter64;
+      description "All valid outgoing IPv6 packets.";
+    }
+    leaf out-ipv6-frag {
+      type yang:zero-based-counter64;
+      description
+        "An outgoing packet exceeded the configured IPv6 MTU, so needed to be
+        fragmented. This may happen, but should be unusual.";
+    }
+    leaf out-ipv6-frag-not {
+      type yang:zero-based-counter64;
+      description
+        "An outgoing packet was small enough to pass through unfragmented - this
+         should be the usual case.";
+    }
+    leaf out-ipv6-packets {
+      type yang:zero-based-counter64;
+      description "All valid outgoing IPv6 packets.";
+    }
+  }
+}

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -355,6 +355,7 @@ module snabb-softwire-v2 {
 
         leaf br-address {
           type inet:ipv6-address;
+          mandatory true;
           description
            "The B4-facing address of the lwAFTR for this softwire.";
         }

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -1,4 +1,4 @@
-module snabb-softwire-v1 {
+module snabb-softwire-v2 {
   namespace snabb:lwaftr;
   prefix softwire;
 
@@ -13,6 +13,15 @@ module snabb-softwire-v1 {
   revision 2016-11-04 {
     description
      "Initial revision.";
+  }
+
+  revision 2017-01-19 {
+    description
+      "Removal of br-address leaf-list and  br leaf. It adds the
+       addition of br-address binding_table.softwire. This is to
+       make the schema more yang-like. One now only need to specify
+       the br-address on the softwire rather than managing the index's
+       to a leaf-list of them.";
   }
 
   container softwire-config {

--- a/src/program/lwaftr/doc/configuration.md
+++ b/src/program/lwaftr/doc/configuration.md
@@ -2,7 +2,7 @@
 
 The lwAFTR's configuration is modelled by a
 [YANG](https://tools.ietf.org/html/rfc6020) schema,
-[snabb-softwire-v1](../../../lib/yang/snabb-softwire-v1.yang).
+[snabb-softwire-v2](../../../lib/yang/snabb-softwire-v2.yang).
 
 The lwAFTR takes its configuration from the user in the form of a text
 file.  That file's grammar is derived from the YANG schema; see the
@@ -64,35 +64,35 @@ softwire-config {
       max-packets 20000;
     }
   }
-  // Now the binding table!  3 parts: PSID map, BR address table, and
+  // Now the binding table!  3 parts: PSID map, , and
   // softwire set.  See description below for details.
   binding-table {
     psid-map { addr 178.79.150.15; psid-length 4; }
     psid-map { addr 178.79.150.233; psid-length 16; }
     psid-map { addr 178.79.150.2; psid-length 16; }
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 1;
+      br-address 1e:1:1:1:1:1:1:af;
     }
   }
 }
@@ -121,7 +121,7 @@ given *PID* to reload the table.
 ## In-depth configuration explanation
 
 See the embedded descriptions in the
-[snabb-softwire-v1](../../../lib/yang/snabb-softwire-v1.yang) schema
+[snabb-softwire-v2](../../../lib/yang/snabb-softwire-v2.yang) schema
 file.
 
 ## Binding tables
@@ -134,8 +134,8 @@ encapsulated in IPv6 and sent to the AFTR; the AFTR does the reverse.
 The binding table is how the AFTR knows which B4 is associated with
 an incoming packet.
 
-In the Snabb lwAFTR there are three parts of a binding table: the PSID
-info map, the border router (BR) address table, and the softwire map.
+In the Snabb lwAFTR there are two parts of a binding table: the PSID
+info map and the softwire map.
 
 ### PSID info map
 
@@ -165,18 +165,6 @@ just two of them.  Actually it's sufficient to just specify the
 `reserved-ports-bit-count` defaults to 0, and `shift` defaults to `16 -
 psid-length`.
 
-### Border router addresses
-
-Next, the `br-address` clauses define the set of IPv6 addresses to
-associate with the lwAFTR.  These are the "border router" addresses.
-For a usual deployment there will be one main address and possibly some
-additional ones.  For example:
-
-```
-  br-address 8:9:a:b:c:d:e:f;
-  br-address 1E:1:1:1:1:1:1:af;
-  ...
-```
 
 ### Softwires
 
@@ -185,16 +173,9 @@ provision.  Each softwire associates an IPv4 address, a PSID, and a B4
 address.  For example:
 
 ```
-  softwire { ipv4 178.79.150.233; psid 80; b4-ipv6 127:2:3:4:5:6:7:128; }
+  softwire { ipv4 178.79.150.233; psid 80; b4-ipv6 127:2:3:4:5:6:7:128; br-address 8:9:a:b:c:d:e:f }
 ```
 
-By default, a softwire is associated with the first `br-address`
-(`br 0;`).  To associate the tunnel with a different border router,
-specify it by index:
-
-```
-  softwire { ipv4 178.79.150.233; psid 80; b4-ipv6 127:2:3:4:5:6:7:128; aftr 0; }
-```
 
 ## Ingress and egress filters
 

--- a/src/program/lwaftr/generate_binding_table/generate_binding_table.lua
+++ b/src/program/lwaftr/generate_binding_table/generate_binding_table.lua
@@ -41,10 +41,10 @@ local function psid_map(w, params)
    end
 end
 
-local function softwire_entry(v4addr, psid_len, b4)
+local function softwire_entry(v4addr, psid_len, b4 br_address)
    if tonumber(v4addr) then v4addr = to_ipv4_string(v4addr) end
-   return ("  softwire { ipv4 %s; psid %d; b4-ipv6 %s; }"):format(
-      v4addr, psid_len, b4)
+   return ("  softwire { ipv4 %s; psid %d; b4-ipv6 %s; br-address %s; }"):format(
+      v4addr, psid_len, b4, br_address)
 end
 
 local function inc_ipv6(ipv6)
@@ -77,10 +77,12 @@ end
 local function softwires(w, params)
    local v4addr = to_ipv4_u32(params.from_ipv4)
    local b4 = ipv6:pton(params.from_b4)
+   local br_address = ipv6:pton(params.br_address)
    local n = 2^params.psid_len
    for _ = 1, params.num_ips do
       for psid = 1, n-1 do
-         w:ln(softwire_entry(v4addr, psid, ipv6:ntop(b4)))
+         w:ln(softwire_entry(v4addr, psid, ipv6:ntop(b4),
+              ipv6:ntop(br_address))
          b4 = inc_ipv6(b4)
       end
       v4addr = inc_ipv4(v4addr)
@@ -131,12 +133,12 @@ function run(args)
       psid_len = psid_len,
       shift = shift,
    })
-   w:ln("  br-address "..br_address..";")
    softwires(w, {
       from_ipv4 = from_ipv4,
       num_ips = num_ips,
       from_b4 = from_b4,
       psid_len = psid_len,
+      br_address = br_address,
    })
    w:ln("}")
    w:close()

--- a/src/program/lwaftr/generate_binding_table/generate_binding_table.lua
+++ b/src/program/lwaftr/generate_binding_table/generate_binding_table.lua
@@ -41,7 +41,7 @@ local function psid_map(w, params)
    end
 end
 
-local function softwire_entry(v4addr, psid_len, b4 br_address)
+local function softwire_entry(v4addr, psid_len, b4, br_address)
    if tonumber(v4addr) then v4addr = to_ipv4_string(v4addr) end
    return ("  softwire { ipv4 %s; psid %d; b4-ipv6 %s; br-address %s; }"):format(
       v4addr, psid_len, b4, br_address)
@@ -82,7 +82,7 @@ local function softwires(w, params)
    for _ = 1, params.num_ips do
       for psid = 1, n-1 do
          w:ln(softwire_entry(v4addr, psid, ipv6:ntop(b4),
-              ipv6:ntop(br_address))
+              ipv6:ntop(br_address)))
          b4 = inc_ipv6(b4)
       end
       v4addr = inc_ipv4(v4addr)

--- a/src/program/lwaftr/migrate_configuration/README
+++ b/src/program/lwaftr/migrate_configuration/README
@@ -17,6 +17,9 @@ configuration.  Available VERSION values are:
   3.0.1.1
     lwAFTR development snapshot where "br" fields of softwires were
     0-based instead of 1-based.
+  3.2.0
+    lwAFTR versions where "br" fields were indexes for the "br-address"
+    leaf-list instead of "br-address" IPv6 entries on the softwire.
 
 The default version is "legacy".
 

--- a/src/program/lwaftr/migrate_configuration/migrate_configuration.lua
+++ b/src/program/lwaftr/migrate_configuration/migrate_configuration.lua
@@ -421,14 +421,14 @@ local function migrate_3_0_1bis(conf_file)
                        conf_file)
 end
 
-local function migrate_3_1_0(conf_file)
+local function migrate_3_2_0(conf_file)
    local src = io.open(conf_file, "r"):read("*a")
    return v2_migration(src, conf_file)
 end
 
 local migrators = { legacy = migrate_legacy, ['3.0.1'] = migrate_3_0_1,
                     ['3.0.1.1'] = migrate_3_0_1bis,
-                    ['3.1.0'] = migrate_3_1_0 }
+                    ['3.2.0'] = migrate_3_2_0 }
 function run(args)
    local conf_file, version = parse_args(args)
    local migrate = migrators[version]

--- a/src/program/lwaftr/migrate_configuration/migrate_configuration.lua
+++ b/src/program/lwaftr/migrate_configuration/migrate_configuration.lua
@@ -370,7 +370,6 @@ end
 
 local function remove_address_list(conf)
    local bt = conf.softwire_config.binding_table
-   local k, e
    for key, entry in cltable.pairs(bt.softwire) do
       entry.br_address = assert(bt.br_address[entry.br])
       entry.br = nil

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -544,5 +544,5 @@ function reconfigurable(scheduling, f, graph, conf, ...)
    config.app(graph, 'leader', leader.Leader,
               { setup_fn = setup_fn, initial_configuration = conf,
                 follower_pids = { follower_pid },
-                schema_name = 'snabb-softwire-v1'})
+                schema_name = 'snabb-softwire-v2'})
 end

--- a/src/program/lwaftr/tests/config/test-config-add.sh
+++ b/src/program/lwaftr/tests/config/test-config-add.sh
@@ -20,7 +20,7 @@ SNABB_NAME="`random_name`"
 start_lwaftr_bench $SNABB_NAME
 
 # IP to test with.
-TEST_SOFTWIRE="{ ipv4 1.2.3.4; psid 72; b4-ipv6 ::1; br 1; }"
+TEST_SOFTWIRE="{ ipv4 1.2.3.4; psid 72; b4-ipv6 ::1; br-address 5:9:a:b:c:d:e:f; }"
 ./snabb config add "$SNABB_NAME" "/softwire-config/binding-table/softwire" "$TEST_SOFTWIRE"
 
 # Check it can get this just fine

--- a/src/program/lwaftr/tests/data/big_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/big_mtu_no_icmp.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/icmp_on_fail.conf
+++ b/src/program/lwaftr/tests/data/icmp_on_fail.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/no_hairpin.conf
+++ b/src/program/lwaftr/tests/data/no_hairpin.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/no_icmp.conf
+++ b/src/program/lwaftr/tests/data/no_icmp.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/no_icmp_maxfrags1.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_maxfrags1.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_accept.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_accept.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_accept.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_accept.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_drop.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_drop.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_drop.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_drop.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/small_ipv4_mtu_icmp.conf
+++ b/src/program/lwaftr/tests/data/small_ipv4_mtu_icmp.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_allow.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_allow.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_vlan_allow.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_vlan_allow.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/tunnel_icmp.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/tunnel_icmp_without_mac4.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp_without_mac4.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/tunnel_icmp_withoutmac.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp_withoutmac.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan.conf
+++ b/src/program/lwaftr/tests/data/vlan.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/big_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/big_mtu_no_icmp.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/icmp_on_fail.conf
+++ b/src/program/lwaftr/tests/data/vlan/icmp_on_fail.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/no_hairpin.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_hairpin.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_maxfrags1.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_maxfrags1.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_accept.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_accept.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_drop.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_drop.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/small_ipv4_mtu_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv4_mtu_icmp.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp_allow.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp_allow.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp_without_mac4.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp_without_mac4.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp_withoutmac.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp_withoutmac.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/lwaftr/tests/data/vlan/vlan.conf
+++ b/src/program/lwaftr/tests/data/vlan/vlan.conf
@@ -1,8 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 8:9:a:b:c:d:e:f;
-    br-address 1e:1:1:1:1:1:1:af;
-    br-address 1e:2:2:2:2:2:2:af;
     psid-map {
       addr 178.79.150.15;
       psid-length 4;
@@ -32,63 +29,73 @@ softwire-config {
       ipv4 178.79.150.233;
       psid 4660;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.1;
       psid 0;
       b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 80;
       b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 54192;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.3;
       psid 4;
       b4-ipv6 127:14:25:36:47:58:69:128;
-      br 3;
+      br-address 1e:2:2:2:2:2:2:af;
     }
     softwire {
       ipv4 178.79.150.2;
       psid 7850;
       b4-ipv6 127:24:35:46:57:68:79:128;
-      br 2;
+      br-address 1e:1:1:1:1:1:1:af;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 7850;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2300;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 22788;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.233;
       psid 2700;
       b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 1;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
     softwire {
       ipv4 178.79.150.15;
       psid 0;
       b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
     }
   }
   external-interface {

--- a/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr-xe0.conf
+++ b/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr-xe0.conf
@@ -1,6 +1,5 @@
 softwire-config {
   binding-table {
-    br-address fc00::100;
     psid-map {
       addr 193.5.1.100;
       psid-length 6;
@@ -10,946 +9,1135 @@ softwire-config {
       ipv4 193.5.1.100;
       psid 43;
       b4-ipv6 fc00:1:2:3:4:5:0:a8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 45;
       b4-ipv6 fc00:1:2:3:4:5:0:aa;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 60;
       b4-ipv6 fc00:1:2:3:4:5:0:f8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 18;
       b4-ipv6 fc00:1:2:3:4:5:0:ce;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 47;
       b4-ipv6 fc00:1:2:3:4:5:0:eb;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 33;
       b4-ipv6 fc00:1:2:3:4:5:0:9e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 63;
       b4-ipv6 fc00:1:2:3:4:5:0:fb;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 30;
       b4-ipv6 fc00:1:2:3:4:5:0:119;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 49;
       b4-ipv6 fc00:1:2:3:4:5:0:ed;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 9;
       b4-ipv6 fc00:1:2:3:4:5:0:c5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 3;
       b4-ipv6 fc00:1:2:3:4:5:0:fe;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 56;
       b4-ipv6 fc00:1:2:3:4:5:0:b5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 51;
       b4-ipv6 fc00:1:2:3:4:5:0:b0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 26;
       b4-ipv6 fc00:1:2:3:4:5:0:d6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 37;
       b4-ipv6 fc00:1:2:3:4:5:0:a2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 44;
       b4-ipv6 fc00:1:2:3:4:5:0:e8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 17;
       b4-ipv6 fc00:1:2:3:4:5:0:8e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 48;
       b4-ipv6 fc00:1:2:3:4:5:0:ec;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 39;
       b4-ipv6 fc00:1:2:3:4:5:0:122;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 5;
       b4-ipv6 fc00:1:2:3:4:5:0:c1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 38;
       b4-ipv6 fc00:1:2:3:4:5:0:121;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 21;
       b4-ipv6 fc00:1:2:3:4:5:0:d1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 50;
       b4-ipv6 fc00:1:2:3:4:5:0:ee;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 35;
       b4-ipv6 fc00:1:2:3:4:5:0:df;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 55;
       b4-ipv6 fc00:1:2:3:4:5:0:b4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 46;
       b4-ipv6 fc00:1:2:3:4:5:0:ab;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 53;
       b4-ipv6 fc00:1:2:3:4:5:0:b2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 58;
       b4-ipv6 fc00:1:2:3:4:5:0:b7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 55;
       b4-ipv6 fc00:1:2:3:4:5:0:f3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 1;
       b4-ipv6 fc00:1:2:3:4:5:0:bd;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 61;
       b4-ipv6 fc00:1:2:3:4:5:0:ba;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 31;
       b4-ipv6 fc00:1:2:3:4:5:0:9c;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 27;
       b4-ipv6 fc00:1:2:3:4:5:0:116;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 54;
       b4-ipv6 fc00:1:2:3:4:5:0:f2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 24;
       b4-ipv6 fc00:1:2:3:4:5:0:113;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 11;
       b4-ipv6 fc00:1:2:3:4:5:0:88;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 34;
       b4-ipv6 fc00:1:2:3:4:5:0:9f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 46;
       b4-ipv6 fc00:1:2:3:4:5:0:129;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 16;
       b4-ipv6 fc00:1:2:3:4:5:0:cc;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 19;
       b4-ipv6 fc00:1:2:3:4:5:0:10e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 63;
       b4-ipv6 fc00:1:2:3:4:5:0:13a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 15;
       b4-ipv6 fc00:1:2:3:4:5:0:8c;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 13;
       b4-ipv6 fc00:1:2:3:4:5:0:8a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 40;
       b4-ipv6 fc00:1:2:3:4:5:0:123;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 2;
       b4-ipv6 fc00:1:2:3:4:5:0:fd;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 21;
       b4-ipv6 fc00:1:2:3:4:5:0:110;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 19;
       b4-ipv6 fc00:1:2:3:4:5:0:cf;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 61;
       b4-ipv6 fc00:1:2:3:4:5:0:138;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 32;
       b4-ipv6 fc00:1:2:3:4:5:0:9d;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 14;
       b4-ipv6 fc00:1:2:3:4:5:0:109;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 25;
       b4-ipv6 fc00:1:2:3:4:5:0:96;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 20;
       b4-ipv6 fc00:1:2:3:4:5:0:91;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 59;
       b4-ipv6 fc00:1:2:3:4:5:0:b8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 9;
       b4-ipv6 fc00:1:2:3:4:5:0:104;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 23;
       b4-ipv6 fc00:1:2:3:4:5:0:d3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 60;
       b4-ipv6 fc00:1:2:3:4:5:0:137;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 43;
       b4-ipv6 fc00:1:2:3:4:5:0:e7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 13;
       b4-ipv6 fc00:1:2:3:4:5:0:108;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 33;
       b4-ipv6 fc00:1:2:3:4:5:0:dd;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 47;
       b4-ipv6 fc00:1:2:3:4:5:0:12a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 37;
       b4-ipv6 fc00:1:2:3:4:5:0:120;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 6;
       b4-ipv6 fc00:1:2:3:4:5:0:83;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 48;
       b4-ipv6 fc00:1:2:3:4:5:0:ad;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 30;
       b4-ipv6 fc00:1:2:3:4:5:0:9b;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 62;
       b4-ipv6 fc00:1:2:3:4:5:0:bb;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 16;
       b4-ipv6 fc00:1:2:3:4:5:0:10b;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 50;
       b4-ipv6 fc00:1:2:3:4:5:0:af;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 42;
       b4-ipv6 fc00:1:2:3:4:5:0:e6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 29;
       b4-ipv6 fc00:1:2:3:4:5:0:118;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 52;
       b4-ipv6 fc00:1:2:3:4:5:0:b1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 56;
       b4-ipv6 fc00:1:2:3:4:5:0:133;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 49;
       b4-ipv6 fc00:1:2:3:4:5:0:ae;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 53;
       b4-ipv6 fc00:1:2:3:4:5:0:f1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 57;
       b4-ipv6 fc00:1:2:3:4:5:0:134;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 36;
       b4-ipv6 fc00:1:2:3:4:5:0:a1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 5;
       b4-ipv6 fc00:1:2:3:4:5:0:100;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 31;
       b4-ipv6 fc00:1:2:3:4:5:0:db;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 58;
       b4-ipv6 fc00:1:2:3:4:5:0:135;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 35;
       b4-ipv6 fc00:1:2:3:4:5:0:11e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 42;
       b4-ipv6 fc00:1:2:3:4:5:0:a7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 4;
       b4-ipv6 fc00:1:2:3:4:5:0:ff;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 12;
       b4-ipv6 fc00:1:2:3:4:5:0:89;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 3;
       b4-ipv6 fc00:1:2:3:4:5:0:80;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 7;
       b4-ipv6 fc00:1:2:3:4:5:0:84;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 43;
       b4-ipv6 fc00:1:2:3:4:5:0:126;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 10;
       b4-ipv6 fc00:1:2:3:4:5:0:c6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 60;
       b4-ipv6 fc00:1:2:3:4:5:0:b9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 22;
       b4-ipv6 fc00:1:2:3:4:5:0:d2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 32;
       b4-ipv6 fc00:1:2:3:4:5:0:dc;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 23;
       b4-ipv6 fc00:1:2:3:4:5:0:112;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 41;
       b4-ipv6 fc00:1:2:3:4:5:0:124;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 19;
       b4-ipv6 fc00:1:2:3:4:5:0:90;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 37;
       b4-ipv6 fc00:1:2:3:4:5:0:e1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 25;
       b4-ipv6 fc00:1:2:3:4:5:0:d5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 38;
       b4-ipv6 fc00:1:2:3:4:5:0:a3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 23;
       b4-ipv6 fc00:1:2:3:4:5:0:94;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 40;
       b4-ipv6 fc00:1:2:3:4:5:0:a5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 1;
       b4-ipv6 fc00:1:2:3:4:5:0:7e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 55;
       b4-ipv6 fc00:1:2:3:4:5:0:132;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 40;
       b4-ipv6 fc00:1:2:3:4:5:0:e4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 15;
       b4-ipv6 fc00:1:2:3:4:5:0:10a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 6;
       b4-ipv6 fc00:1:2:3:4:5:0:c2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 28;
       b4-ipv6 fc00:1:2:3:4:5:0:99;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 41;
       b4-ipv6 fc00:1:2:3:4:5:0:e5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 7;
       b4-ipv6 fc00:1:2:3:4:5:0:c3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 62;
       b4-ipv6 fc00:1:2:3:4:5:0:fa;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 45;
       b4-ipv6 fc00:1:2:3:4:5:0:128;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 31;
       b4-ipv6 fc00:1:2:3:4:5:0:11a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 13;
       b4-ipv6 fc00:1:2:3:4:5:0:c9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 59;
       b4-ipv6 fc00:1:2:3:4:5:0:f7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 57;
       b4-ipv6 fc00:1:2:3:4:5:0:f5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 11;
       b4-ipv6 fc00:1:2:3:4:5:0:106;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 46;
       b4-ipv6 fc00:1:2:3:4:5:0:ea;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 34;
       b4-ipv6 fc00:1:2:3:4:5:0:11d;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 2;
       b4-ipv6 fc00:1:2:3:4:5:0:7f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 30;
       b4-ipv6 fc00:1:2:3:4:5:0:da;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 45;
       b4-ipv6 fc00:1:2:3:4:5:0:e9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 61;
       b4-ipv6 fc00:1:2:3:4:5:0:f9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 17;
       b4-ipv6 fc00:1:2:3:4:5:0:10c;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 29;
       b4-ipv6 fc00:1:2:3:4:5:0:d9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 33;
       b4-ipv6 fc00:1:2:3:4:5:0:11c;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 12;
       b4-ipv6 fc00:1:2:3:4:5:0:c8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 4;
       b4-ipv6 fc00:1:2:3:4:5:0:c0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 52;
       b4-ipv6 fc00:1:2:3:4:5:0:f0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 18;
       b4-ipv6 fc00:1:2:3:4:5:0:10d;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 3;
       b4-ipv6 fc00:1:2:3:4:5:0:bf;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 10;
       b4-ipv6 fc00:1:2:3:4:5:0:105;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 8;
       b4-ipv6 fc00:1:2:3:4:5:0:85;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 2;
       b4-ipv6 fc00:1:2:3:4:5:0:be;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 39;
       b4-ipv6 fc00:1:2:3:4:5:0:a4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 36;
       b4-ipv6 fc00:1:2:3:4:5:0:e0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 32;
       b4-ipv6 fc00:1:2:3:4:5:0:11b;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 44;
       b4-ipv6 fc00:1:2:3:4:5:0:127;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 48;
       b4-ipv6 fc00:1:2:3:4:5:0:12b;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 20;
       b4-ipv6 fc00:1:2:3:4:5:0:10f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 14;
       b4-ipv6 fc00:1:2:3:4:5:0:8b;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 24;
       b4-ipv6 fc00:1:2:3:4:5:0:95;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 51;
       b4-ipv6 fc00:1:2:3:4:5:0:12e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 25;
       b4-ipv6 fc00:1:2:3:4:5:0:114;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 10;
       b4-ipv6 fc00:1:2:3:4:5:0:87;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 22;
       b4-ipv6 fc00:1:2:3:4:5:0:93;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 8;
       b4-ipv6 fc00:1:2:3:4:5:0:103;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 22;
       b4-ipv6 fc00:1:2:3:4:5:0:111;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 56;
       b4-ipv6 fc00:1:2:3:4:5:0:f4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 27;
       b4-ipv6 fc00:1:2:3:4:5:0:98;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 63;
       b4-ipv6 fc00:1:2:3:4:5:0:bc;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 26;
       b4-ipv6 fc00:1:2:3:4:5:0:115;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 54;
       b4-ipv6 fc00:1:2:3:4:5:0:b3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 44;
       b4-ipv6 fc00:1:2:3:4:5:0:a9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 50;
       b4-ipv6 fc00:1:2:3:4:5:0:12d;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 9;
       b4-ipv6 fc00:1:2:3:4:5:0:86;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 58;
       b4-ipv6 fc00:1:2:3:4:5:0:f6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 18;
       b4-ipv6 fc00:1:2:3:4:5:0:8f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 28;
       b4-ipv6 fc00:1:2:3:4:5:0:d8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 27;
       b4-ipv6 fc00:1:2:3:4:5:0:d7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 54;
       b4-ipv6 fc00:1:2:3:4:5:0:131;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 59;
       b4-ipv6 fc00:1:2:3:4:5:0:136;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 41;
       b4-ipv6 fc00:1:2:3:4:5:0:a6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 12;
       b4-ipv6 fc00:1:2:3:4:5:0:107;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 35;
       b4-ipv6 fc00:1:2:3:4:5:0:a0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 11;
       b4-ipv6 fc00:1:2:3:4:5:0:c7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 47;
       b4-ipv6 fc00:1:2:3:4:5:0:ac;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 24;
       b4-ipv6 fc00:1:2:3:4:5:0:d4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 1;
       b4-ipv6 fc00:1:2:3:4:5:0:fc;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 8;
       b4-ipv6 fc00:1:2:3:4:5:0:c4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 14;
       b4-ipv6 fc00:1:2:3:4:5:0:ca;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 17;
       b4-ipv6 fc00:1:2:3:4:5:0:cd;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 7;
       b4-ipv6 fc00:1:2:3:4:5:0:102;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 51;
       b4-ipv6 fc00:1:2:3:4:5:0:ef;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 6;
       b4-ipv6 fc00:1:2:3:4:5:0:101;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 62;
       b4-ipv6 fc00:1:2:3:4:5:0:139;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 28;
       b4-ipv6 fc00:1:2:3:4:5:0:117;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 16;
       b4-ipv6 fc00:1:2:3:4:5:0:8d;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 29;
       b4-ipv6 fc00:1:2:3:4:5:0:9a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 42;
       b4-ipv6 fc00:1:2:3:4:5:0:125;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 21;
       b4-ipv6 fc00:1:2:3:4:5:0:92;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 49;
       b4-ipv6 fc00:1:2:3:4:5:0:12c;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 57;
       b4-ipv6 fc00:1:2:3:4:5:0:b6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 20;
       b4-ipv6 fc00:1:2:3:4:5:0:d0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 52;
       b4-ipv6 fc00:1:2:3:4:5:0:12f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 26;
       b4-ipv6 fc00:1:2:3:4:5:0:97;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 36;
       b4-ipv6 fc00:1:2:3:4:5:0:11f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 4;
       b4-ipv6 fc00:1:2:3:4:5:0:81;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 34;
       b4-ipv6 fc00:1:2:3:4:5:0:de;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 5;
       b4-ipv6 fc00:1:2:3:4:5:0:82;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 38;
       b4-ipv6 fc00:1:2:3:4:5:0:e2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 15;
       b4-ipv6 fc00:1:2:3:4:5:0:cb;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 39;
       b4-ipv6 fc00:1:2:3:4:5:0:e3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 53;
       b4-ipv6 fc00:1:2:3:4:5:0:130;
+      br-address fc00::100;
     }
   }
   external-interface {

--- a/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr.conf
+++ b/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr.conf
@@ -1,6 +1,5 @@
 softwire-config {
   binding-table {
-    br-address fc00::100;
     psid-map {
       addr 193.5.1.100;
       psid-length 6;
@@ -10,946 +9,1135 @@ softwire-config {
       ipv4 193.5.1.100;
       psid 43;
       b4-ipv6 fc00:1:2:3:4:5:0:a8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 45;
       b4-ipv6 fc00:1:2:3:4:5:0:aa;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 60;
       b4-ipv6 fc00:1:2:3:4:5:0:f8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 18;
       b4-ipv6 fc00:1:2:3:4:5:0:ce;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 47;
       b4-ipv6 fc00:1:2:3:4:5:0:eb;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 33;
       b4-ipv6 fc00:1:2:3:4:5:0:9e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 63;
       b4-ipv6 fc00:1:2:3:4:5:0:fb;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 30;
       b4-ipv6 fc00:1:2:3:4:5:0:119;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 49;
       b4-ipv6 fc00:1:2:3:4:5:0:ed;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 9;
       b4-ipv6 fc00:1:2:3:4:5:0:c5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 3;
       b4-ipv6 fc00:1:2:3:4:5:0:fe;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 56;
       b4-ipv6 fc00:1:2:3:4:5:0:b5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 51;
       b4-ipv6 fc00:1:2:3:4:5:0:b0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 26;
       b4-ipv6 fc00:1:2:3:4:5:0:d6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 37;
       b4-ipv6 fc00:1:2:3:4:5:0:a2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 44;
       b4-ipv6 fc00:1:2:3:4:5:0:e8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 17;
       b4-ipv6 fc00:1:2:3:4:5:0:8e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 48;
       b4-ipv6 fc00:1:2:3:4:5:0:ec;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 39;
       b4-ipv6 fc00:1:2:3:4:5:0:122;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 5;
       b4-ipv6 fc00:1:2:3:4:5:0:c1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 38;
       b4-ipv6 fc00:1:2:3:4:5:0:121;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 21;
       b4-ipv6 fc00:1:2:3:4:5:0:d1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 50;
       b4-ipv6 fc00:1:2:3:4:5:0:ee;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 35;
       b4-ipv6 fc00:1:2:3:4:5:0:df;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 55;
       b4-ipv6 fc00:1:2:3:4:5:0:b4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 46;
       b4-ipv6 fc00:1:2:3:4:5:0:ab;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 53;
       b4-ipv6 fc00:1:2:3:4:5:0:b2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 58;
       b4-ipv6 fc00:1:2:3:4:5:0:b7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 55;
       b4-ipv6 fc00:1:2:3:4:5:0:f3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 1;
       b4-ipv6 fc00:1:2:3:4:5:0:bd;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 61;
       b4-ipv6 fc00:1:2:3:4:5:0:ba;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 31;
       b4-ipv6 fc00:1:2:3:4:5:0:9c;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 27;
       b4-ipv6 fc00:1:2:3:4:5:0:116;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 54;
       b4-ipv6 fc00:1:2:3:4:5:0:f2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 24;
       b4-ipv6 fc00:1:2:3:4:5:0:113;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 11;
       b4-ipv6 fc00:1:2:3:4:5:0:88;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 34;
       b4-ipv6 fc00:1:2:3:4:5:0:9f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 46;
       b4-ipv6 fc00:1:2:3:4:5:0:129;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 16;
       b4-ipv6 fc00:1:2:3:4:5:0:cc;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 19;
       b4-ipv6 fc00:1:2:3:4:5:0:10e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 63;
       b4-ipv6 fc00:1:2:3:4:5:0:13a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 15;
       b4-ipv6 fc00:1:2:3:4:5:0:8c;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 13;
       b4-ipv6 fc00:1:2:3:4:5:0:8a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 40;
       b4-ipv6 fc00:1:2:3:4:5:0:123;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 2;
       b4-ipv6 fc00:1:2:3:4:5:0:fd;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 21;
       b4-ipv6 fc00:1:2:3:4:5:0:110;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 19;
       b4-ipv6 fc00:1:2:3:4:5:0:cf;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 61;
       b4-ipv6 fc00:1:2:3:4:5:0:138;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 32;
       b4-ipv6 fc00:1:2:3:4:5:0:9d;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 14;
       b4-ipv6 fc00:1:2:3:4:5:0:109;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 25;
       b4-ipv6 fc00:1:2:3:4:5:0:96;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 20;
       b4-ipv6 fc00:1:2:3:4:5:0:91;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 59;
       b4-ipv6 fc00:1:2:3:4:5:0:b8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 9;
       b4-ipv6 fc00:1:2:3:4:5:0:104;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 23;
       b4-ipv6 fc00:1:2:3:4:5:0:d3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 60;
       b4-ipv6 fc00:1:2:3:4:5:0:137;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 43;
       b4-ipv6 fc00:1:2:3:4:5:0:e7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 13;
       b4-ipv6 fc00:1:2:3:4:5:0:108;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 33;
       b4-ipv6 fc00:1:2:3:4:5:0:dd;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 47;
       b4-ipv6 fc00:1:2:3:4:5:0:12a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 37;
       b4-ipv6 fc00:1:2:3:4:5:0:120;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 6;
       b4-ipv6 fc00:1:2:3:4:5:0:83;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 48;
       b4-ipv6 fc00:1:2:3:4:5:0:ad;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 30;
       b4-ipv6 fc00:1:2:3:4:5:0:9b;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 62;
       b4-ipv6 fc00:1:2:3:4:5:0:bb;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 16;
       b4-ipv6 fc00:1:2:3:4:5:0:10b;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 50;
       b4-ipv6 fc00:1:2:3:4:5:0:af;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 42;
       b4-ipv6 fc00:1:2:3:4:5:0:e6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 29;
       b4-ipv6 fc00:1:2:3:4:5:0:118;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 52;
       b4-ipv6 fc00:1:2:3:4:5:0:b1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 56;
       b4-ipv6 fc00:1:2:3:4:5:0:133;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 49;
       b4-ipv6 fc00:1:2:3:4:5:0:ae;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 53;
       b4-ipv6 fc00:1:2:3:4:5:0:f1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 57;
       b4-ipv6 fc00:1:2:3:4:5:0:134;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 36;
       b4-ipv6 fc00:1:2:3:4:5:0:a1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 5;
       b4-ipv6 fc00:1:2:3:4:5:0:100;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 31;
       b4-ipv6 fc00:1:2:3:4:5:0:db;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 58;
       b4-ipv6 fc00:1:2:3:4:5:0:135;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 35;
       b4-ipv6 fc00:1:2:3:4:5:0:11e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 42;
       b4-ipv6 fc00:1:2:3:4:5:0:a7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 4;
       b4-ipv6 fc00:1:2:3:4:5:0:ff;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 12;
       b4-ipv6 fc00:1:2:3:4:5:0:89;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 3;
       b4-ipv6 fc00:1:2:3:4:5:0:80;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 7;
       b4-ipv6 fc00:1:2:3:4:5:0:84;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 43;
       b4-ipv6 fc00:1:2:3:4:5:0:126;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 10;
       b4-ipv6 fc00:1:2:3:4:5:0:c6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 60;
       b4-ipv6 fc00:1:2:3:4:5:0:b9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 22;
       b4-ipv6 fc00:1:2:3:4:5:0:d2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 32;
       b4-ipv6 fc00:1:2:3:4:5:0:dc;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 23;
       b4-ipv6 fc00:1:2:3:4:5:0:112;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 41;
       b4-ipv6 fc00:1:2:3:4:5:0:124;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 19;
       b4-ipv6 fc00:1:2:3:4:5:0:90;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 37;
       b4-ipv6 fc00:1:2:3:4:5:0:e1;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 25;
       b4-ipv6 fc00:1:2:3:4:5:0:d5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 38;
       b4-ipv6 fc00:1:2:3:4:5:0:a3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 23;
       b4-ipv6 fc00:1:2:3:4:5:0:94;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 40;
       b4-ipv6 fc00:1:2:3:4:5:0:a5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 1;
       b4-ipv6 fc00:1:2:3:4:5:0:7e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 55;
       b4-ipv6 fc00:1:2:3:4:5:0:132;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 40;
       b4-ipv6 fc00:1:2:3:4:5:0:e4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 15;
       b4-ipv6 fc00:1:2:3:4:5:0:10a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 6;
       b4-ipv6 fc00:1:2:3:4:5:0:c2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 28;
       b4-ipv6 fc00:1:2:3:4:5:0:99;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 41;
       b4-ipv6 fc00:1:2:3:4:5:0:e5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 7;
       b4-ipv6 fc00:1:2:3:4:5:0:c3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 62;
       b4-ipv6 fc00:1:2:3:4:5:0:fa;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 45;
       b4-ipv6 fc00:1:2:3:4:5:0:128;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 31;
       b4-ipv6 fc00:1:2:3:4:5:0:11a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 13;
       b4-ipv6 fc00:1:2:3:4:5:0:c9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 59;
       b4-ipv6 fc00:1:2:3:4:5:0:f7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 57;
       b4-ipv6 fc00:1:2:3:4:5:0:f5;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 11;
       b4-ipv6 fc00:1:2:3:4:5:0:106;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 46;
       b4-ipv6 fc00:1:2:3:4:5:0:ea;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 34;
       b4-ipv6 fc00:1:2:3:4:5:0:11d;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 2;
       b4-ipv6 fc00:1:2:3:4:5:0:7f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 30;
       b4-ipv6 fc00:1:2:3:4:5:0:da;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 45;
       b4-ipv6 fc00:1:2:3:4:5:0:e9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 61;
       b4-ipv6 fc00:1:2:3:4:5:0:f9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 17;
       b4-ipv6 fc00:1:2:3:4:5:0:10c;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 29;
       b4-ipv6 fc00:1:2:3:4:5:0:d9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 33;
       b4-ipv6 fc00:1:2:3:4:5:0:11c;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 12;
       b4-ipv6 fc00:1:2:3:4:5:0:c8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 4;
       b4-ipv6 fc00:1:2:3:4:5:0:c0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 52;
       b4-ipv6 fc00:1:2:3:4:5:0:f0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 18;
       b4-ipv6 fc00:1:2:3:4:5:0:10d;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 3;
       b4-ipv6 fc00:1:2:3:4:5:0:bf;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 10;
       b4-ipv6 fc00:1:2:3:4:5:0:105;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 8;
       b4-ipv6 fc00:1:2:3:4:5:0:85;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 2;
       b4-ipv6 fc00:1:2:3:4:5:0:be;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 39;
       b4-ipv6 fc00:1:2:3:4:5:0:a4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 36;
       b4-ipv6 fc00:1:2:3:4:5:0:e0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 32;
       b4-ipv6 fc00:1:2:3:4:5:0:11b;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 44;
       b4-ipv6 fc00:1:2:3:4:5:0:127;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 48;
       b4-ipv6 fc00:1:2:3:4:5:0:12b;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 20;
       b4-ipv6 fc00:1:2:3:4:5:0:10f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 14;
       b4-ipv6 fc00:1:2:3:4:5:0:8b;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 24;
       b4-ipv6 fc00:1:2:3:4:5:0:95;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 51;
       b4-ipv6 fc00:1:2:3:4:5:0:12e;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 25;
       b4-ipv6 fc00:1:2:3:4:5:0:114;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 10;
       b4-ipv6 fc00:1:2:3:4:5:0:87;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 22;
       b4-ipv6 fc00:1:2:3:4:5:0:93;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 8;
       b4-ipv6 fc00:1:2:3:4:5:0:103;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 22;
       b4-ipv6 fc00:1:2:3:4:5:0:111;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 56;
       b4-ipv6 fc00:1:2:3:4:5:0:f4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 27;
       b4-ipv6 fc00:1:2:3:4:5:0:98;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 63;
       b4-ipv6 fc00:1:2:3:4:5:0:bc;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 26;
       b4-ipv6 fc00:1:2:3:4:5:0:115;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 54;
       b4-ipv6 fc00:1:2:3:4:5:0:b3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 44;
       b4-ipv6 fc00:1:2:3:4:5:0:a9;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 50;
       b4-ipv6 fc00:1:2:3:4:5:0:12d;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 9;
       b4-ipv6 fc00:1:2:3:4:5:0:86;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 58;
       b4-ipv6 fc00:1:2:3:4:5:0:f6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 18;
       b4-ipv6 fc00:1:2:3:4:5:0:8f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 28;
       b4-ipv6 fc00:1:2:3:4:5:0:d8;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 27;
       b4-ipv6 fc00:1:2:3:4:5:0:d7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 54;
       b4-ipv6 fc00:1:2:3:4:5:0:131;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 59;
       b4-ipv6 fc00:1:2:3:4:5:0:136;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 41;
       b4-ipv6 fc00:1:2:3:4:5:0:a6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 12;
       b4-ipv6 fc00:1:2:3:4:5:0:107;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 35;
       b4-ipv6 fc00:1:2:3:4:5:0:a0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 11;
       b4-ipv6 fc00:1:2:3:4:5:0:c7;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 47;
       b4-ipv6 fc00:1:2:3:4:5:0:ac;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 24;
       b4-ipv6 fc00:1:2:3:4:5:0:d4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 1;
       b4-ipv6 fc00:1:2:3:4:5:0:fc;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 8;
       b4-ipv6 fc00:1:2:3:4:5:0:c4;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 14;
       b4-ipv6 fc00:1:2:3:4:5:0:ca;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 17;
       b4-ipv6 fc00:1:2:3:4:5:0:cd;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 7;
       b4-ipv6 fc00:1:2:3:4:5:0:102;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 51;
       b4-ipv6 fc00:1:2:3:4:5:0:ef;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 6;
       b4-ipv6 fc00:1:2:3:4:5:0:101;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 62;
       b4-ipv6 fc00:1:2:3:4:5:0:139;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 28;
       b4-ipv6 fc00:1:2:3:4:5:0:117;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 16;
       b4-ipv6 fc00:1:2:3:4:5:0:8d;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 29;
       b4-ipv6 fc00:1:2:3:4:5:0:9a;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 42;
       b4-ipv6 fc00:1:2:3:4:5:0:125;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 21;
       b4-ipv6 fc00:1:2:3:4:5:0:92;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 49;
       b4-ipv6 fc00:1:2:3:4:5:0:12c;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 57;
       b4-ipv6 fc00:1:2:3:4:5:0:b6;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 20;
       b4-ipv6 fc00:1:2:3:4:5:0:d0;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 52;
       b4-ipv6 fc00:1:2:3:4:5:0:12f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 26;
       b4-ipv6 fc00:1:2:3:4:5:0:97;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 36;
       b4-ipv6 fc00:1:2:3:4:5:0:11f;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 4;
       b4-ipv6 fc00:1:2:3:4:5:0:81;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 34;
       b4-ipv6 fc00:1:2:3:4:5:0:de;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.100;
       psid 5;
       b4-ipv6 fc00:1:2:3:4:5:0:82;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 38;
       b4-ipv6 fc00:1:2:3:4:5:0:e2;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 15;
       b4-ipv6 fc00:1:2:3:4:5:0:cb;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.101;
       psid 39;
       b4-ipv6 fc00:1:2:3:4:5:0:e3;
+      br-address fc00::100;
     }
     softwire {
       ipv4 193.5.1.102;
       psid 53;
       b4-ipv6 fc00:1:2:3:4:5:0:130;
+      br-address fc00::100;
     }
   }
   external-interface {

--- a/src/program/snabbvmx/tests/end-to-end/data/snabbvmx-lwaftr-xe1.conf
+++ b/src/program/snabbvmx/tests/end-to-end/data/snabbvmx-lwaftr-xe1.conf
@@ -1,6 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 2a02:587:f700::100;
     psid-map {
       addr 10.10.0.10;
       psid-length 6;
@@ -15,21 +14,25 @@ softwire-config {
       ipv4 10.10.0.0;
       psid 1;
       b4-ipv6 2a02:587:f710::400;
+      br-address 2a02:587:f700::100;
     }
     softwire {
       ipv4 10.10.0.0;
       psid 4;
       b4-ipv6 2a02:587:f710::430;
+      br-address 2a02:587:f700::100;
     }
     softwire {
       ipv4 10.10.0.0;
       psid 2;
       b4-ipv6 2a02:587:f710::410;
+      br-address 2a02:587:f700::100;
     }
     softwire {
       ipv4 10.10.0.0;
       psid 3;
       b4-ipv6 2a02:587:f710::420;
+      br-address 2a02:587:f700::100;
     }
   }
   external-interface {

--- a/src/program/snabbvmx/tests/end-to-end/data/vlan/snabbvmx-lwaftr-xe1.conf
+++ b/src/program/snabbvmx/tests/end-to-end/data/vlan/snabbvmx-lwaftr-xe1.conf
@@ -1,6 +1,5 @@
 softwire-config {
   binding-table {
-    br-address 2a02:587:f700::100;
     psid-map {
       addr 10.10.0.10;
       psid-length 6;
@@ -15,21 +14,25 @@ softwire-config {
       ipv4 10.10.0.0;
       psid 1;
       b4-ipv6 2a02:587:f710::400;
+      br-address 2a02:587:f700::100;
     }
     softwire {
       ipv4 10.10.0.0;
       psid 4;
       b4-ipv6 2a02:587:f710::430;
+      br-address 2a02:587:f700::100;
     }
     softwire {
       ipv4 10.10.0.0;
       psid 2;
       b4-ipv6 2a02:587:f710::410;
+      br-address 2a02:587:f700::100;
     }
     softwire {
       ipv4 10.10.0.0;
       psid 3;
       b4-ipv6 2a02:587:f710::420;
+      br-address 2a02:587:f700::100;
     }
   }
   external-interface {


### PR DESCRIPTION
This resolves #683. It removes the `br-address` leaf-list and `br` leaf (an index for `br-address`) and converts those to a `br-address` leaf which just specifies the IPv6 address of the BR for that softwire. This makes it far more yang-like.

This change will break break backwards compatibility with `snabb-softwire-v1` (i.e. you won't be able to use v1 with the code in this branch and v2 configs can't be loaded with v1 parsers, etc.). Therefore I have changed the schema to `snabb-softwire-v2`. This includes a migration and migrated testing configs. 

NB: that this does touch the data-plane so, help regarding checking performance regression would be helpful - Maybe the unit tests have a performance element to them?). 