### PR TITLE
Validate softwire for missing PSID mapping

### DIFF
--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -69,6 +69,7 @@ function Leader:new (conf)
 end
 
 function Leader:set_initial_configuration (configuration)
+   self.support.validate_config(configuration)
    self.current_configuration = configuration
    self.current_app_graph = self.setup_fn(configuration)
    self.current_in_place_dependencies = {}
@@ -395,6 +396,7 @@ function compute_remove_config_fn (schema_name, path)
 end
 
 function Leader:notify_pre_update (config, verb, path, ...)
+   self.support.validate_update(config, verb, path, ...)
    for _,translator in pairs(self.support.translators) do
       translator.pre_update(config, verb, path, ...)
    end

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -69,6 +69,7 @@ function Leader:new (conf)
 end
 
 function Leader:set_initial_configuration (configuration)
+   self.support.validate_config(configuration)
    self.current_configuration = configuration
    self.current_app_graph = self.setup_fn(configuration)
    self.current_in_place_dependencies = {}

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -69,7 +69,6 @@ function Leader:new (conf)
 end
 
 function Leader:set_initial_configuration (configuration)
-   self.support.validate_config(configuration)
    self.current_configuration = configuration
    self.current_app_graph = self.setup_fn(configuration)
    self.current_in_place_dependencies = {}

--- a/src/apps/config/support.lua
+++ b/src/apps/config/support.lua
@@ -177,6 +177,8 @@ end
 
 
 generic_schema_config_support = {
+   validate_config = function() end,
+   validate_update = function () end,
    compute_config_actions = function(
          old_graph, new_graph, to_restart, verb, path, ...)
       return add_restarts(app.compute_config_actions(old_graph, new_graph),

--- a/src/apps/config/support/snabb-softwire-v1.lua
+++ b/src/apps/config/support/snabb-softwire-v1.lua
@@ -18,11 +18,7 @@ local binding_table = require("apps.lwaftr.binding_table")
 
 local binding_table_instance
 local function get_binding_table(conf)
-	if binding_table_instance ~= nil then
-		-- TODO: fix me!
-		binding_table_instance = nil
-		return get_binding_table(conf)
-	else
+	if binding_table_instance == nil then
 		binding_table_instance = binding_table.load(conf)
 	end
 	return binding_table_instance
@@ -96,6 +92,11 @@ end
 
 local function compute_config_actions(old_graph, new_graph, to_restart,
                                       verb, path, arg)
+   -- If the binding cable changes, remove our cached version.
+   if path ~= nil and path:match("^/softwire%-config/binding%-table") then
+      binding_table_instance = nil
+   end
+
    if verb == 'add' and path == '/softwire-config/binding-table/softwire' then
       return add_softwire_entry_actions(new_graph, arg)
    elseif (verb == 'remove' and

--- a/src/apps/config/support/snabb-softwire-v1.lua
+++ b/src/apps/config/support/snabb-softwire-v1.lua
@@ -30,7 +30,7 @@ local function validate_softwire(config, softwire)
    assert(psidmap_entry,  "No PSID map for softwire '"..ip.."'")
 end
 
-local function validate_config(config)
+function validate_config(config)
    assert(config)
    local bt = config.softwire_config.binding_table
    for softwire in bt.softwire:iterate() do

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -57,6 +57,7 @@ function run(args)
    else
       setup.apply_scheduling(scheduling)
       setup.load_bench(graph, conf, inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
+      setup.validate_config(conf)
    end
    app.configure(graph)
 

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -161,8 +161,8 @@ function run(args)
       setup.reconfigurable(scheduling, setup_fn, c, conf, unpack(setup_args))
    else
       setup.apply_scheduling(scheduling)
-      setup_fn(c, conf, unpack(setup_args))
       setup.validate_config(conf)
+      setup_fn(c, conf, unpack(setup_args))
    end
 
    engine.configure(c)

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -162,6 +162,7 @@ function run(args)
    else
       setup.apply_scheduling(scheduling)
       setup_fn(c, conf, unpack(setup_args))
+      setup.validate_config(conf)
    end
 
    engine.configure(c)

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -24,6 +24,11 @@ local S          = require("syscall")
 local capabilities = {['ietf-softwire']={feature={'binding', 'br'}}}
 require('lib.yang.schema').set_default_capabilities(capabilities)
 
+local function validate_config(conf)
+   local support = require("apps.config.support.snabb_softwire_v1")
+   return support.validate_config(conf)
+end
+
 local function convert_ipv4(addr)
    if addr ~= nil then return ipv4:pton(ipv4_ntop(addr)) end
 end
@@ -57,6 +62,9 @@ function lwaftr_app(c, conf)
    if internal_interface.next_hop == nil then
       error("One or both of the 'next_hop' values must be specified")
    end
+
+   -- Validate configuration file we've been given.
+   validate_config(conf)
 
    config.app(c, "reassemblerv4", ipv4_apps.Reassembler,
               { max_ipv4_reassembly_packets =

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -24,7 +24,7 @@ local S          = require("syscall")
 local capabilities = {['ietf-softwire']={feature={'binding', 'br'}}}
 require('lib.yang.schema').set_default_capabilities(capabilities)
 
-local function validate_config(conf)
+function validate_config(conf)
    local support = require("apps.config.support.snabb_softwire_v1")
    return support.validate_config(conf)
 end
@@ -62,9 +62,6 @@ function lwaftr_app(c, conf)
    if internal_interface.next_hop == nil then
       error("One or both of the 'next_hop' values must be specified")
    end
-
-   -- Validate configuration file we've been given.
-   validate_config(conf)
 
    config.app(c, "reassemblerv4", ipv4_apps.Reassembler,
               { max_ipv4_reassembly_packets =

--- a/src/program/lwaftr/tests/data/missing_softwire_psidmap.conf
+++ b/src/program/lwaftr/tests/data/missing_softwire_psidmap.conf
@@ -1,0 +1,50 @@
+softwire-config {
+  binding-table {
+    br-address 8:9:a:b:c:d:e:f;
+    br-address 1e:1:1:1:1:1:1:af;
+    br-address 1e:2:2:2:2:2:2:af;
+    psid-map {
+      addr 178.79.150.15;
+      psid-length 4;
+      shift 12;
+    }
+    softwire {
+      ipv4 178.79.150.233;
+      psid 4660;
+      b4-ipv6 127:11:12:13:14:15:16:128;
+    }
+    softwire {
+      ipv4 178.79.150.9;
+      psid 72;
+      b4-ipv6 127:12:13:14:15:16:17:128;
+    }
+  }
+  external-interface {
+    allow-incoming-icmp false;
+    error-rate-limiting {
+      packets 600000;
+    }
+    ip 10.10.10.10;
+    mac 12:12:12:12:12:12;
+    next-hop {
+      mac 68:68:68:68:68:68;
+    }
+    reassembly {
+      max-fragments-per-packet 40;
+    }
+  }
+  internal-interface {
+    allow-incoming-icmp false;
+    error-rate-limiting {
+      packets 600000;
+    }
+    ip 8:9:a:b:c:d:e:f;
+    mac 22:22:22:22:22:22;
+    next-hop {
+      mac 44:44:44:44:44:44;
+    }
+    reassembly {
+      max-fragments-per-packet 40;
+    }
+  }
+}

--- a/src/program/lwaftr/tests/subcommands/bench_test.py
+++ b/src/program/lwaftr/tests/subcommands/bench_test.py
@@ -33,6 +33,16 @@ class TestBench(BaseTestCase):
         reconf_args.insert(3, '--reconfigurable')
         self.execute_bench_test(reconf_args)
 
+    def test_config_with_invalid_softwire(self):
+        config_file = str(DATA_DIR / "missing_softwire_psidmap.conf")
+        invalid_softwire_args = list(self.cmd_args)
+        invalid_softwire_args[-3] = config_file
+        # Verify it errors when there is a softwire lacking a PSID mapping entry
+        self.assertRaises(
+            AssertionError,
+            self.execute_bench_test,
+            invalid_softwire_args
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/program/lwaftr/tests/subcommands/bench_test.py
+++ b/src/program/lwaftr/tests/subcommands/bench_test.py
@@ -38,11 +38,9 @@ class TestBench(BaseTestCase):
         invalid_softwire_args = list(self.cmd_args)
         invalid_softwire_args[-3] = config_file
         # Verify it errors when there is a softwire lacking a PSID mapping entry
-        self.assertRaises(
-            AssertionError,
-            self.execute_bench_test,
-            invalid_softwire_args
-        )
+        err = "Started with config file that has softwire without PSID mapping"
+        with self.assertRaises(AssertionError, msg=err):
+            self.execute_bench_test(invalid_softwire_args)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -137,6 +137,14 @@ class TestConfigMisc(BaseTestCase):
         """
         Add a softwire section, get it back and check all the values.
         """
+        # Add a PSID map for the IP we're going to use.
+        psidmap_add_args = self.get_cmd_args('add')
+        psidmap_add_args.extend((
+            '/softwire-config/binding-table/psid-map',
+            '{ addr 1.2.3.4; psid-length 16; }'
+        ))
+        self.run_cmd(psidmap_add_args)
+
         # External IPv4.
         add_args = self.get_cmd_args('add')
         add_args.extend((

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -271,8 +271,18 @@ class TestConfigMisc(BaseTestCase):
             "/softwire-config/binding-table/softwire",
             test_softwire,
         ))
-        self.assertRaises(AssertionError, self.run_cmd, add_args)
+        add_error = "Able to add softwire with without PSID mapping"
+        with self.assertRaises(AssertionError, msg=add_error):
+            self.run_cmd(add_args)
 
+        # Then try and get the softwire added to ensure it's not been added
+        get_args = self.get_cmd_args('get')
+        get_args.append(
+            "/softwire-config/binding-table/softwire[ipv4=192.168.1.23][psid=72]"
+        )
+        get_error = "Softwire was added with an invalid PSID mapping."
+        with self.assertRaises(AssertionError, msg=get_error):
+            self.run_cmd(get_args)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -251,6 +251,20 @@ class TestConfigMisc(BaseTestCase):
         self.assertEqual(output.strip(), bytes(test_psid, ENC),
             '\n'.join(('OUTPUT', str(output, ENC))))
 
+    def test_softwire_not_in_psidmap(self):
+        """
+        Tests that softwire with a PSID out of PSID map errors
+        """
+        # Create a softwire which won't have an IPv4 address in the PSID map.
+        test_softwire = "{ ipv4 192.168.1.23; psid 72; b4-ipv6 ::1; } "
+
+        add_args = self.get_cmd_args('add')
+        add_args.extend((
+            "/softwire-config/binding-table/softwire",
+            test_softwire,
+        ))
+        self.assertRaises(AssertionError, self.run_cmd, add_args)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -259,30 +259,52 @@ class TestConfigMisc(BaseTestCase):
         self.assertEqual(output.strip(), bytes(test_psid, ENC),
             '\n'.join(('OUTPUT', str(output, ENC))))
 
-    def test_softwire_not_in_psidmap(self):
+    def test_softwire_not_in_psidmap_add(self):
         """
-        Tests that softwire with a PSID out of PSID map errors
+        Tests that adding softwire without PSID map entry errors
         """
         # Create a softwire which won't have an IPv4 address in the PSID map.
-        test_softwire = "{ ipv4 192.168.1.23; psid 72; b4-ipv6 ::1; } "
+        test_softwire = '{ ipv4 192.168.1.23; psid 72; b4-ipv6 ::1; } '
 
         add_args = self.get_cmd_args('add')
         add_args.extend((
-            "/softwire-config/binding-table/softwire",
+            '/softwire-config/binding-table/softwire',
             test_softwire,
         ))
-        add_error = "Able to add softwire with without PSID mapping"
+        add_error = 'Able to add softwire with without PSID mapping'
         with self.assertRaises(AssertionError, msg=add_error):
             self.run_cmd(add_args)
 
         # Then try and get the softwire added to ensure it's not been added
         get_args = self.get_cmd_args('get')
         get_args.append(
-            "/softwire-config/binding-table/softwire[ipv4=192.168.1.23][psid=72]"
+            '/softwire-config/binding-table/softwire[ipv4=192.168.1.23][psid=72]'
         )
-        get_error = "Softwire was added with an invalid PSID mapping."
+        get_error = 'Softwire was added with an invalid PSID mapping.'
         with self.assertRaises(AssertionError, msg=get_error):
             self.run_cmd(get_args)
+
+    def test_softwire_not_in_psidmap_set(self):
+        """
+        Test setting softwire without PSID map entry errors
+        """
+        # Set the entire binding-table
+        set_args = self.get_cmd_args('set')
+
+        # PSID mapping for a softwire.
+        binding_table = ["psid-map { addr 1.1.1.1; psid-length 16;}"]
+
+        # Add a valid softwire
+        binding_table.append("softwire { ipv4 1.1.1.1; psid 1; b4-ipv6 ::1; }")
+
+        # Add an invalid softwire
+        binding_table.append("softwire { ipv4 5.5.5.5; psid 1; b4-ipv6 ::1; }")
+
+        set_args.append(" ".join(binding_table))
+        err = "Softwire with an invalid PSID mapping was set"
+        with self.assertRaises(AssertionError, msg=err):
+            self.run_cmd(set_args)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -40,12 +40,9 @@ class TestRun(BaseTestCase):
         invalid_softwire_args = list(self.cmd_args)
         invalid_softwire_args[-5] = config_file
         # Verify it errors when there is a softwire lacking a PSID mapping entry
-        self.assertRaises(
-            AssertionError,
-            self.execute_run_test,
-            invalid_softwire_args
-        )
-
+        err = "Started with config file that has softwire without PSID mapping"
+        with self.assertRaises(AssertionError, msg=err):
+            self.execute_run_test(invalid_softwire_args)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -35,6 +35,17 @@ class TestRun(BaseTestCase):
         reconf_args.insert(3, '--reconfigurable')
         self.execute_run_test(reconf_args)
 
+    def test_config_with_invalid_softwire(self):
+        config_file = str(DATA_DIR / "missing_softwire_psidmap.conf")
+        invalid_softwire_args = list(self.cmd_args)
+        invalid_softwire_args[-5] = config_file
+        # Verify it errors when there is a softwire lacking a PSID mapping entry
+        self.assertRaises(
+            AssertionError,
+            self.execute_run_test,
+            invalid_softwire_args
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This now will validate softwires which are added via `snabb config add` or `snabb config set` and ensure that every softwire has a corresponding PSID mapping and that invalid softwires are not silently accepted. It also checks that when you start the lwaftr the config file it is started with is valid. This occurs by having validation in the leader to validate softwires prior to them being sent to the data plane.

This fixes the problem described in #727.