### PR TITLE
Fix #702 - Error when neither of next-hop's leaves are specified

### DIFF
--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -53,6 +53,11 @@ function lwaftr_app(c, conf)
    end
    switch_names(conf)
 
+   -- Verify either or both of next-hop value's are specified (can't be done in YANG)
+   if internal_interface.next_hop == nil then
+      error("One or both of the 'next_hop' values must be specified")
+   end
+
    config.app(c, "reassemblerv4", ipv4_apps.Reassembler,
               { max_ipv4_reassembly_packets =
                    external_interface.reassembly.max_packets,


### PR DESCRIPTION
This fixes the problem brought up in #702. The `next-hop` container has two leaves `ip` and `mac`. One of the two leaves must be specified, or both can be. The problem is there isn't a good way using YANG to make one of them mandatory in a container but leaving them both optional produces a cryptic error message.

I've pushed a fix which checks in for both of them being missing and displays a helpful error message.