### PR TITLE
Quit without a backtrace on bad command line args

### DIFF
--- a/src/lib/yang/path.lua
+++ b/src/lib/yang/path.lua
@@ -32,6 +32,8 @@ local valuelib = require("lib.yang.value")
 local util = require("lib.yang.util")
 local normalize_id = datalib.normalize_id
 
+local errq = util.err_and_quit
+
 local function table_keys(t)
    local ret = {}
    for k, v in pairs(t) do table.insert(ret, k) end
@@ -213,14 +215,14 @@ function resolver(grammar, path_string)
    local function compute_getter(grammar, name, query, getter)
       local child_grammar = grammar.members[name]
       if not child_grammar then
-         error("Struct has no field named '"..name.."'.")
+         errq("Struct has no field named '"..name.."'.")
       end
       local id = normalize_id(name)
       local function child_getter(data)
          local struct = getter(data)
          local child = struct[id]
          if child == nil then
-            error("Struct instance has no field named '"..name.."'.")
+            errq("Struct instance has no field named '"..name.."'.")
          end
          return child
       end

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -128,6 +128,12 @@ function memoize(f, max_occupancy)
    end
 end
 
+function err_and_quit(msg)
+   io.stderr:write(msg .. '\n')
+   io.stderr:flush()
+   os.exit(1)
+end
+
 function selftest()
    print('selftest: lib.yang.util')
    assert(tointeger('0') == 0)


### PR DESCRIPTION
This patch makes error messages when specifying an invalid field with snabb
config more user-friendly.

Before:
lib/yang/path.lua:216: Struct has no field named 'reassembly-max-fragments-per-packet'.
[full backtrace]

After:
Struct has no field named 'reassembly-max-fragments-per-packet'.
(non-zero exit code).

This solves issue #707 .