### PR TITLE
Fix named program regression

### DIFF
--- a/src/program/lwaftr/query/tests/test_query.sh
+++ b/src/program/lwaftr/query/tests/test_query.sh
@@ -35,9 +35,8 @@ if [[ -n "$pid" ]]; then
 fi
 
 # Test query by name.
-## FIXME: currently broken in non-reconfigurable mode.
-#test_lwaftr_query "--name $LWAFTR_NAME"
-#test_lwaftr_query "--name $LWAFTR_NAME memuse-ipv"
-#test_lwaftr_query_no_counters "--name $LWAFTR_NAME counter-never-exists-123"
+test_lwaftr_query "--name $LWAFTR_NAME"
+test_lwaftr_query "--name $LWAFTR_NAME memuse-ipv"
+test_lwaftr_query_no_counters "--name $LWAFTR_NAME counter-never-exists-123"
 
 exit 0

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -35,8 +35,8 @@ function lwaftr_app(c, conf)
    local function append(t, elem) table.insert(t, elem) end
    local function prepend(t, elem) table.insert(t, 1, elem) end
 
-	-- Claim the name if one is defined.
-	local function switch_names(config)
+   -- Claim the name if one is defined.
+   local function switch_names(config)
       local currentname = engine.program_name
       local name = config.softwire_config.name
       -- Don't do anything if the name isn't set.

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -35,6 +35,24 @@ function lwaftr_app(c, conf)
    local function append(t, elem) table.insert(t, elem) end
    local function prepend(t, elem) table.insert(t, 1, elem) end
 
+	-- Claim the name if one is defined.
+	local function switch_names(config)
+      local currentname = engine.program_name
+      local name = config.softwire_config.name
+      -- Don't do anything if the name isn't set.
+      if name == nil then
+         return
+      end
+
+      local success, err = pcall(engine.claim_name, name)
+      if success == false then
+         -- Restore the previous name.
+         config.softwire_config.name = currentname
+         assert(success, err)
+      end
+   end
+   switch_names(conf)
+
    config.app(c, "reassemblerv4", ipv4_apps.Reassembler,
               { max_ipv4_reassembly_packets =
                    external_interface.reassembly.max_packets,
@@ -524,26 +542,10 @@ end
 
 function reconfigurable(scheduling, f, graph, conf, ...)
    local args = {...}
-   local function switch_names(conf)
-      local currentname = engine.program_name
-      local name = conf.apps.lwaftr.arg.softwire_config.name
-      -- Don't do anything if the name isn't set.
-      if name == nil then
-	 return
-      end
-
-      local success, err = pcall(engine.claim_name, name)
-      if success == false then
-	 -- Restore the previous name.
-	 conf.apps.lwaftr.arg.softwire_config.name = currentname
-	 assert(success, err)
-      end
-   end
 
    local function setup_fn(conf)
       local graph = config.new()
       f(graph, conf, unpack(args))
-      switch_names(graph)
       return graph
    end
 


### PR DESCRIPTION
This fixes the regression where programs wouldn't claim their names unless the `--reconfigurable` flag was enabled. 

Issue #748 

PTAL @wingo 