### PR TITLE
Improve Python selftests

### DIFF
--- a/src/program/lwaftr/tests/data/counters/empty.lua
+++ b/src/program/lwaftr/tests/data/counters/empty.lua
@@ -1,0 +1,4 @@
+return {
+   ["memuse-ipv4-frag-reassembly-buffer"] = 463571780,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+}

--- a/src/program/lwaftr/tests/lib/test_env.py
+++ b/src/program/lwaftr/tests/lib/test_env.py
@@ -13,6 +13,7 @@ from pathlib import Path
 # Therefore we make all paths absolute.
 TESTS_DIR = Path(os.environ['TESTS_DIR']).resolve()
 DATA_DIR = TESTS_DIR / 'data'
+COUNTERS_DIR = DATA_DIR / 'counters'
 BENCHDATA_DIR = TESTS_DIR / 'benchdata'
 SNABB_CMD = TESTS_DIR.parents[2] / 'snabb'
 BENCHMARK_FILENAME = 'benchtest.csv'

--- a/src/program/lwaftr/tests/lib/test_env.py
+++ b/src/program/lwaftr/tests/lib/test_env.py
@@ -5,6 +5,8 @@ Environment support code for tests.
 import os
 from pathlib import Path
 
+from lib import sh
+
 
 # Commands run under "sudo" run as root. The root's user PATH should not
 # include "." (the current directory) for security reasons. If this is the
@@ -23,3 +25,10 @@ BENCHMARK_PATH = Path.cwd() / BENCHMARK_FILENAME
 
 def nic_names():
     return os.environ.get('SNABB_PCI0'), os.environ.get('SNABB_PCI1')
+
+
+def tap0_available():
+    output = sh.ip('tuntap', 'list')
+    if output.exit_code != 0:
+        return False
+    return 'tap0' in output

--- a/src/program/lwaftr/tests/lib/test_env.py
+++ b/src/program/lwaftr/tests/lib/test_env.py
@@ -27,8 +27,13 @@ def nic_names():
     return os.environ.get('SNABB_PCI0'), os.environ.get('SNABB_PCI1')
 
 
-def tap0_available():
+def tap_name():
+    """
+    Return the first TAP interface name if one found: (tap_iface, None).
+    Return (None, 'No TAP interface available') if none found.
+    """
     output = sh.ip('tuntap', 'list')
-    if output.exit_code != 0:
-        return False
-    return 'tap0' in output
+    tap_iface = output.split(':')[0]
+    if not tap_iface:
+        return None, 'No TAP interface available'
+    return tap_iface, None

--- a/src/program/lwaftr/tests/selftest.sh
+++ b/src/program/lwaftr/tests/selftest.sh
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
 
-# Make it work from wherever this script is called, and let tests know.
-export TESTS_DIR=`dirname "$0"`
-
 # Entry point for Python tests.
 #
-# Start discovery from this script's directory, the root of the "tests" subtree.
-# Find unittests in all Python files ending with "_test.py".
+# Make it work from wherever this script is called, and let tests know.
+export TESTS_DIR=`dirname "$0"`
+export PYTHONPATH=${TESTS_DIR}
+
+# Only run tests in the passed subdirectory of $TESTS_DIR.
+if [[ -n $1 ]]; then
+    START_DIR=${TESTS_DIR}/$1/
+else
+    START_DIR=${TESTS_DIR}
+fi
+
+# Start discovery from this script's directory, the root of the "tests" subtree,
+# or one of its subdirectories, if passed as first argument to this script.
+# Look for unittests in all files whose name ends with "_test.py".
 # List all executed tests, don't show just dots.
 python3 -m unittest discover \
-    --start-directory "${TESTS_DIR}" \
+    --start-directory "${START_DIR}" \
     --pattern "*_test.py" \
     --verbose

--- a/src/program/lwaftr/tests/subcommands/bench_test.py
+++ b/src/program/lwaftr/tests/subcommands/bench_test.py
@@ -4,9 +4,8 @@ Test the "snabb lwaftr bench" subcommand. Does not need NIC cards.
 
 import unittest
 
-from lib.test_env import (
-    BENCHMARK_FILENAME, BENCHMARK_PATH, DATA_DIR, BENCHDATA_DIR, SNABB_CMD,
-    BaseTestCase)
+from lib.test_env import (BENCHMARK_FILENAME, BENCHMARK_PATH, DATA_DIR,
+    BENCHDATA_DIR, SNABB_CMD, BaseTestCase)
 
 
 class TestBench(BaseTestCase):

--- a/src/program/lwaftr/tests/subcommands/bench_test.py
+++ b/src/program/lwaftr/tests/subcommands/bench_test.py
@@ -4,24 +4,24 @@ Test the "snabb lwaftr bench" subcommand. Does not need NIC cards.
 
 import unittest
 
-from lib import sh
 from lib.test_env import (
-    BENCHMARK_FILENAME, BENCHMARK_PATH, DATA_DIR, BENCHDATA_DIR, SNABB_CMD)
+    BENCHMARK_FILENAME, BENCHMARK_PATH, DATA_DIR, BENCHDATA_DIR, SNABB_CMD,
+    BaseTestCase)
 
 
-class TestBench(unittest.TestCase):
+class TestBench(BaseTestCase):
 
     cmd_args = (
-        SNABB_CMD, 'lwaftr', 'bench',
+        str(SNABB_CMD), 'lwaftr', 'bench',
         '--duration', '0.1',
         '--bench-file', BENCHMARK_FILENAME,
-        DATA_DIR / 'icmp_on_fail.conf',
-        BENCHDATA_DIR / 'ipv4-0550.pcap',
-        BENCHDATA_DIR / 'ipv6-0550.pcap',
+        str(DATA_DIR / 'icmp_on_fail.conf'),
+        str(BENCHDATA_DIR / 'ipv4-0550.pcap'),
+        str(BENCHDATA_DIR / 'ipv6-0550.pcap'),
     )
 
     def execute_bench_test(self, cmd_args):
-        output = sh.sudo(*cmd_args)
+        output = self.run_cmd(cmd_args)
         self.assertTrue(BENCHMARK_PATH.is_file(),
             'Cannot find {}'.format(BENCHMARK_PATH))
         BENCHMARK_PATH.unlink()

--- a/src/program/lwaftr/tests/subcommands/bench_test.py
+++ b/src/program/lwaftr/tests/subcommands/bench_test.py
@@ -22,7 +22,6 @@ class TestBench(unittest.TestCase):
 
     def execute_bench_test(self, cmd_args):
         output = sh.sudo(*cmd_args)
-        self.assertEqual(output.exit_code, 0)
         self.assertTrue(BENCHMARK_PATH.is_file(),
             'Cannot find {}'.format(BENCHMARK_PATH))
         BENCHMARK_PATH.unlink()

--- a/src/program/lwaftr/tests/subcommands/bench_test.py
+++ b/src/program/lwaftr/tests/subcommands/bench_test.py
@@ -21,7 +21,7 @@ class TestBench(BaseTestCase):
     )
 
     def execute_bench_test(self, cmd_args):
-        output = self.run_cmd(cmd_args)
+        self.run_cmd(cmd_args)
         self.assertTrue(BENCHMARK_PATH.is_file(),
             'Cannot find {}'.format(BENCHMARK_PATH))
         BENCHMARK_PATH.unlink()
@@ -30,9 +30,9 @@ class TestBench(BaseTestCase):
         self.execute_bench_test(self.cmd_args)
 
     def test_bench_reconfigurable(self):
-        reconf_cmd_args = list(self.cmd_args)
-        reconf_cmd_args.insert(3, '--reconfigurable')
-        self.execute_bench_test(reconf_cmd_args)
+        reconf_args = list(self.cmd_args)
+        reconf_args.insert(3, '--reconfigurable')
+        self.execute_bench_test(reconf_args)
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/check_test.py
+++ b/src/program/lwaftr/tests/subcommands/check_test.py
@@ -1,0 +1,35 @@
+"""
+Test the "snabb lwaftr check" subcommand. Does not need NIC names.
+"""
+
+import unittest
+
+from lib import sh
+from lib.test_env import COUNTERS_DIR, DATA_DIR, SNABB_CMD
+
+
+class TestCheck(unittest.TestCase):
+
+    cmd_args = (
+        SNABB_CMD, 'lwaftr', 'check',
+        DATA_DIR / 'icmp_on_fail.conf',
+        DATA_DIR / 'empty.pcap', DATA_DIR / 'empty.pcap',
+        '/dev/null', '/dev/null',
+        COUNTERS_DIR / 'empty.lua',
+    )
+
+    def execute_check_test(self, cmd_args):
+        output = sh.sudo(*cmd_args)
+        self.assertEqual(output.exit_code, 0)
+
+    def test_check_standard(self):
+        self.execute_check_test(self.cmd_args)
+
+    def test_check_on_a_stick(self):
+        onastick_cmd_args = list(self.cmd_args)
+        onastick_cmd_args.insert(3, '--on-a-stick')
+        self.execute_check_test(onastick_cmd_args)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/program/lwaftr/tests/subcommands/check_test.py
+++ b/src/program/lwaftr/tests/subcommands/check_test.py
@@ -4,23 +4,22 @@ Test the "snabb lwaftr check" subcommand. Does not need NIC names.
 
 import unittest
 
-from lib import sh
-from lib.test_env import COUNTERS_DIR, DATA_DIR, SNABB_CMD
+from lib.test_env import COUNTERS_DIR, DATA_DIR, SNABB_CMD, BaseTestCase
 
 
-class TestCheck(unittest.TestCase):
+class TestCheck(BaseTestCase):
 
     cmd_args = (
-        SNABB_CMD, 'lwaftr', 'check',
-        DATA_DIR / 'icmp_on_fail.conf',
-        DATA_DIR / 'empty.pcap', DATA_DIR / 'empty.pcap',
+        str(SNABB_CMD), 'lwaftr', 'check',
+        str(DATA_DIR / 'icmp_on_fail.conf'),
+        str(DATA_DIR / 'empty.pcap'), str(DATA_DIR / 'empty.pcap'),
         '/dev/null', '/dev/null',
-        COUNTERS_DIR / 'empty.lua',
+        str(COUNTERS_DIR / 'empty.lua'),
     )
 
     def execute_check_test(self, cmd_args):
-        output = sh.sudo(*cmd_args)
-        # An exception is raised by sh if the exit_code is not zero.
+        self.run_cmd(cmd_args)
+        # An exception is raised by run_cmd if the exit code is not zero.
 
     def test_check_standard(self):
         self.execute_check_test(self.cmd_args)

--- a/src/program/lwaftr/tests/subcommands/check_test.py
+++ b/src/program/lwaftr/tests/subcommands/check_test.py
@@ -20,7 +20,7 @@ class TestCheck(unittest.TestCase):
 
     def execute_check_test(self, cmd_args):
         output = sh.sudo(*cmd_args)
-        self.assertEqual(output.exit_code, 0)
+        # An exception is raised by sh if the exit_code is not zero.
 
     def test_check_standard(self):
         self.execute_check_test(self.cmd_args)

--- a/src/program/lwaftr/tests/subcommands/check_test.py
+++ b/src/program/lwaftr/tests/subcommands/check_test.py
@@ -25,9 +25,9 @@ class TestCheck(BaseTestCase):
         self.execute_check_test(self.cmd_args)
 
     def test_check_on_a_stick(self):
-        onastick_cmd_args = list(self.cmd_args)
-        onastick_cmd_args.insert(3, '--on-a-stick')
-        self.execute_check_test(onastick_cmd_args)
+        onastick_args = list(self.cmd_args)
+        onastick_args.insert(3, '--on-a-stick')
+        self.execute_check_test(onastick_args)
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/check_test.py
+++ b/src/program/lwaftr/tests/subcommands/check_test.py
@@ -19,7 +19,7 @@ class TestCheck(BaseTestCase):
 
     def execute_check_test(self, cmd_args):
         self.run_cmd(cmd_args)
-        # An exception is raised by run_cmd if the exit code is not zero.
+        # run_cmd checks the exit code and fails the test if it is not zero.
 
     def test_check_standard(self):
         self.execute_check_test(self.cmd_args)

--- a/src/program/lwaftr/tests/subcommands/loadtest_test.py
+++ b/src/program/lwaftr/tests/subcommands/loadtest_test.py
@@ -24,7 +24,6 @@ class TestLoadtest(BaseTestCase):
         '--conf', str(DATA_DIR / 'icmp_on_fail.conf'),
         '--on-a-stick', SNABB_PCI0,
     )
-
     loadtest_args = (
         str(SNABB_CMD), 'lwaftr', 'loadtest',
         '--bench-file', '/dev/null',
@@ -37,6 +36,7 @@ class TestLoadtest(BaseTestCase):
         str(BENCHDATA_DIR / 'ipv4_and_ipv6_stick_imix.pcap'), 'ALL', 'ALL',
         SNABB_PCI1,
     )
+    wait_for_daemon_startup = True
 
     def test_loadtest(self):
         output = self.run_cmd(self.loadtest_args)

--- a/src/program/lwaftr/tests/subcommands/loadtest_test.py
+++ b/src/program/lwaftr/tests/subcommands/loadtest_test.py
@@ -41,7 +41,7 @@ class TestLoadtest(BaseTestCase):
     def test_loadtest(self):
         output = self.run_cmd(self.loadtest_args)
         self.assertGreater(len(output.splitlines()), 10,
-            "OUTPUT\n{}".format(output))
+            b'\n'.join((b'OUTPUT', output)))
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/loadtest_test.py
+++ b/src/program/lwaftr/tests/subcommands/loadtest_test.py
@@ -49,7 +49,7 @@ class TestLoadtest(unittest.TestCase):
         Needed to see the daemon's stdout and stderr if it fails.
         The _done attribute is not working well.
         """
-        print('\nRun command:', line)
+        print('Run command:', line)
 
     def test_loadtest(self):
         output = sh.sudo(*self.loadtest_cmd_args)
@@ -57,12 +57,11 @@ class TestLoadtest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if cls.run_cmd.process.is_alive():
-            try:
-                cls.run_cmd.terminate()
-            except ProcessLookupError:
-                # It was already gone.
-                pass
+        try:
+            cls.run_cmd.terminate()
+        except ProcessLookupError:
+            # It was already gone.
+            pass
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/loadtest_test.py
+++ b/src/program/lwaftr/tests/subcommands/loadtest_test.py
@@ -8,25 +8,25 @@ are set to on-a-stick mode, so that they use one NIC each instead of two.
 
 import unittest
 
-from lib import sh
-from lib.test_env import BENCHDATA_DIR, DATA_DIR, SNABB_CMD, nic_names
+from lib.test_env import (
+    BENCHDATA_DIR, DATA_DIR, SNABB_CMD, DaemonBasedTest, nic_names)
 
 
 SNABB_PCI0, SNABB_PCI1 = nic_names()
 
 
 @unittest.skipUnless(SNABB_PCI0 and SNABB_PCI1, 'NICs not configured')
-class TestLoadtest(unittest.TestCase):
+class TestLoadtest(DaemonBasedTest):
 
-    run_cmd_args = (
-        SNABB_CMD, 'lwaftr', 'run',
+    daemon_args = (
+        str(SNABB_CMD), 'lwaftr', 'run',
         '--bench-file', '/dev/null',
-        '--conf', DATA_DIR / 'icmp_on_fail.conf',
+        '--conf', str(DATA_DIR / 'icmp_on_fail.conf'),
         '--on-a-stick', SNABB_PCI0,
     )
 
-    loadtest_cmd_args = (
-        SNABB_CMD, 'lwaftr', 'loadtest',
+    loadtest_args = (
+        str(SNABB_CMD), 'lwaftr', 'loadtest',
         '--bench-file', '/dev/null',
         # Something quick and easy.
         '--program', 'ramp_up',
@@ -34,34 +34,13 @@ class TestLoadtest(unittest.TestCase):
         '--duration', '0.1',
         '--bitrate', '0.2e8',
         # Just one card for on-a-stick mode.
-        BENCHDATA_DIR / 'ipv4_and_ipv6_stick_imix.pcap', 'ALL', 'ALL', SNABB_PCI1,
+        str(BENCHDATA_DIR / 'ipv4_and_ipv6_stick_imix.pcap'), 'ALL', 'ALL',
+        SNABB_PCI1,
     )
 
-    # Use setUpClass to only setup the "run" daemon once for all tests.
-    @classmethod
-    def setUpClass(cls):
-        cls.run_cmd = sh.sudo(*cls.run_cmd_args,
-            _bg=True, _err_to_out=True, _out=cls.run_cmd_out, _tty_out=False)
-
-    @classmethod
-    def run_cmd_out(cls, line):
-        """
-        Needed to see the daemon's stdout and stderr if it fails.
-        The _done attribute is not working well.
-        """
-        print('Run command:', line)
-
     def test_loadtest(self):
-        output = sh.sudo(*self.loadtest_cmd_args)
+        output = self.run_cmd(self.loadtest_args)
         self.assertTrue(len(output.splitlines()) > 10)
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            cls.run_cmd.terminate()
-        except ProcessLookupError:
-            # It was already gone.
-            pass
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/loadtest_test.py
+++ b/src/program/lwaftr/tests/subcommands/loadtest_test.py
@@ -9,14 +9,14 @@ are set to on-a-stick mode, so that they use one NIC each instead of two.
 import unittest
 
 from lib.test_env import (
-    BENCHDATA_DIR, DATA_DIR, SNABB_CMD, DaemonBasedTest, nic_names)
+    BENCHDATA_DIR, DATA_DIR, SNABB_CMD, BaseTestCase, nic_names)
 
 
 SNABB_PCI0, SNABB_PCI1 = nic_names()
 
 
 @unittest.skipUnless(SNABB_PCI0 and SNABB_PCI1, 'NICs not configured')
-class TestLoadtest(DaemonBasedTest):
+class TestLoadtest(BaseTestCase):
 
     daemon_args = (
         str(SNABB_CMD), 'lwaftr', 'run',

--- a/src/program/lwaftr/tests/subcommands/loadtest_test.py
+++ b/src/program/lwaftr/tests/subcommands/loadtest_test.py
@@ -40,7 +40,8 @@ class TestLoadtest(BaseTestCase):
 
     def test_loadtest(self):
         output = self.run_cmd(self.loadtest_args)
-        self.assertTrue(len(output.splitlines()) > 10)
+        self.assertGreater(len(output.splitlines()), 10,
+            "OUTPUT\n{}".format(output))
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -7,8 +7,7 @@ Test the "snabb lwaftr monitor" subcommand. Needs a NIC name and a TAP interface
 
 import unittest
 
-from lib.test_env import (
-    BENCHDATA_DIR, DATA_DIR, SNABB_CMD, BaseTestCase, nic_names, tap_name)
+from lib.test_env import DATA_DIR, SNABB_CMD, BaseTestCase, nic_names, tap_name
 
 
 SNABB_PCI0 = nic_names()[0]
@@ -21,25 +20,22 @@ class TestMonitor(BaseTestCase):
 
     daemon_args = (
         str(SNABB_CMD), 'lwaftr', 'run',
-        '--name', 'monitor_test_daemon',
         '--bench-file', '/dev/null',
         '--conf', str(DATA_DIR / 'icmp_on_fail.conf'),
         '--on-a-stick', SNABB_PCI0,
         '--mirror', TAP_IFACE,
     )
 
-    monitor_args = (
-        str(SNABB_CMD), 'lwaftr', 'monitor',
-        '--name', 'monitor_test',
-        'all',
-    )
+    monitor_args = (str(SNABB_CMD), 'lwaftr', 'monitor', 'all')
 
     def test_monitor(self):
-        output = self.run_cmd(self.monitor_args)
-        self.assertIn('Mirror address set', output,
-            "OUTPUT\n{}".format(output))
-        self.assertIn('255.255.255.255', output,
-            "OUTPUT\n{}".format(output))
+        monitor_args = list(self.monitor_args)
+        monitor_args.append(str(self.daemon.pid))
+        output = self.run_cmd(monitor_args)
+        self.assertIn(b'Mirror address set', output,
+            b'\n'.join((b'OUTPUT', output)))
+        self.assertIn(b'255.255.255.255', output,
+            b'\n'.join((b'OUTPUT', output)))
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -36,8 +36,10 @@ class TestMonitor(BaseTestCase):
 
     def test_monitor(self):
         output = self.run_cmd(self.monitor_args)
-        self.assertIn('Mirror address set', output)
-        self.assertIn('255.255.255.255', output)
+        self.assertIn('Mirror address set', output,
+            "OUTPUT\n{}".format(output))
+        self.assertIn('255.255.255.255', output,
+            "OUTPUT\n{}".format(output))
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -1,0 +1,53 @@
+"""
+Test the "snabb lwaftr monitor" subcommand. Needs a NIC name and a TAP interface.
+
+1. Execute "snabb lwaftr run" in on-a-stick mode and with the mirror option set.
+2. Run "snabb lwaftr monitor" to set the counter and check its output.
+"""
+
+import unittest
+
+from lib import sh
+from lib.test_env import DATA_DIR, SNABB_CMD, nic_names, tap0_available
+
+
+SNABB_PCI0 = nic_names()[0]
+
+
+@unittest.skipUnless(SNABB_PCI0, 'NIC not configured')
+@unittest.skipUnless(tap0_available(), 'tap0 not available')
+class TestMonitor(unittest.TestCase):
+
+    run_cmd_args = (
+        SNABB_CMD, 'lwaftr', 'run',
+        '--name', 'monitor_test',
+        '--bench-file', '/dev/null',
+        '--conf', DATA_DIR / 'icmp_on_fail.conf',
+        '--on-a-stick', SNABB_PCI0,
+        '--mirror', 'tap0',
+    )
+
+    monitor_cmd_args = (
+        SNABB_CMD, 'lwaftr', 'monitor',
+        '--name', 'monitor_test',
+        'all',
+    )
+
+    # Use setUpClass to only setup the "run" daemon once for all tests.
+    @classmethod
+    def setUpClass(cls):
+        cls.run_cmd = sh.sudo(*cls.run_cmd_args, _bg=True)
+
+    def test_monitor(self):
+        output = sh.sudo(*self.monitor_cmd_args)
+        self.assertEqual(output.exit_code, 0)
+        self.assertIn('Mirror address set', output)
+        self.assertIn('255.255.255.255', output)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.run_cmd.terminate()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -37,17 +37,30 @@ class TestMonitor(unittest.TestCase):
     # Use setUpClass to only setup the "run" daemon once for all tests.
     @classmethod
     def setUpClass(cls):
-        cls.run_cmd = sh.sudo(*cls.run_cmd_args, _bg=True)
+        cls.run_cmd = sh.sudo(*cls.run_cmd_args,
+            _bg=True, _err_to_out=True, _out=cls.run_cmd_out, _tty_out=False)
+
+    @classmethod
+    def run_cmd_out(cls, line):
+        """
+        Needed to see the daemon's stdout and stderr if it fails.
+        The _done attribute is not working well.
+        """
+        print('\nRun command:', line)
 
     def test_monitor(self):
         output = sh.sudo(*self.monitor_cmd_args)
-        self.assertEqual(output.exit_code, 0)
         self.assertIn('Mirror address set', output)
         self.assertIn('255.255.255.255', output)
 
     @classmethod
     def tearDownClass(cls):
-        cls.run_cmd.terminate()
+        if cls.run_cmd.process.is_alive():
+            try:
+                cls.run_cmd.terminate()
+            except ProcessLookupError:
+                # It was already gone.
+                pass
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -25,8 +25,8 @@ class TestMonitor(BaseTestCase):
         '--on-a-stick', SNABB_PCI0,
         '--mirror', TAP_IFACE,
     )
-
     monitor_args = (str(SNABB_CMD), 'lwaftr', 'monitor', 'all')
+    wait_for_daemon_startup = True
 
     def test_monitor(self):
         monitor_args = list(self.monitor_args)

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -8,14 +8,15 @@ Test the "snabb lwaftr monitor" subcommand. Needs a NIC name and a TAP interface
 import unittest
 
 from lib import sh
-from lib.test_env import DATA_DIR, SNABB_CMD, nic_names, tap0_available
+from lib.test_env import DATA_DIR, SNABB_CMD, nic_names, tap_name
 
 
 SNABB_PCI0 = nic_names()[0]
+TAP_IFACE, tap_err_msg = tap_name()
 
 
 @unittest.skipUnless(SNABB_PCI0, 'NIC not configured')
-@unittest.skipUnless(tap0_available(), 'tap0 not available')
+@unittest.skipUnless(TAP_IFACE, tap_err_msg)
 class TestMonitor(unittest.TestCase):
 
     run_cmd_args = (
@@ -24,7 +25,7 @@ class TestMonitor(unittest.TestCase):
         '--bench-file', '/dev/null',
         '--conf', DATA_DIR / 'icmp_on_fail.conf',
         '--on-a-stick', SNABB_PCI0,
-        '--mirror', 'tap0',
+        '--mirror', TAP_IFACE,
     )
 
     monitor_cmd_args = (

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -8,7 +8,7 @@ Test the "snabb lwaftr monitor" subcommand. Needs a NIC name and a TAP interface
 import unittest
 
 from lib.test_env import (
-    BENCHDATA_DIR, DATA_DIR, SNABB_CMD, DaemonBasedTest, nic_names, tap_name)
+    BENCHDATA_DIR, DATA_DIR, SNABB_CMD, BaseTestCase, nic_names, tap_name)
 
 
 SNABB_PCI0 = nic_names()[0]
@@ -17,7 +17,7 @@ TAP_IFACE, tap_err_msg = tap_name()
 
 @unittest.skipUnless(SNABB_PCI0, 'NIC not configured')
 @unittest.skipUnless(TAP_IFACE, tap_err_msg)
-class TestMonitor(DaemonBasedTest):
+class TestMonitor(BaseTestCase):
 
     daemon_args = (
         str(SNABB_CMD), 'lwaftr', 'run',

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -46,7 +46,7 @@ class TestMonitor(unittest.TestCase):
         Needed to see the daemon's stdout and stderr if it fails.
         The _done attribute is not working well.
         """
-        print('\nRun command:', line)
+        print('Run command:', line)
 
     def test_monitor(self):
         output = sh.sudo(*self.monitor_cmd_args)
@@ -55,12 +55,11 @@ class TestMonitor(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if cls.run_cmd.process.is_alive():
-            try:
-                cls.run_cmd.terminate()
-            except ProcessLookupError:
-                # It was already gone.
-                pass
+        try:
+            cls.run_cmd.terminate()
+        except ProcessLookupError:
+            # It was already gone.
+            pass
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -24,7 +24,8 @@ class TestRun(BaseTestCase):
 
     def execute_run_test(self, cmd_args):
         output = self.run_cmd(cmd_args)
-        self.assertTrue(len(output.splitlines()) > 1)
+        self.assertLess(len(output.splitlines()), 1,
+            "OUTPUT\n{}".format(output))
 
     def test_run_standard(self):
         self.execute_run_test(self.cmd_args)

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -24,16 +24,16 @@ class TestRun(BaseTestCase):
 
     def execute_run_test(self, cmd_args):
         output = self.run_cmd(cmd_args)
-        self.assertLess(len(output.splitlines()), 1,
-            "OUTPUT\n{}".format(output))
+        self.assertIn(b'link report', output,
+            b'\n'.join((b'OUTPUT', output)))
 
     def test_run_standard(self):
         self.execute_run_test(self.cmd_args)
 
     def test_run_reconfigurable(self):
-        reconf_cmd_args = list(self.cmd_args)
-        reconf_cmd_args.insert(3, '--reconfigurable')
-        self.execute_run_test(reconf_cmd_args)
+        reconf_args = list(self.cmd_args)
+        reconf_args.insert(3, '--reconfigurable')
+        self.execute_run_test(reconf_args)
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -25,7 +25,6 @@ class TestRun(unittest.TestCase):
 
     def execute_run_test(self, cmd_args):
         output = sh.sudo(*cmd_args)
-        self.assertEqual(output.exit_code, 0)
         self.assertTrue(len(output.splitlines()) > 1)
 
     def test_run_standard(self):

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -4,27 +4,26 @@ Test the "snabb lwaftr run" subcommand. Needs NIC names.
 
 import unittest
 
-from lib import sh
-from lib.test_env import DATA_DIR, SNABB_CMD, nic_names
+from lib.test_env import DATA_DIR, SNABB_CMD, BaseTestCase, nic_names
 
 
 SNABB_PCI0, SNABB_PCI1 = nic_names()
 
 
 @unittest.skipUnless(SNABB_PCI0 and SNABB_PCI1, 'NICs not configured')
-class TestRun(unittest.TestCase):
+class TestRun(BaseTestCase):
 
     cmd_args = (
-        SNABB_CMD, 'lwaftr', 'run',
+        str(SNABB_CMD), 'lwaftr', 'run',
         '--duration', '0.1',
         '--bench-file', '/dev/null',
-        '--conf', DATA_DIR / 'icmp_on_fail.conf',
+        '--conf', str(DATA_DIR / 'icmp_on_fail.conf'),
         '--v4', SNABB_PCI0,
         '--v6', SNABB_PCI1,
     )
 
     def execute_run_test(self, cmd_args):
-        output = sh.sudo(*cmd_args)
+        output = self.run_cmd(cmd_args)
         self.assertTrue(len(output.splitlines()) > 1)
 
     def test_run_standard(self):


### PR DESCRIPTION
1) Allow running tests in just one subdirectory;
2) move exit code checks to one place;
3) add a TestCase superclass for tests needing a long-running process;
4) remove usage of the `sh` library; it is flaky when handling long-running processes;
5) improve test diagnostics in case of failure.