### PR TITLE
Remove the default "bench.csv" filename for benchmark data

### DIFF
--- a/src/program/lwaftr/bench/README
+++ b/src/program/lwaftr/bench/README
@@ -12,10 +12,9 @@ Usage: bench CONF IPV4-IN.PCAP IPV6-IN.PCAP
 
                                Time (s),Decap. MPPS,Decap. Gbps,Encap. MPPS,Encap. Gbps
   -b FILENAME, --bench-file FILENAME
-                             The file or path name to which benchmark data is
-                             written. A simple filename or relative pathname
-                             will be based on the current directory. Default
-                             is "bench.csv".
+                             The file or path name where benchmark data is to
+                             be written. A simple filename or relative pathname
+                             will be based on the current directory.
   -D DURATION, --duration DURATION
                              Duration in seconds.
   -n NAME, --name NAME       Sets the name for this program, which will be used
@@ -33,5 +32,6 @@ machine that may not have Intel 82599 NICs.  Exit when finished.  This
 program is used in the lwAFTR test suite.
 
 Packets are counted and recorded, and the corresponding incoming and outgoing
-packet rates are written to a file in CSV format, suitable for passing to a
-graphing program.
+packet rates are written to the stdout in CSV format, suitable for passing
+to a graphing program. If bench-file is set, output is written to a file
+instead of stdout.

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -14,7 +14,7 @@ end
 
 function parse_args(args)
    local handlers = {}
-   local opts = { bench_file = 'bench.csv' }
+   local opts = {}
    local scheduling = {}
    function handlers.D(arg)
       opts.duration = assert(tonumber(arg), "duration must be a number")

--- a/src/program/lwaftr/loadtest/README
+++ b/src/program/lwaftr/loadtest/README
@@ -9,10 +9,9 @@ Usage: loadtest [OPTIONS] <PCAP-FILE> <TX-NAME> <RX-NAME> <PCI> [<PCAP-FILE> <TX
   -p PROGRAM, --program PROGRAM
                              Use workload PROGRAM.
   --bench-file FILENAME
-                             The file or path name to which benchmark data is
-                             written. A simple filename or relative pathname
-                             will be based on the current directory. Default
-                             is "bench.csv".
+                             The file or path name where benchmark data is to
+                             be written. A simple filename or relative pathname
+                             will be based on the current directory.
   -y, --hydra
                              Hydra mode: emit CSV data in the format expected
                              by the Hydra reports. For instance:
@@ -53,11 +52,12 @@ The default workload program is ramp_up_down.
 
 Packets received on the network interfaces are counted and recorded,
 and the corresponding incoming and outgoing packet rates are written
-to standard output in human-readable format, and also to a file in CSV
-format, suitable for passing to a graphing program.  The TX-NAME values
-are used to label the columns.  The RX-NAME values indicate interfaces
-on which we should be looking for a response.  Packets sent but not
-received will be counted as loss.
+to standard output in human-readable format. If bench-file is set,
+output is also written to a file in CSV format, suitable for passing
+to a graphing program.  The TX-NAME values are used to label the
+columns.  The RX-NAME values indicate interfaces on which we should
+be looking for a response.  Packets sent but not received will be
+counted as loss.
 
 Examples:
   loadtest cap1.pcap tx tx 01:00.0

--- a/src/program/lwaftr/run/README
+++ b/src/program/lwaftr/run/README
@@ -30,13 +30,13 @@ Optional arguments:
 
                                   Time (s),Decap. MPPS,Decap. Gbps,Encap. MPPS,Encap. Gbps
        -b FILENAME, --bench-file FILENAME
-                                The file or path name to which benchmark data is
-                                written. A simple filename or relative pathname
-                                will be based on the current directory. Default
-                                is "bench.csv".
+                                The file or path name where benchmark data is to
+                                be written. A simple filename or relative pathname
+                                will be based on the current directory.
        -n NAME, --name NAME     Sets the name as the identifier of this program.
                                 This must be unique amongst other snab programs.
 
 When the -v option is used at least once, packets on the network interfaces are
 counted and recorded, and the corresponding incoming and outgoing packet rates
-are written to a file in CSV format, suitable for passing to a graphing program.
+are written to stdout in CSV format, suitable for passing to a graphing program.
+If bench-file is set, output is written to a file instead of stdout.

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -21,7 +21,7 @@ function parse_args(args)
    if #args == 0 then show_usage(1) end
    local conf_file, v4, v6
    local ring_buffer_size
-   local opts = { verbosity = 0, bench_file = 'bench.csv' }
+   local opts = { verbosity = 0 }
    local scheduling = { ingress_drop_monitor = 'flush' }
    local handlers = {}
    function handlers.n (arg) opts.name = assert(arg) end

--- a/src/program/lwaftr/run_nohw/README
+++ b/src/program/lwaftr/run_nohw/README
@@ -16,8 +16,7 @@ it is to create 2 veth pairs and use them as the inet and b4 interfaces.
 Flush traffic to the lwAFTR by pushing packets from the other end of the veth
 pairs, using a program such as tcpreplay, for example.
 
-When the -v option is used, packets on the network interfaces are counted and
-recorded, and the corresponding incoming and outgoing packet rates are print
-out to stdout, suitable for passing to a graphing program.
-
-If bench-file is set, output is printed to a file instead of stdout.
+When the -v option is used, packets on the network interfaces are counted
+and recorded, and the corresponding incoming and outgoing packet rates are
+written to stdout, in a format suitable for passing to a graphing program.
+If bench-file is set, output is written to a file instead of stdout.

--- a/src/program/lwaftr/tests/subcommands/run_nohw_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_nohw_test.py
@@ -5,10 +5,11 @@ Test the "snabb lwaftr run-nohw" subcommand.
 import unittest
 
 from random import randint
-from subprocess import call, check_call
+from subprocess import check_call
 from test_env import DATA_DIR, SNABB_CMD, BaseTestCase
 
-class TestRun(BaseTestCase):
+
+class TestRunNoHW(BaseTestCase):
 
     cmd_args = [
         str(SNABB_CMD), 'lwaftr', 'run-nohw',
@@ -27,8 +28,9 @@ class TestRun(BaseTestCase):
         veth0 = cls.random_veth_name()
         veth1 = cls.random_veth_name()
         # Create veth pair.
-        check_call(('ip', 'link', 'add', veth0, 'type', 'veth', 'peer', \
-            'name', veth1))
+        check_call(
+            ('ip', 'link', 'add', veth0, 'type', 'veth', 'peer', 'name', veth1)
+        )
         # Set interfaces up.
         check_call(('ip', 'link', 'set', veth0, 'up'))
         check_call(('ip', 'link', 'set', veth1, 'up'))
@@ -56,6 +58,7 @@ class TestRun(BaseTestCase):
     @classmethod
     def tearDownClass(cls):
         check_call(('ip', 'link', 'delete', cls.veths[0]))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/program/lwaftr/transient/README
+++ b/src/program/lwaftr/transient/README
@@ -9,10 +9,9 @@ Usage: transient [OPTIONS] <PCAP-FILE> <NAME> <PCI> [<PCAP-FILE> <NAME> <PCI>]..
   -p period, --period PERIOD
                              Measure each PERIOD seconds.
   --bench-file FILENAME
-                             The file or path name to which benchmark data is
-                             written. A simple filename or relative pathname
-                             will be based on the current directory. Default
-                             is "bench.csv".
+                             The file or path name where benchmark data is to
+                             be written. A simple filename or relative pathname
+                             will be based on the current directory.
   -h, --help
                              Print usage information.
 
@@ -25,10 +24,11 @@ peak bitrate is reached, back down the same way until 0 is reached, and
 end the test.
 
 Packets received on the network interfaces are counted and recorded, and the
-corresponding incoming and outgoing packet rates are written to a file in CSV
-format, suitable for passing to a graphing program. The NAME values are used
-to label the columns. Measurements will be taken each PERIOD seconds, which
-defaults to 1.
+corresponding incoming and outgoing packet rates are written to standard
+output in CSV format, suitable for passing to a graphing program. If
+bench-file is set, output is written to a file instead of stdout. The NAME
+values are used to label the columns. Measurements will be taken each PERIOD
+seconds, which defaults to 1.
 
 Examples:
   transient cap1.pcap tx 01:00.0

--- a/src/program/lwaftr/transient/transient.lua
+++ b/src/program/lwaftr/transient/transient.lua
@@ -44,8 +44,7 @@ end
 
 function parse_args(args)
    local handlers = {}
-   local opts = {
-      bitrate = 10e9, duration = 5, period = 1, bench_file = 'bench.csv' }
+   local opts = { bitrate = 10e9, duration = 5, period = 1 }
    function handlers.b(arg)
       opts.bitrate = assert(tonumber(arg), 'bitrate must be a number')
    end


### PR DESCRIPTION
Across all subcommands, as agreed in chat. Benchmark data will be sent to stdout, and written to a file instead if the `-b / --bench-file` option is given.

Includes a little touch-up of the `run-nohw` subcommand test.