### PR TITLE
Allow list statements without "key"s when "config false" is set

### DIFF
--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -96,7 +96,9 @@ function data_grammar_from_schema(schema)
    function handlers.list(node)
       local members=visit_body(node)
       local keys, values = {}, {}
-      for k in node.key:split(' +') do keys[k] = assert(members[k]) end
+      if node.key then
+         for k in node.key:split(' +') do keys[k] = assert(members[k]) end
+      end
       for k,v in pairs(members) do
          if not keys[k] then values[k] = v end
       end
@@ -791,7 +793,7 @@ function selftest()
       }
    }]]
    local keyless_schema = schema.load_schema(list_wo_key_config_false)
-   local keyless_list_schema = load_data_for_schema(keyless_schema, [[
+   local keyless_list_data = load_data_for_schema(keyless_schema, [[
    test {
       node {
          name "hello";

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -775,5 +775,27 @@ function selftest()
    assert(parse_uint32('"1"') == 1)
    assert(parse_uint32('    "1"   \n  ') == 1)
    assert(print_uint32(1, string_output_file()) == '1')
+
+   -- Verify that lists can lack keys when "config false;" is set.
+   local list_wo_key_config_false = [[module config-false-schema {
+      namespace "urn:ietf:params:xml:ns:yang:config-false-schema";
+      prefix "test";
+
+      container test {
+         description "Top level node";
+         list node {
+            config false;
+            description "List without key as config false is set";
+            leaf name { type string; }
+         }
+      }
+   }]]
+   local keyless_schema = schema.load_schema(list_wo_key_config_false)
+   local keyless_list_schema = load_data_for_schema(keyless_schema, [[
+   test {
+      node {
+         name "hello";
+      }
+   }]])
    print('selfcheck: ok')
 end


### PR DESCRIPTION
This fixes issue #789.

It adds a test to catch the error and also fixes the error. It now allows for lists not to require a key which is the case when "config false" is set as said in the RFC (second 7.8.2 and the issue).

@wingo PTAL