### PR TITLE
Allow for empty containers in snabb set

### DIFF
--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -204,9 +204,16 @@ local function struct_parser(keyword, members, ctype)
       return parse1(P)
    end
    local struct_t = ctype and typeof(ctype)
-   local function finish(out)
-      -- FIXME check mandatory values.
-      if struct_t then return struct_t(out) else return out end
+   local function finish(out, leaf)
+     -- FIXME check mandatory values.
+      if struct_t then
+        local ret
+        if out == nil then ret = struct_t()
+        else ret = struct_t(out) end
+        return ret
+      else
+        return out
+      end
    end
    return {init=init, parse=parse, finish=finish}
 end


### PR DESCRIPTION
This fixes a problem brought up in issue #700. If you omitted some containers which were entirely optional it would produce an obtuse error. This is because some of the containers were represented as simple ctypes and when trying to create those when passing in "nil" (when omitted) could cause a casting error in the FFI. Since omitting optional values or blocks is how this is designed and expected to work this has been solved for checking for nil.

The following now succeeds:
```
$ sudo ./snabb config set lwaftr1 /softwire-config/internal-interface/ "ip ::1; mac 22:22:22:22:22:22; next-hop {}"
```

And the query that was performed in the issue itself now reports a more sensible error prompting for missing mandatory values:
```
$ sudo ./snabb config set lwaftr "/softwire-config/internal-interface/" "next-hop {}"
lib/yang/data.lua:266: missing scalar value: mac
stack traceback:
	core/main.lua:149: in function <core/main.lua:147>
	[C]: in function 'error'
	lib/yang/data.lua:266: in function 'finish'
	lib/yang/data.lua:412: in function 'parser'
	program/config/common.lua:78: in function 'parse_command_line'
	program/config/set/set.lua:7: in function 'run'
	program/config/config.lua:23: in function 'run'
	core/main.lua:67: in function <core/main.lua:43>
	[C]: in function 'xpcall'
	core/main.lua:211: in main chunk
	[C]: at 0x004545e0
	[C]: in function 'pcall'
	core/startup.lua:3: in main chunk
	[C]: in function 'require'
	[string "require "core.startup""]:1: in main chunk
```