### PR TITLE
Make the leader process use less CPU

### DIFF
--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -217,7 +217,10 @@ function run(args)
       end
    end
 
-   engine.busywait = true
+   if not opts.reconfigurable then
+      -- The leader does not need all the CPU, only the followers do.
+      engine.busywait = true
+   end
    if opts.duration then
       engine.main({duration=opts.duration, report={showlinks=true}})
    else


### PR DESCRIPTION
When running `lwaftr run --reconfigurable`, don't set the leader process to busywait mode.

Verified on `snabb1` by running the command:
```
$ sudo ./snabb lwaftr run --reconfigurable --cpu 4 --conf program/lwaftr/tests/data/icmp_on_fail.conf --v4 0000:03:00.0 --v6 0000:03:00.1
```
and checking CPU usage with the `htop` command. See also #731.

Fixes #652.