### PR TITLE
Fix run nohw

### DIFF
--- a/src/program/lwaftr/README
+++ b/src/program/lwaftr/README
@@ -1,14 +1,14 @@
 Usage:
   snabb lwaftr bench
   snabb lwaftr check
-  snabb lwaftr run
-  snabb lwaftr transient
-  snabb lwaftr compile-binding-table
   snabb lwaftr generate-binding-table
-  snabb lwaftr migrate-configuration
-  snabb lwaftr control
   snabb lwaftr loadtest
+  snabb lwaftr migrate-configuration
+  snabb lwaftr monitor
   snabb lwaftr query
+  snabb lwaftr run
+  snabb lwaftr run_nohw
+  snabb lwaftr transient
 
 Use --help for per-command usage.
 Example:

--- a/src/program/lwaftr/csv_stats.lua
+++ b/src/program/lwaftr/csv_stats.lua
@@ -48,7 +48,7 @@ function CSVStatsTimer:new(filename, hydra_mode, pid)
    local o = { hydra_mode=hydra_mode, link_data={}, file=file, period=1,
       header = hydra_mode and "benchmark,id,score,unit" or "Time (s)" }
    o.pid = pid or S.getpid()
-   o.links_by_app = open_link_counters(pid)
+   o.links_by_app = open_link_counters(o.pid)
    return setmetatable(o, {__index = CSVStatsTimer})
 end
 

--- a/src/program/lwaftr/run_nohw/README
+++ b/src/program/lwaftr/run_nohw/README
@@ -4,14 +4,15 @@ Usage: run-nohw --help
        --conf, -c PATH      Path to the lwAFTR configuration file.
        --b4-if, -B NAME     Name of the B4-side network interface.
        --inet-if, -I NAME   Name of the Internet-side network interface.
-       --verbose, -v        Be verbose. Can be used multiple times.
+       --verbose, -v        Print CSV stats to stdout.
        --bench-file, -b FILENAME
                             The file or path name to which benchmark data is
-                            written. A simple filename or relative pathname
-                            will be based on the current directory. Default
-                            is "bench.csv".
+                            written.  A simple filename or relative pathname
+                            will be based on the current directory.
        --help, -h           Show this help message.
 
-When the -v option is used at least once, packets on the network interfaces are
-counted and recorded, and the corresponding incoming and outgoing packet rates
-are written to a file in CSV format, suitable for passing to a graphing program.
+When the -v option is used, packets on the network interfaces are counted and
+recorded, and the corresponding incoming and outgoing packet rates are print
+out to stdout, suitable for passing to a graphing program.
+
+If bench-file is set, output is printed to a file instead of stdout.

--- a/src/program/lwaftr/run_nohw/README
+++ b/src/program/lwaftr/run_nohw/README
@@ -11,6 +11,11 @@ Usage: run-nohw --help
                             will be based on the current directory.
        --help, -h           Show this help message.
 
+It runs the lwAFTR over two OS network interfaces.  The simplest way to run
+it is to create 2 veth pairs and use them as the inet and b4 interfaces.
+Flush traffic to the lwAFTR by pushing packets from the other end of the veth
+pairs, using a program such as tcpreplay, for example.
+
 When the -v option is used, packets on the network interfaces are counted and
 recorded, and the corresponding incoming and outgoing packet rates are print
 out to stdout, suitable for passing to a graphing program.

--- a/src/program/lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/lwaftr/run_nohw/run_nohw.lua
@@ -19,28 +19,28 @@ end
 local function parse_args(args)
    local verbosity = 0
    local conf_file, b4_if, inet_if
-   local bench_file = 'bench.csv'
+   local bench_file
    local handlers = {
       v = function ()
          verbosity = verbosity + 1
-      end;
+      end,
       c = function (arg)
          check(file_exists(arg), "no such file '%s'", arg)
          conf_file = arg
-      end;
+      end,
       B = function (arg)
          b4_if = arg
-      end;
+      end,
       I = function (arg)
          inet_if = arg
-      end;
+      end,
       b = function (arg)
          bench_file = arg
-      end;
+      end,
       h = function (arg)
          print(require("program.lwaftr.run_nohw.README_inc"))
          main.exit(0)
-      end;
+      end,
    }
    lib.dogetopt(args, handlers, "b:c:B:I:vh", {
       help = "h", conf = "c", verbose = "v",
@@ -52,7 +52,6 @@ local function parse_args(args)
    check(inet_if, "no Internet-side interface specified (--inet-if/-I)")
    return verbosity, conf_file, b4_if, inet_if, bench_file
 end
-
 
 function run(parameters)
    local verbosity, conf_file, b4_if, inet_if, bench_file = parse_args(parameters)
@@ -82,17 +81,7 @@ function run(parameters)
       csv:add_app("inet", {"tx", "rx"}, { tx = "IPv4 TX", rx = "IPv4 RX" })
       csv:add_app("b4if", {"tx", "rx"}, { tx = "IPv6 TX", rx = "IPv6 RX" })
       csv:activate()
-
-      if verbosity >= 2 then
-         timer.activate(timer.new("report", function ()
-            app.report_apps()
-         end, 1e9, "repeating"))
-      end
    end
 
-   engine.main {
-      report = {
-         showlinks = true;
-      }
-   }
+   engine.main({report = { showlinks = true }})
 end

--- a/src/program/lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/lwaftr/run_nohw/run_nohw.lua
@@ -18,12 +18,12 @@ end
 
 local function parse_args(args)
    local opts = {
-      verbosity = 0,
+      verbosity = false,
    }
    local conf_file, b4_if, inet_if
    local handlers = {
       v = function ()
-         opts.verbosity = opts.verbosity + 1
+         opts.verbosity = true
       end,
       c = function (arg)
          check(file_exists(arg), "no such file '%s'", arg)
@@ -37,6 +37,7 @@ local function parse_args(args)
       end,
       b = function (arg)
          opts.bench_file = arg
+         opts.verbosity = true
       end,
       h = function (arg)
          print(require("program.lwaftr.run_nohw.README_inc"))
@@ -80,7 +81,7 @@ function run(parameters)
 
    engine.configure(c)
 
-   if opts.verbosity >= 1 then
+   if opts.verbosity then
       local csv = CSVStatsTimer:new(opts.bench_file)
       csv:add_app("inet", {"tx", "rx"}, { tx = "IPv4 TX", rx = "IPv4 RX" })
       csv:add_app("b4if", {"tx", "rx"}, { tx = "IPv6 TX", rx = "IPv6 RX" })

--- a/src/program/lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/lwaftr/run_nohw/run_nohw.lua
@@ -73,11 +73,14 @@ function run(parameters)
    config.link(c, "b4if.tx -> aftr.v6")
    config.link(c, "aftr.v4 -> inet.rx")
    config.link(c, "aftr.v6 -> b4if.rx")
+   config.link(c, "aftr.hairpin_out -> aftr.hairpin_in")
+
+   engine.configure(c)
 
    if verbosity >= 1 then
       local csv = CSVStatsTimer:new(bench_file)
       csv:add_app("inet", {"tx", "rx"}, { tx = "IPv4 TX", rx = "IPv4 RX" })
-      csv:add_app("tob4", {"tx", "rx"}, { tx = "IPv6 TX", rx = "IPv6 RX" })
+      csv:add_app("b4if", {"tx", "rx"}, { tx = "IPv6 TX", rx = "IPv6 RX" })
       csv:activate()
 
       if verbosity >= 2 then
@@ -87,7 +90,6 @@ function run(parameters)
       end
    end
 
-   engine.configure(c)
    engine.main {
       report = {
          showlinks = true;

--- a/src/program/lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/lwaftr/run_nohw/run_nohw.lua
@@ -17,12 +17,13 @@ local function check(flag, fmt, ...)
 end
 
 local function parse_args(args)
-   local verbosity = 0
+   local opts = {
+      verbosity = 0,
+   }
    local conf_file, b4_if, inet_if
-   local bench_file
    local handlers = {
       v = function ()
-         verbosity = verbosity + 1
+         opts.verbosity = opts.verbosity + 1
       end,
       c = function (arg)
          check(file_exists(arg), "no such file '%s'", arg)
@@ -35,26 +36,29 @@ local function parse_args(args)
          inet_if = arg
       end,
       b = function (arg)
-         bench_file = arg
+         opts.bench_file = arg
       end,
       h = function (arg)
          print(require("program.lwaftr.run_nohw.README_inc"))
          main.exit(0)
       end,
+      D = function (arg)
+         opts.duration = assert(tonumber(arg), "duration must be a number")
+      end,
    }
-   lib.dogetopt(args, handlers, "b:c:B:I:vh", {
+   lib.dogetopt(args, handlers, "b:c:B:I:vhD:", {
       help = "h", conf = "c", verbose = "v",
       ["b4-if"] = "B", ["inet-if"] = "I",
-      ["bench-file"] = "b",
+      ["bench-file"] = "b", duration = "D",
    })
    check(conf_file, "no configuration specified (--conf/-c)")
    check(b4_if, "no B4-side interface specified (--b4-if/-B)")
    check(inet_if, "no Internet-side interface specified (--inet-if/-I)")
-   return verbosity, conf_file, b4_if, inet_if, bench_file
+   return conf_file, b4_if, inet_if, opts
 end
 
 function run(parameters)
-   local verbosity, conf_file, b4_if, inet_if, bench_file = parse_args(parameters)
+   local conf_file, b4_if, inet_if, opts = parse_args(parameters)
    local conf = require('apps.lwaftr.conf').load_lwaftr_config(conf_file)
    local c = config.new()
 
@@ -76,12 +80,16 @@ function run(parameters)
 
    engine.configure(c)
 
-   if verbosity >= 1 then
-      local csv = CSVStatsTimer:new(bench_file)
+   if opts.verbosity >= 1 then
+      local csv = CSVStatsTimer:new(opts.bench_file)
       csv:add_app("inet", {"tx", "rx"}, { tx = "IPv4 TX", rx = "IPv4 RX" })
       csv:add_app("b4if", {"tx", "rx"}, { tx = "IPv6 TX", rx = "IPv6 RX" })
       csv:activate()
    end
 
-   engine.main({report = { showlinks = true }})
+   if opts.duration then
+      engine.main({duration = opts.duration, report = { showlinks = true }})
+   else
+      engine.main()
+   end
 end

--- a/src/program/lwaftr/tests/subcommands/run_nohw_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_nohw_test.py
@@ -1,0 +1,77 @@
+"""
+Test the "snabb lwaftr run_nohw" subcommand.
+"""
+
+import unittest
+
+from random import randint
+from subprocess import call, check_call
+from test_env import DATA_DIR, SNABB_CMD, BaseTestCase
+
+class TestRun(BaseTestCase):
+
+    program = [
+        str(SNABB_CMD), 'lwaftr', 'run_nohw',
+    ]
+    cmd_args = {
+        '--duration': '1',
+        '--bench-file': '/dev/null',
+        '--conf': str(DATA_DIR / 'icmp_on_fail.conf'),
+        '--inet-if': '',
+        '--b4-if': '',
+    }
+    veths = []
+
+    @classmethod
+    def setUpClass(cls):
+        cls.create_veth_pair()
+
+    @classmethod
+    def create_veth_pair(cls):
+        veth0 = cls.random_veth_name()
+        veth1 = cls.random_veth_name()
+
+        # Create veth pair.
+        check_call(('ip', 'link', 'add', veth0, 'type', 'veth', 'peer', \
+            'name', veth1))
+
+        # Set interfaces up.
+        check_call(('ip', 'link', 'set', veth0, 'up'))
+        check_call(('ip', 'link', 'set', veth1, 'up'))
+
+        # Add interface names to class.
+        cls.veths.append(veth0)
+        cls.veths.append(veth1)
+
+    @classmethod
+    def random_veth_name(cls):
+        return 'veth%s' % randint(10000, 999999)
+
+    def test_run_nohw(self):
+        self.execute_run_test(self.cmd_args)
+
+    def execute_run_test(self, cmd_args):
+        self.cmd_args['--inet-if'] = self.veths[0]
+        self.cmd_args['--b4-if'] = self.veths[1]
+        output = self.run_cmd(self.build_cmd())
+        self.assertIn(b'link report', output,
+            b'\n'.join((b'OUTPUT', output)))
+
+    def build_cmd(self):
+        result = self.program
+        for item in self.cmd_args.items():
+            for each in item:
+                result.append(each)
+        return result
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.remove_veths()
+
+    @classmethod
+    def remove_veths(cls):
+        for i in range(0, len(cls.veths), 2):
+            check_call(('ip', 'link', 'delete', cls.veths[i]))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/program/lwaftr/tests/subcommands/run_nohw_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_nohw_test.py
@@ -1,5 +1,5 @@
 """
-Test the "snabb lwaftr run_nohw" subcommand.
+Test the "snabb lwaftr run-nohw" subcommand.
 """
 
 import unittest
@@ -10,10 +10,10 @@ from test_env import DATA_DIR, SNABB_CMD, BaseTestCase
 
 class TestRun(BaseTestCase):
 
-    program = [
-        str(SNABB_CMD), 'lwaftr', 'run_nohw',
+    cmd_args = [
+        str(SNABB_CMD), 'lwaftr', 'run-nohw',
     ]
-    cmd_args = {
+    cmd_options = {
         '--duration': '1',
         '--bench-file': '/dev/null',
         '--conf': str(DATA_DIR / 'icmp_on_fail.conf'),
@@ -24,21 +24,14 @@ class TestRun(BaseTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.create_veth_pair()
-
-    @classmethod
-    def create_veth_pair(cls):
         veth0 = cls.random_veth_name()
         veth1 = cls.random_veth_name()
-
         # Create veth pair.
         check_call(('ip', 'link', 'add', veth0, 'type', 'veth', 'peer', \
             'name', veth1))
-
         # Set interfaces up.
         check_call(('ip', 'link', 'set', veth0, 'up'))
         check_call(('ip', 'link', 'set', veth1, 'up'))
-
         # Add interface names to class.
         cls.veths.append(veth0)
         cls.veths.append(veth1)
@@ -48,30 +41,21 @@ class TestRun(BaseTestCase):
         return 'veth%s' % randint(10000, 999999)
 
     def test_run_nohw(self):
-        self.execute_run_test(self.cmd_args)
-
-    def execute_run_test(self, cmd_args):
-        self.cmd_args['--inet-if'] = self.veths[0]
-        self.cmd_args['--b4-if'] = self.veths[1]
+        self.cmd_options['--inet-if'] = self.veths[0]
+        self.cmd_options['--b4-if'] = self.veths[1]
         output = self.run_cmd(self.build_cmd())
         self.assertIn(b'link report', output,
             b'\n'.join((b'OUTPUT', output)))
 
     def build_cmd(self):
-        result = self.program
-        for item in self.cmd_args.items():
-            for each in item:
-                result.append(each)
+        result = self.cmd_args
+        for key, value in self.cmd_options.items():
+            result.extend((key, value))
         return result
 
     @classmethod
     def tearDownClass(cls):
-        cls.remove_veths()
-
-    @classmethod
-    def remove_veths(cls):
-        for i in range(0, len(cls.veths), 2):
-            check_call(('ip', 'link', 'delete', cls.veths[i]))
+        check_call(('ip', 'link', 'delete', cls.veths[0]))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The run_nohw, the app that lets run an lwAFTR over network interfaces, was broken. This PR fixes the app and adds other improvements. Check out the commit messages for a description of what each commit does.

How to use run_nohw app:

First thing is to add two veth pairs. A veth pair is like a patch cable. What is copied in one end arrives the other end:

```bash
$ sudo ip link add veth0 type veth peer name veth1
$ sudo ip link add veth2 type veth peer name veth3
```

Set the interfaces up:

```bash
$ sudo ip set veth0 up
$ sudo ip set veth1 up
$ sudo ip set veth2 up
$ sudo ip set veth3 up
```

Run the lwAFTR with run_nohw:

```bash
$ sudo ./snabb lwaftr run_nohw -v --conf lwaftr-migrated.conf --inet-if veth1 --b4-if veth3
```

Send traffic via the other veth pairs:

```bash
$ sudo tcpreplay -i veth0 from-inet-0550.pcap
```

When traffic hit the lwAFTR interface, run_nohw will report accordingly:

```
Time (s),IPv4 TX MPPS,IPv4 TX Gbps,IPv4 RX MPPS,IPv4 RX Gbps,IPv6 TX MPPS,IPv6 TX Gbps,IPv6 RX MPPS,IPv6 RX Gbps
0.999632,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000
1.999666,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000
2.999727,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000
3.999644,0.000770,0.003388,0.000000,0.000000,0.000000,0.000000,0.000770,0.003635
```

Tap interfaces are much slower than NICs, so the result above is normal.  The goal of this app is to provide a means to test out the lwAFTR, specially for those users lacking an Intel82599 card.