### PR TITLE
Rework query tests to use common test tooling

### DIFF
--- a/src/program/lwaftr/query/selftest.sh
+++ b/src/program/lwaftr/query/selftest.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
-./program/lwaftr/query/tests/test_query_reconfigurable.sh
-./program/lwaftr/query/tests/test_query.sh
+LWAFTR_DIR="./program/lwaftr"
+
+# Pass TEST_DIR and QUERY_TEST_DIR to the invoked scripts.
+export TEST_DIR="${LWAFTR_DIR}/tests"
+export QUERY_TEST_DIR="${LWAFTR_DIR}/query/tests"
+
+${QUERY_TEST_DIR}/test_query.sh
+${QUERY_TEST_DIR}/test_query_reconfigurable.sh

--- a/src/program/lwaftr/query/tests/test_query.sh
+++ b/src/program/lwaftr/query/tests/test_query.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 
-SKIPPED_CODE=43
+TEST_NAME="query"
 
-if [[ -z "$SNABB_PCI0" ]]; then
-    echo "SNABB_PCI0 not set"
-    exit $SKIPPED_CODE
-fi
+# TEST_DIR is set by the caller, and passed onward.
+export TEST_DIR
+source ${TEST_DIR}/common.sh
 
-if [[ -z "$SNABB_PCI1" ]]; then
-    echo "SNABB_PCI1 not set"
-    exit $SKIPPED_CODE
-fi
+check_for_root
+check_nics_available $TEST_NAME
 
-source ./program/lwaftr/query/tests/test_env.sh
+# QUERY_TEST_DIR is also set by the caller.
+source ${QUERY_TEST_DIR}/test_env.sh
+
+echo "Testing ${TEST_NAME}"
 
 trap cleanup EXIT HUP INT QUIT TERM
 
-LWAFTR_CONF=./program/lwaftr/tests/data/no_icmp.conf
 LWAFTR_NAME=lwaftr-$$
+LWAFTR_CONF=${TEST_DIR}/data/no_icmp.conf
 
 # Run lwAFTR.
 tmux_launch "lwaftr" "./snabb lwaftr run --name $LWAFTR_NAME --conf $LWAFTR_CONF --v4 $SNABB_PCI0 --v6 $SNABB_PCI1" "lwaftr.log"

--- a/src/program/lwaftr/query/tests/test_query_reconfigurable.sh
+++ b/src/program/lwaftr/query/tests/test_query_reconfigurable.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 
-SKIPPED_CODE=43
+TEST_NAME="query-reconfigurable"
 
-if [[ -z "$SNABB_PCI0" ]]; then
-    echo "SNABB_PCI0 not set"
-    exit $SKIPPED_CODE
-fi
+# TEST_DIR is set by the caller, and passed onward.
+export TEST_DIR
+source ${TEST_DIR}/common.sh
 
-if [[ -z "$SNABB_PCI1" ]]; then
-    echo "SNABB_PCI1 not set"
-    exit $SKIPPED_CODE
-fi
+check_for_root
+check_nics_available $TEST_NAME
 
-source ./program/lwaftr/query/tests/test_env.sh
+# QUERY_TEST_DIR is also set by the caller.
+source ${QUERY_TEST_DIR}/test_env.sh
+
+echo "Testing ${TEST_NAME}"
 
 trap cleanup EXIT HUP INT QUIT TERM
 
-LWAFTR_CONF=./program/lwaftr/tests/data/no_icmp.conf
 LWAFTR_NAME=lwaftr-$$
+LWAFTR_CONF=${TEST_DIR}/data/no_icmp.conf
 
 # Run lwAFTR.
 tmux_launch "lwaftr" "./snabb lwaftr run --reconfigurable --name $LWAFTR_NAME --conf $LWAFTR_CONF --v4 $SNABB_PCI0 --v6 $SNABB_PCI1" "lwaftr.log"

--- a/src/program/lwaftr/tests/common.sh
+++ b/src/program/lwaftr/tests/common.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+SKIPPED_CODE=43
+
+# Show $1 as error message and exit with code $2, or 1 if not passed.
+function exit_on_error {
+    (>&2 echo $1)
+    if [[ -n "$2" ]]; then
+        exit $2
+    else
+        exit 1
+    fi
+}
+
+# Check that the script is run as root, otherwise exit.
+function check_for_root {
+    if [[ $EUID != 0 ]]; then
+        exit_on_error "This script must be run as root"
+    fi
+}
+
+# Check that a command is available, otherwise exit with code $SKIPPED_CODE.
+function check_command_available {
+    which "$1" &> /dev/null
+    if [[ $? -ne 0 ]]; then
+       exit_on_error "No $1 tool present, unable to run test." $SKIPPED_CODE
+    fi
+}
+
+# Check that NIC interfaces are available, otherwise exit with code $SKIPPED_CODE.
+function check_nics_available {
+    if [[ -z "$SNABB_PCI0" ]]; then
+        exit_on_error "SNABB_PCI0 not set, skipping $1" $SKIPPED_CODE
+    fi
+    if [[ -z "$SNABB_PCI1" ]]; then
+        exit_on_error "SNABB_PCI1 not set, skipping $1" $SKIPPED_CODE
+    fi
+}
+
+# Check that a file exists, otherwise exit.
+# If the second argument is "--remove", remove the file.
+function assert_file_exists {
+    if [[ ! -f "$1" ]]; then
+        exit_on_error "File $1 does not exists."
+    fi
+    if [[ "$2" == "--remove" ]]; then
+        rm -f "$1"
+    fi
+}
+
+# Check equality of the first two arguments.
+# The third argument will be displayed if the check fails.
+# e.g.
+#  $ assert_equal "yellow "cat"                   -> error
+#  $ assert_equal "yellow "cat" "Cat not yellow"  -> error with message
+#  $ assert_equal "banana" "banana"               -> nothing (valid)
+function assert_equal {
+    if [[ -z "$2" ]]; then
+        exit_on_error "assert_equal: not enough arguments."
+        exit 1
+    fi
+    if [[ "$1" == "$2" ]]; then
+        return
+    else
+        if [[ -z "$3" ]]; then
+            exit_on_error "Error: $1 != $2"
+        else
+            exit_on_error "Error: $3"
+        fi
+    fi
+}


### PR DESCRIPTION
Commonly useful parts of `src/program/lwaftr/query/tests/test_env.sh` moved to `src/program/lwaftr/tests/common.sh` (also used by #739 and #740, will remove conflicts later).

All query test scripts reworked accordingly. Part of #412.

Pinging @dpino on this.