### PR TITLE
Sleep 2 seconds in monitor unit test

### DIFF
--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -6,6 +6,7 @@ Test the "snabb lwaftr monitor" subcommand. Needs a NIC name and a TAP interface
 """
 
 import unittest
+import time
 
 from lib import sh
 from lib.test_env import DATA_DIR, SNABB_CMD, nic_names, tap_name
@@ -38,6 +39,7 @@ class TestMonitor(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.run_cmd = sh.sudo(*cls.run_cmd_args, _bg=True)
+        time.sleep(2)
 
     def test_monitor(self):
         output = sh.sudo(*self.monitor_cmd_args)


### PR DESCRIPTION
Sometimes the test complains it couldn't find a process called "monitor_test". Likely the cause is the directory is not yet created in /var/run/snabb/by-name.