### PR TITLE
Improve snabbvmx test

### DIFF
--- a/src/program/snabbvmx/tests/selftest.sh
+++ b/src/program/snabbvmx/tests/selftest.sh
@@ -45,9 +45,11 @@ function tcpreplay {
 }
 
 function create_mirror_tap_if_needed {
-    sudo ip tuntap add $MIRROR_TAP mode tap &>/dev/null
-    sudo ip li set dev $MIRROR_TAP up &>/dev/null
-    sudo ip li sh $MIRROR_TAP &>/dev/null
+    local TAP_LOG="tap0.log"
+    sudo ip li delete $MIRROR_TAP &> $TAP_LOG
+    sudo ip tuntap add $MIRROR_TAP mode tap &>> $TAP_LOG
+    sudo ip li set dev $MIRROR_TAP up &>> $TAP_LOG
+    sudo ip li sh $MIRROR_TAP &>> $TAP_LOG
     if [[ $? -ne 0 ]]; then
         echo "Couldn't create mirror tap: $MIRROR_TAP"
         exit 1

--- a/src/program/snabbvmx/tests/test_env/test_env.sh
+++ b/src/program/snabbvmx/tests/test_env/test_env.sh
@@ -69,6 +69,7 @@ function start_test_env {
     wait_vm_up $SNABB_TELNET0
 
     # Configure eth0 interface in the VM.
+    echo -n "Setting up VM..."
 
     # Bring up interface.
     run_telnet $SNABB_TELNET0 "ifconfig eth0 up" >/dev/null
@@ -88,4 +89,6 @@ function start_test_env {
     # Activate IPv4 and IPv6 forwarding.
     run_telnet $SNABB_TELNET0 "sysctl -w net.ipv4.conf.all.forwarding=1" >/dev/null
     run_telnet $SNABB_TELNET0 "sysctl -w net.ipv6.conf.all.forwarding=1" >/dev/null
+
+    echo " [OK]"
 }


### PR DESCRIPTION
I started this PR as a means to fix the errors in SnabbVMX's selftest I got from snabb2. It turned out that the errors from snabb2 were due to a environment problem. I think the changes in this PR are still valuable so I'd like to merge them. Changes:

* Notify when VM setup is done.
* Pass a PID to "snabb lwaftr monitor".
* Recreate TAP mirror interface.
