### PR TITLE
Add a selftest for the lwaftr run command

### DIFF
--- a/src/program/lwaftr/tests/lib/test_env.py
+++ b/src/program/lwaftr/tests/lib/test_env.py
@@ -1,0 +1,24 @@
+"""
+Environment support code for tests.
+"""
+
+import os
+from pathlib import Path
+
+
+# Commands run under "sudo" run as root. The root's user PATH should not
+# include "." (the current directory) for security reasons. If this is the
+# case, when we run tests from the "src" directory (where the "snabb"
+# executable is), the "snabb" executable will not be found by relative paths.
+# Therefore we make all paths absolute.
+TESTS_DIR = Path(os.environ['TESTS_DIR']).resolve()
+DATA_DIR = TESTS_DIR / 'data'
+BENCHDATA_DIR = TESTS_DIR / 'benchdata'
+SNABB_CMD = TESTS_DIR.parents[2] / 'snabb'
+BENCHMARK_FILENAME = 'benchtest.csv'
+# Snabb creates the benchmark file in the current directory
+BENCHMARK_PATH = Path.cwd() / BENCHMARK_FILENAME
+
+
+def nic_names():
+    return os.environ.get('SNABB_PCI0'), os.environ.get('SNABB_PCI1')

--- a/src/program/lwaftr/tests/subcommands/branch_test.py
+++ b/src/program/lwaftr/tests/subcommands/branch_test.py
@@ -2,28 +2,14 @@
 Test the "snabb lwaftr bench" subcommand. Does not need NIC cards.
 """
 
-import os
-from pathlib import Path
 import unittest
 
 from lib import sh
+from lib.test_env import (
+    BENCHMARK_FILENAME, BENCHMARK_PATH, DATA_DIR, BENCHDATA_DIR, SNABB_CMD)
 
 
-# Commands run under "sudo" run as root. The root's user PATH should not
-# include "." (the current directory) for security reasons. If this is the
-# case, when we run tests from the "src" directory (where the "snabb"
-# executable is), the "snabb" executable will not be found by relative paths.
-# Therefore we make all paths absolute.
-TESTS_DIR = Path(os.environ['TESTS_DIR']).resolve()
-DATA_DIR = TESTS_DIR / 'data'
-BENCHDATA_DIR = TESTS_DIR / 'benchdata'
-SNABB_CMD = TESTS_DIR.parents[2] / 'snabb'
-BENCHMARK_FILENAME = 'benchtest.csv'
-# Snabb creates the benchmark file in the current directory
-BENCHMARK_PATH = Path.cwd() / BENCHMARK_FILENAME
-
-
-class TestBenchSubcommand(unittest.TestCase):
+class TestBench(unittest.TestCase):
 
     cmd_args = (
         SNABB_CMD, 'lwaftr', 'bench',
@@ -34,20 +20,20 @@ class TestBenchSubcommand(unittest.TestCase):
         BENCHDATA_DIR / 'ipv6-0550.pcap',
     )
 
-    def run_bench_test(self, cmd_args):
+    def execute_bench_test(self, cmd_args):
         output = sh.sudo(*cmd_args)
         self.assertEqual(output.exit_code, 0)
         self.assertTrue(BENCHMARK_PATH.is_file(),
             'Cannot find {}'.format(BENCHMARK_PATH))
         BENCHMARK_PATH.unlink()
 
-    def test_standard(self):
-        self.run_bench_test(self.cmd_args)
+    def test_bench_standard(self):
+        self.execute_bench_test(self.cmd_args)
 
-    def test_reconfigurable(self):
+    def test_bench_reconfigurable(self):
         reconf_cmd_args = list(self.cmd_args)
         reconf_cmd_args.insert(3, '--reconfigurable')
-        self.run_bench_test(reconf_cmd_args)
+        self.execute_bench_test(reconf_cmd_args)
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -1,0 +1,42 @@
+"""
+Test the "snabb lwaftr run" subcommand. Needs NIC names.
+"""
+
+import unittest
+
+from lib import sh
+from lib.test_env import DATA_DIR, SNABB_CMD, nic_names
+
+
+SNABB_PCI0, SNABB_PCI1 = nic_names()
+
+
+class TestRun(unittest.TestCase):
+
+    cmd_args = (
+        SNABB_CMD, 'lwaftr', 'run',
+        '--duration', '0.1',
+        '--bench-file', '/dev/null',
+        '--conf', DATA_DIR / 'icmp_on_fail.conf',
+        '--v4', SNABB_PCI0,
+        '--v6', SNABB_PCI1,
+    )
+
+    def execute_run_test(self, cmd_args):
+        output = sh.sudo(*cmd_args)
+        self.assertEqual(output.exit_code, 0)
+        self.assert_(len(output.splitlines()) > 1)
+
+    @unittest.skipUnless(SNABB_PCI0 and SNABB_PCI1, 'NICs not configured')
+    def test_run_standard(self):
+        self.execute_run_test(self.cmd_args)
+
+    @unittest.skipUnless(SNABB_PCI0 and SNABB_PCI1, 'NICs not configured')
+    def test_run_reconfigurable(self):
+        reconf_cmd_args = list(self.cmd_args)
+        reconf_cmd_args.insert(3, '--reconfigurable')
+        self.execute_run_test(reconf_cmd_args)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add a selftest for the `snabb lwaftr run` command, and refactor the `bench` one. Part of #412, implements #745, supercedes #747.