### PR TITLE
Add name leaf to snabb-softwire-v1

### DIFF
--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -169,9 +169,8 @@ local function path_setter_for_grammar(grammar, path)
       assert(grammar.type == 'struct')
       local tail_id = data.normalize_id(tail_name)
       return function(config, subconfig)
-	 local newconfig = lib.deepcopy(config)
-         getter(newconfig)[tail_id] = subconfig
-         return newconfig
+         getter(config)[tail_id] = subconfig
+         return config
       end
    end
 
@@ -410,8 +409,7 @@ function Leader:update_configuration (update_fn, verb, path, ...)
    local new_config = update_fn(self.current_configuration, ...)
    local new_app_graph = self.setup_fn(new_config)
    local actions = self.support.compute_config_actions(
-      self.current_app_graph, new_app_graph, to_restart, verb, path,
-      self.followers, ...)
+      self.current_app_graph, new_app_graph, to_restart, verb, path, ...)
    self:enqueue_config_actions(actions)
    self.current_app_graph = new_app_graph
    self.current_configuration = new_config

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -169,8 +169,9 @@ local function path_setter_for_grammar(grammar, path)
       assert(grammar.type == 'struct')
       local tail_id = data.normalize_id(tail_name)
       return function(config, subconfig)
-         getter(config)[tail_id] = subconfig
-         return config
+	 local newconfig = lib.deepcopy(config)
+         getter(newconfig)[tail_id] = subconfig
+         return newconfig
       end
    end
 
@@ -409,7 +410,8 @@ function Leader:update_configuration (update_fn, verb, path, ...)
    local new_config = update_fn(self.current_configuration, ...)
    local new_app_graph = self.setup_fn(new_config)
    local actions = self.support.compute_config_actions(
-      self.current_app_graph, new_app_graph, to_restart, verb, path, ...)
+      self.current_app_graph, new_app_graph, to_restart, verb, path,
+      self.followers, ...)
    self:enqueue_config_actions(actions)
    self.current_app_graph = new_app_graph
    self.current_configuration = new_config

--- a/src/apps/config/support/snabb-softwire-v1.lua
+++ b/src/apps/config/support/snabb-softwire-v1.lua
@@ -254,6 +254,7 @@ local function ietf_softwire_translator ()
       local br_instance, br_instance_key_t =
          cltable_for_grammar(get_ietf_br_instance_grammar())
       br_instance[br_instance_key_t({id=1})] = {
+	 name = native_config.softwire_config.name,
          tunnel_payload_mtu = native_config.softwire_config.internal_interface.mtu,
          tunnel_path_mru = native_config.softwire_config.external_interface.mtu,
          -- FIXME: There's no equivalent of softwire-num-threshold in snabb-softwire-v1.
@@ -326,6 +327,11 @@ local function ietf_softwire_translator ()
          if path[#path].name == 'softwire-num-threshold' then
             error('not yet implemented: softwire-num-threshold')
          end
+	 if path[#path].name == 'name' then
+	    return {{'set', {schema='snabb-softwire-v1',
+			    path="/softwire-config/name",
+			    config=arg}}}
+	 end
          error('unrecognized leaf: '..path[#path].name)
       end
 

--- a/src/apps/config/support/snabb-softwire-v1.lua
+++ b/src/apps/config/support/snabb-softwire-v1.lua
@@ -1,9 +1,6 @@
 -- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 module(..., package.seeall)
-local S = require("syscall")
 local ffi = require('ffi')
-local shm = require('core.shm')
-local lib = require('core.lib')
 local app = require('core.app')
 local equal = require('core.lib').equal
 local dirname = require('core.lib').dirname
@@ -41,34 +38,6 @@ local function get_softwire_grammar()
    return softwire_grammar
 end
 
-local function change_lwaftr_name_actions(old_graph, new_graph, followers)
-   -- We should perform the name change (rename) of the lwaftr instance here
-   -- as it involves making syscalls and isn't paticually performant. It
-   -- shouldn't matter if it's done in another process from the lwaftr as it's
-   -- mainly used externally.
-   assert(old_graph.apps.lwaftr)
-   assert(new_graph.apps.lwaftr)
-
-   local function lwaftr_pid_by_follower_pid(follower_pid)
-      assert(follower_pid)
-      local lwaftrdir = assert(S.readlink(shm.root .. "/" .. follower_pid .. "/group"))
-      return tonumber(lib.basename(lwaftrdir))
-   end
-
-   local oldname = old_graph.apps.lwaftr.arg.softwire_config.name
-   local newname = new_graph.apps.lwaftr.arg.softwire_config.name
-
-   if oldname == nil then
-      for _, follower in pairs(followers) do
-	 app.claim_name(newname, lwaftr_pid_by_follower_pid(follower.pid))
-      end
-   else
-      app.rename_program(oldname, newname)
-   end
-
-   return {}
-end
-
 local function remove_softwire_entry_actions(app_graph, path)
    assert(app_graph.apps['lwaftr'])
    path = path_mod.parse_path(path)
@@ -80,14 +49,14 @@ local function remove_softwire_entry_actions(app_graph, path)
 end
 
 local function compute_config_actions(old_graph, new_graph, to_restart,
-                                      verb, path, followers, arg)
+                                      verb, path, arg)
    if verb == 'add' and path == '/softwire-config/binding-table/softwire' then
       return add_softwire_entry_actions(new_graph, arg)
    elseif (verb == 'remove' and
            path:match('^/softwire%-config/binding%-table/softwire')) then
       return remove_softwire_entry_actions(new_graph, path)
    elseif (verb == 'set' and path == '/softwire-config/name') then
-      return change_lwaftr_name_actions(old_graph, new_graph, followers)
+      return {}
    else
       return generic.compute_config_actions(
          old_graph, new_graph, to_restart, verb, path, arg)

--- a/src/apps/config/support/snabb-softwire-v1.lua
+++ b/src/apps/config/support/snabb-softwire-v1.lua
@@ -223,7 +223,7 @@ local function ietf_softwire_translator ()
       local br_instance, br_instance_key_t =
          cltable_for_grammar(get_ietf_br_instance_grammar())
       br_instance[br_instance_key_t({id=1})] = {
-	 name = native_config.softwire_config.name,
+         name = native_config.softwire_config.name,
          tunnel_payload_mtu = native_config.softwire_config.internal_interface.mtu,
          tunnel_path_mru = native_config.softwire_config.external_interface.mtu,
          -- FIXME: There's no equivalent of softwire-num-threshold in snabb-softwire-v1.

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -695,9 +695,6 @@ function selftest ()
    local progs = assert(enumerate_named_programs())
    assert(progs[progname])
 
-   -- Ensure that trying to take the same name fails
-   assert(not pcall(claim_name, progname))
-
    -- Ensure changing the name succeeds
    local newname = basename.."2"
    claim_name(newname)

--- a/src/lib/yang/snabb-softwire-v1.yang
+++ b/src/lib/yang/snabb-softwire-v1.yang
@@ -126,7 +126,10 @@ module snabb-softwire-v1 {
       }
     }
 
-
+    leaf name {
+      type string;
+      description "Name of lwAFTR instance.";
+    }
 
     container external-interface {
       description

--- a/src/lib/yang/snabb-softwire-v1.yang
+++ b/src/lib/yang/snabb-softwire-v1.yang
@@ -128,7 +128,19 @@ module snabb-softwire-v1 {
 
     leaf name {
       type string;
-      description "Name of lwAFTR instance.";
+      description
+        "Name of lwAFTR instance. This must be unique amongst the Snabb
+         processes on the system. This may be specified either here, in the
+         YANG configuration or via the command line when the lwAFTR is started.
+
+         The order of presidence for this leaf is as followers:
+         1. The name set on an already running lwAFTR instance via snabb set.
+         2. A command line option to specify the name upon starting the lwAFTR
+            instance (i.e. overriding this value).
+         3. The value here in the configuration when starting a lwaftr instance.
+
+         If no name is specified the lwaftr can be referred to using the PID of
+         the lwAFTR process on the system.";
     }
 
     container external-interface {

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -44,7 +44,15 @@ function run(args)
    local opts, scheduling, conf_file, inv4_pcap, inv6_pcap = parse_args(args)
    local conf = require('apps.lwaftr.conf').load_lwaftr_config(conf_file)
 
-   if opts.name then engine.claim_name(opts.name) end
+   -- If there is a name defined on the command line, it should override
+   -- anything defined in the config.
+   if opts.name then
+      conf.softwire_config.name = opts.name
+   end
+
+   if conf.softwire_config.name ~= nil then
+      engine.claim_name(opts.name)
+   end
 
    local graph = config.new()
    if opts.reconfigurable then

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -50,10 +50,6 @@ function run(args)
       conf.softwire_config.name = opts.name
    end
 
-   if conf.softwire_config.name ~= nil then
-      engine.claim_name(opts.name)
-   end
-
    local graph = config.new()
    if opts.reconfigurable then
       setup.reconfigurable(scheduling, setup.load_bench, graph, conf,

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -143,10 +143,6 @@ function run(args)
       conf.softwire_config.name = opts.name
    end
 
-   if conf.softwire_config.name ~= nil then
-      engine.claim_name(opts.name)
-   end
-
    local c = config.new()
    local setup_fn, setup_args
    if opts.virtio_net then

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -137,7 +137,15 @@ function run(args)
    local conf = require('apps.lwaftr.conf').load_lwaftr_config(conf_file)
    local use_splitter = requires_splitter(opts, conf)
 
-   if opts.name then engine.claim_name(opts.name) end
+   -- If there is a name defined on the command line, it should override
+   -- anything defined in the config.
+   if opts.name then
+      conf.softwire_config.name = opts.name
+   end
+
+   if conf.softwire_config.name ~= nil then
+      engine.claim_name(opts.name)
+   end
 
    local c = config.new()
    local setup_fn, setup_args

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -524,18 +524,26 @@ end
 
 function reconfigurable(scheduling, f, graph, conf, ...)
    local args = {...}
+   local function switch_names(conf)
+      local currentname = engine.program_name
+      local name = conf.apps.lwaftr.arg.softwire_config.name
+      -- Don't do anything if the name isn't set.
+      if name == nil then
+	 return
+      end
+
+      local success, err = pcall(engine.claim_name, name)
+      if success == false then
+	 -- Restore the previous name.
+	 conf.apps.lwaftr.arg.softwire_config.name = currentname
+	 assert(success, err)
+      end
+   end
+
    local function setup_fn(conf)
       local graph = config.new()
       f(graph, conf, unpack(args))
-      local name = graph.apps.lwaftr.arg.softwire_config.name
-      if name then
-	 local succ, err = pcall(engine.claim_name, name)
-	 if succ == false then
-	    local oldname = engine.configuration.name
-	    graph.apps.lwaftr.arg.softwire_config.name = oldname
-	 end
-	 assert(succ, err)
-      end
+      switch_names(graph)
       return graph
    end
 

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -527,6 +527,15 @@ function reconfigurable(scheduling, f, graph, conf, ...)
    local function setup_fn(conf)
       local graph = config.new()
       f(graph, conf, unpack(args))
+      local name = graph.apps.lwaftr.arg.softwire_config.name
+      if name then
+	 local succ, err = pcall(engine.claim_name, name)
+	 if succ == false then
+	    local oldname = engine.configuration.name
+	    graph.apps.lwaftr.arg.softwire_config.name = oldname
+	 end
+	 assert(succ, err)
+      end
       return graph
    end
 


### PR DESCRIPTION
This is the implementation of the proposal in issue #737. You can now get and set the name either using the snabb-softwire-v1 schema or the translated ietf-softwire schema. The information of how this is implemented is specified in the issue so to avoid duplicating that, please check #737.

I opted to do the renaming in the leader opposed to the follower, which somewhat breaks the paradigm we were using. Changing the name can be done entirely in another process and since it uses syscalls and isn't as performant as we might like I think doing it in the leader makes the most sense. It also means requests to change the name should not be able to effect the lwaftr's performance as it never reaches the lwaftr.

PTAL @wingo