### PR TITLE
Stop using tmux in query tests

### DIFF
--- a/src/program/lwaftr/query/tests/test_query.sh
+++ b/src/program/lwaftr/query/tests/test_query.sh
@@ -7,7 +7,6 @@ export TEST_DIR
 source ${TEST_DIR}/common.sh || exit $?
 
 check_nics_available "$TEST_NAME"
-check_commands_available "$TEST_NAME" tmux
 
 # QUERY_TEST_DIR is also set by the caller.
 source ${QUERY_TEST_DIR}/test_env.sh || exit $?
@@ -20,9 +19,8 @@ LWAFTR_NAME=lwaftr-$$
 LWAFTR_CONF=${TEST_DIR}/data/no_icmp.conf
 
 # Launch "lwaftr run".
-CMD_LINE="./snabb lwaftr run --name $LWAFTR_NAME --conf $LWAFTR_CONF"
-CMD_LINE+=" --v4 $SNABB_PCI0 --v6 $SNABB_PCI1"
-tmux_launch "$CMD_LINE" "lwaftr.log"
+./snabb lwaftr run --name $LWAFTR_NAME --conf $LWAFTR_CONF \
+    --v4 $SNABB_PCI0 --v6 $SNABB_PCI1 &> lwaftr.log &
 sleep 2
 
 # Test query all.

--- a/src/program/lwaftr/query/tests/test_query_reconfigurable.sh
+++ b/src/program/lwaftr/query/tests/test_query_reconfigurable.sh
@@ -7,7 +7,6 @@ export TEST_DIR
 source ${TEST_DIR}/common.sh || exit $?
 
 check_nics_available "$TEST_NAME"
-check_commands_available "$TEST_NAME" tmux
 
 # QUERY_TEST_DIR is also set by the caller.
 source ${QUERY_TEST_DIR}/test_env.sh || exit $?
@@ -19,11 +18,9 @@ trap query_cleanup EXIT HUP INT QUIT TERM
 LWAFTR_NAME=lwaftr-$$
 LWAFTR_CONF=${TEST_DIR}/data/no_icmp.conf
 
-# Launch "lwaftr run". Do not break the "lwaftr run --reconfigurable" string,
-# see get_lwaftr_leader in common.sh .
-CMD_LINE="./snabb lwaftr run --reconfigurable --name $LWAFTR_NAME"
-CMD_LINE+=" --conf $LWAFTR_CONF --v4 $SNABB_PCI0 --v6 $SNABB_PCI1"
-tmux_launch "$CMD_LINE" "lwaftr.log"
+# Launch "lwaftr run".
+./snabb lwaftr run --name $LWAFTR_NAME --conf $LWAFTR_CONF --reconfigurable \
+    --v4 $SNABB_PCI0 --v6 $SNABB_PCI1 &> lwaftr.log &
 sleep 2
 
 # Test query all.

--- a/src/program/lwaftr/tests/common.sh
+++ b/src/program/lwaftr/tests/common.sh
@@ -72,16 +72,3 @@ function assert_equal {
         fi
     fi
 }
-
-# Launch a command in a new window of an existing session, or in a new session.
-# First parameter: the command as one string;
-# second parameter: the log file name.
-function tmux_launch {
-    local command="$1 2>&1 | tee $2"
-    if [ -z "$tmux_session" ]; then
-        tmux_session=test_env-$$
-        tmux new-session -d -n "lwaftr" -s $tmux_session "$command"
-    else
-        tmux new-window -a -d -n "lwaftr" -t $tmux_session "$command"
-    fi
-}

--- a/src/program/lwaftr/tests/config/test_env.sh
+++ b/src/program/lwaftr/tests/config/test_env.sh
@@ -21,20 +21,20 @@ function start_lwaftr_bench {
 
 function stop_lwaftr_bench {
     # Get the job number for lwaftr bench.
-    local jobid="`jobs | grep -i \"lwaftr bench\" | awk '{print $1}' | tr -d '[]+'`"
-    kill -15 "%$jobid"
+    local jobid=`jobs | grep -i "lwaftr bench" | awk '{print $1}' | tr -d '[]+'`
+    kill "%$jobid"
     # Wait until it's shutdown.
     wait &> /dev/null
 }
 
 function stop_if_running {
     # Check if it's running, if not, job done.
-    kill -0 "$1" &> /dev/null
+    kill -0 $1 &> /dev/null
     if [[ $? -ne 0 ]]; then
         return
     fi
 
     # It's running, try and close it nicely.
-    kill -15 "$1"
+    kill $1
     wait &> /dev/null
 }


### PR DESCRIPTION
Remove tmux as a dependency in query tests, use shell jobs instead. Part of #412.