### PR TITLE
Automate creation of tarball releases with Hydra

### DIFF
--- a/tarball.nix
+++ b/tarball.nix
@@ -5,10 +5,10 @@
 # and the release tarball will be written to ./result/ . It will contain
 # both the sources and the executable, patched to run on Linux LSB systems.
 #
-# FIXME: currently Hydra doesn't use the --tags parameter in the "git
-# describe" command, so lightweight (non-annotated) tags are not found.
-# See https://github.com/NixOS/hydra/blob/master/src/lib/Hydra/Plugin/GitInput.pm#L148
-# Always need to use one of -a, -s or -u with the "git tag" command.
+# NOTE: Hydra doesn't use the --tags parameter in the "git describe" command (see
+# https://github.com/NixOS/hydra/blob/master/src/lib/Hydra/Plugin/GitInput.pm#L148
+# ), so lightweight (non-annotated) tags are not found. Always create annotated
+# tags with the "git tag" command by using one of the -a, -s or -u options.
 
 { nixpkgs ? <nixpkgs>
 , hydraName ? "snabb"
@@ -21,14 +21,12 @@ let
   name = (src:
     if builtins.isAttrs  src then
       # Called from Hydra with "src" as "Git version", get the version from git tags.
-      # Massage output of "git describe": "v3.1.7-7-g89747a1" -> "v3.1.7"
-      # version = (builtins.parseDrvName src.gitTag).name;
-      # name = "${hydraName}-${version}";
-      # TODO: don't massage src.gitTag for now, re-evaluate later.
-      # Possibly add policy to only generate the tarball when there's a new tag.
+      # If the last commit is the tag's one, you'll just get the tag name: "v3.1.7";
+      # otherwise you'll also get the number of commits since the last tag, and the
+      # shortened commit checksum: "v3.1.7-7-g89747a1".
       "${hydraName}-${src.gitTag}"
     else
-      # Called from the command line.
+      # Called from the command line, the user supplies the version.
       "${hydraName}-${version}") src;
 in {
   tarball = pkgs.stdenv.mkDerivation rec {

--- a/tarball.nix
+++ b/tarball.nix
@@ -10,12 +10,16 @@
 pkgs.stdenv.mkDerivation rec {
   inherit name src;
 
-  buildInputs = with pkgs; [ git patchelf ];
+  buildInputs = with pkgs; [ git makeWrapper patchelf ];
 
   postUnpack = ''
     export DISTDIR="$out/${name}-`cd snabb; git describe --tags`"
     mkdir -p $DISTDIR
     cp -a $sourceRoot/* $DISTDIR
+  '';
+
+  preBuild = ''
+    make clean
   '';
 
   installPhase = ''
@@ -37,7 +41,7 @@ pkgs.stdenv.mkDerivation rec {
     # Remove a leftover stray binary. FIXME: should not happen.
     rm "$DISTDIR/src/snabb"
     tar Jcf $DISTDIR.tar.xz *
-# TODO: make tarball available through Hydra.
-#    cp -av $DISTDIR.tar.xz "$out"
+    # Make tarball available through Hydra.
+    cp -av $DISTDIR.tar.xz "$out/nix-support/hydra-build-products"
   '';
 }

--- a/tarball.nix
+++ b/tarball.nix
@@ -11,42 +11,44 @@
 
 let
   pkgs = import nixpkgs {};
-in pkgs.stdenv.mkDerivation rec {
-  inherit name src;
+in {
+  tarball = pkgs.stdenv.mkDerivation rec {
+    inherit name src;
 
-  buildInputs = with pkgs; [ git makeWrapper patchelf ];
+    buildInputs = with pkgs; [ git makeWrapper patchelf ];
 
-  postUnpack = ''
-    export DISTNAME="$out/${name}-`cd snabb; git describe --tags | cut -d '-' -f 1`"
-    mkdir -p $DISTNAME
-    cp -a $sourceRoot/* $DISTNAME
-  '';
+    postUnpack = ''
+      export DISTNAME="$out/${name}-`cd snabb; git describe --tags | cut -d '-' -f 1`"
+      mkdir -p $DISTNAME
+      cp -a $sourceRoot/* $DISTNAME
+    '';
 
-  preBuild = ''
-    make clean
-  '';
+    # preBuild = ''
+    #   make clean
+    # '';
 
-  installPhase = ''
-    mv src/snabb "$out"
-  '';
+    installPhase = ''
+      mv src/snabb "$out"
+    '';
 
-  fixupPhase = ''
-    patchelf --shrink-rpath "$out/snabb"
-    patchelf --set-rpath /lib/x86_64-linux-gnu "$out/snabb"
-    patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 "$out/snabb"
-  '';
+    fixupPhase = ''
+      patchelf --shrink-rpath "$out/snabb"
+      patchelf --set-rpath /lib/x86_64-linux-gnu "$out/snabb"
+      patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 "$out/snabb"
+    '';
 
-  doDist = true;
+    doDist = true;
 
-  distPhase = ''
-    cd "$out"
-    # $out will only contain the DISTNAME directory and the "snabb" binary.
-    export DISTNAME=`ls -I snabb`
-    # Remove a leftover stray binary. FIXME: should not happen.
-    rm "$DISTNAME/src/snabb"
-    tar Jcf $DISTNAME.tar.xz *
-    # Make tarball available through Hydra.
-    mkdir -p "$out/nix-support"
-    mv $DISTNAME.tar.xz "$out/nix-support"
-  '';
+    distPhase = ''
+      cd "$out"
+      # $out will only contain the DISTNAME directory and the "snabb" binary.
+      export DISTNAME=`ls -I snabb`
+      # Remove a leftover stray binary. FIXME: should not happen.
+      rm "$DISTNAME/src/snabb"
+      tar Jcf $DISTNAME.tar.xz *
+      # Make tarball available through Hydra.
+      mkdir -p "$out/nix-support"
+      mv $DISTNAME.tar.xz "$out/nix-support"
+    '';
+  };
 }

--- a/tarball.nix
+++ b/tarball.nix
@@ -1,0 +1,43 @@
+# Run like this:
+#   nix-build /path/to/this/directory/tarball.nix
+# ... and the files are produced in ./result/
+
+{ pkgs ? (import <nixpkgs> {})
+, name ? "snabb"
+, src ? ./.
+}:
+
+pkgs.stdenv.mkDerivation rec {
+  inherit name src;
+
+  buildInputs = with pkgs; [ git patchelf ];
+
+  postUnpack = ''
+    export DISTDIR="$out/${name}-`cd snabb; git describe --tags`"
+    mkdir -p $DISTDIR
+    cp -a $sourceRoot/* $DISTDIR
+  '';
+
+  installPhase = ''
+    mv src/snabb "$out"
+  '';
+
+  fixupPhase = ''
+    patchelf --shrink-rpath "$out/snabb"
+    patchelf --set-rpath /lib/x86_64-linux-gnu "$out/snabb"
+    patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 "$out/snabb"
+  '';
+
+  doDist = true;
+
+  distPhase = ''
+    cd "$out"
+    # The tarball will only contain the DISTDIR and the "snabb" binary.
+    export DISTDIR=`ls -I snabb`
+    # Remove a leftover stray binary. FIXME: should not happen.
+    rm "$DISTDIR/src/snabb"
+    tar Jcf $DISTDIR.tar.xz *
+# TODO: make tarball available through Hydra.
+#    cp -av $DISTDIR.tar.xz "$out"
+  '';
+}

--- a/tarball.nix
+++ b/tarball.nix
@@ -1,6 +1,8 @@
 # Run like this:
-#   nix-build /path/to/this/directory/tarball.nix
-# ... and the files are produced in ./result/
+#   nix-build --argstr name snabb-lwaftr ./tarball.nix
+# and the release tarball will be written to ./result/nix-support .
+# It will contain both the sources and the executable, patched to run on
+# Linux LSB systems.
 
 { nixpkgs ? <nixpkgs>
 , name ? "snabb"

--- a/tarball.nix
+++ b/tarball.nix
@@ -43,8 +43,6 @@ in {
       cd "$out"
       # $out will only contain the DISTNAME directory and the "snabb" binary.
       export DISTNAME=`ls -I snabb`
-      # Remove a leftover stray binary. FIXME: should not happen.
-      rm "$DISTNAME/src/snabb"
       tar Jcf $DISTNAME.tar.xz *
       # Make tarball available through Hydra.
       mkdir -p "$out/nix-support"

--- a/tarball.nix
+++ b/tarball.nix
@@ -28,25 +28,25 @@ in {
     # '';
 
     installPhase = ''
-      mv src/snabb "$out"
+      mv src/snabb $out
     '';
 
     fixupPhase = ''
-      patchelf --shrink-rpath "$out/snabb"
-      patchelf --set-rpath /lib/x86_64-linux-gnu "$out/snabb"
-      patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 "$out/snabb"
+      patchelf --shrink-rpath $out/snabb
+      patchelf --set-rpath /lib/x86_64-linux-gnu $out/snabb
+      patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 $out/snabb
     '';
 
     doDist = true;
 
     distPhase = ''
-      cd "$out"
+      cd $out
       # $out will only contain the DISTNAME directory and the "snabb" binary.
       export DISTNAME=`ls -I snabb`
       tar Jcf $DISTNAME.tar.xz *
-      # Make tarball available through Hydra.
-      mkdir -p "$out/nix-support"
-      mv $DISTNAME.tar.xz "$out/nix-support"
+      # Make the tarball available for download through Hydra.
+      mkdir -p $out/nix-support
+      echo "file tarball $out/$DISTNAME.tar.xz" >> $out/nix-support/hydra-build-products
     '';
   };
 }

--- a/tarball.nix
+++ b/tarball.nix
@@ -1,9 +1,10 @@
 # Run like this:
+#   nix-build ./tarball.nix
+# or
 #   nix-build --argstr hydraName snabb-lwaftr --arg hydraSrc \
-#     '{ uri = ./. ; gitTag = "1.0.0"; }' ./tarball.nix
-# and the release tarball will be written to ./result/nix-support .
-# It will contain both the sources and the executable, patched to run on
-# Linux LSB systems.
+#     '{ storePath = ./. ; gitTag = "1.0.0"; }' ./tarball.nix
+# and the release tarball will be written to ./result/ . It will contain
+# both the sources and the executable, patched to run on Linux LSB systems.
 #
 # FIXME: currently Hydra doesn't use the --tags parameter in the "git
 # describe" command, so lightweight (non-annotated) tags are not found.
@@ -12,7 +13,7 @@
 
 { nixpkgs ? <nixpkgs>
 , hydraName ? "snabb"
-, hydraSrc ? { uri = ./. ; gitTag = "1.0.0"; }
+, hydraSrc ? { storePath = ./. ; gitTag = "1.0.0"; }
 }:
 
 let
@@ -23,7 +24,7 @@ let
   # TODO: don't massage gitTag for now, re-evaluate later.
   # Possibly add policy to only generate the tarball when there's a new tag.
   name = "${hydraName}-${hydraSrc.gitTag}";
-  src = hydraSrc.uri;
+  src = hydraSrc.storePath;
 in {
   tarball = pkgs.stdenv.mkDerivation rec {
     inherit name src;
@@ -35,9 +36,9 @@ in {
       cp -a $sourceRoot/* $out/$name
     '';
 
-    # preBuild = ''
-    #   make clean
-    # '';
+    preBuild = ''
+      make clean
+    '';
 
     installPhase = ''
       mv src/snabb $out


### PR DESCRIPTION
Implements #642, see the issue for details. The tarballs are available at the [Hydra job webpage](https://hydra.snabb.co/job/igalia/snabb-lwaftr-release/tarball).

This adds a .nix file in the root directory, while two more are already there. It will probably need coordination with upstream.