### PR TITLE
Add a selftest for the "lwaftr check" command

### DIFF
--- a/src/program/lwaftr/tests/data/counters/empty.lua
+++ b/src/program/lwaftr/tests/data/counters/empty.lua
@@ -1,0 +1,4 @@
+return {
+   ["memuse-ipv4-frag-reassembly-buffer"] = 463571780,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+}

--- a/src/program/lwaftr/tests/lib/test_env.py
+++ b/src/program/lwaftr/tests/lib/test_env.py
@@ -13,6 +13,7 @@ from pathlib import Path
 # Therefore we make all paths absolute.
 TESTS_DIR = Path(os.environ['TESTS_DIR']).resolve()
 DATA_DIR = TESTS_DIR / 'data'
+COUNTERS_DIR = DATA_DIR / 'counters'
 BENCHDATA_DIR = TESTS_DIR / 'benchdata'
 SNABB_CMD = TESTS_DIR.parents[2] / 'snabb'
 BENCHMARK_FILENAME = 'benchtest.csv'

--- a/src/program/lwaftr/tests/subcommands/check_test.py
+++ b/src/program/lwaftr/tests/subcommands/check_test.py
@@ -1,0 +1,35 @@
+"""
+Test the "snabb lwaftr check" subcommand. Does not need NIC names.
+"""
+
+import unittest
+
+from lib import sh
+from lib.test_env import COUNTERS_DIR, DATA_DIR, SNABB_CMD
+
+
+class TestCheck(unittest.TestCase):
+
+    cmd_args = (
+        SNABB_CMD, 'lwaftr', 'check',
+        DATA_DIR / 'icmp_on_fail.conf',
+        DATA_DIR / 'empty.pcap', DATA_DIR / 'empty.pcap',
+        '/dev/null', '/dev/null',
+        COUNTERS_DIR / 'empty.lua',
+    )
+
+    def execute_check_test(self, cmd_args):
+        output = sh.sudo(*cmd_args)
+        self.assertEqual(output.exit_code, 0)
+
+    def test_check_standard(self):
+        self.execute_check_test(self.cmd_args)
+
+    def test_check_on_a_stick(self):
+        onastick_cmd_args = list(self.cmd_args)
+        onastick_cmd_args.insert(3, '--on-a-stick')
+        self.execute_check_test(onastick_cmd_args)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add a selftest for the `snabb lwaftr check` command. Part of #412, implements #756.