### PR TITLE
Revert "Remove end-addr in psid-map"

### DIFF
--- a/src/apps/lwaftr/binding_table.lua
+++ b/src/apps/lwaftr/binding_table.lua
@@ -260,7 +260,7 @@ function load(conf)
              'psid_length '..psid_length..' + shift '..shift..
              ' should not exceed 16')
       psid_value.psid_length, psid_value.shift = psid_length, shift
-      psid_builder:add_range(k.addr, k.addr, psid_value)
+      psid_builder:add_range(k.addr, v.end_addr or k.addr, psid_value)
    end
    local psid_map = psid_builder:build(psid_map_value_t())
    return BindingTable.new(psid_map, conf.br_address, conf.softwire)

--- a/src/program/lwaftr/migrate_configuration/migrate_configuration.lua
+++ b/src/program/lwaftr/migrate_configuration/migrate_configuration.lua
@@ -320,8 +320,10 @@ local function migrate_conf(old)
    local psid_map = cltable.new({ key_type = psid_key_t })
    for addr, end_addr, params in old_bt.psid_map:iterate() do
       local reserved_ports_bit_count = 16 - params.psid_length - params.shift
+      if end_addr == addr then end_addr = nil end
       if reserved_ports_bit_count ~= 16 then
          psid_map[psid_key_t(addr)] = {
+            end_addr = end_addr,
             psid_length = params.psid_length,
             shift = params.shift,
             reserved_ports_bit_count = reserved_ports_bit_count


### PR DESCRIPTION
This reverts commit 86b9835eed86b0068d9e93637cc175167f1feba1.

This commit introduced an important regression that made many packets get loss as they don't match valid softwires.