### PR TITLE
Fix small nit in test on lwaftr-kristian

### DIFF
--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -149,12 +149,12 @@ class TestConfigMisc(BaseTestCase):
         self.run_cmd(add_args)
         get_args = self.get_cmd_args('get')
         get_args.append(
-            '/softwire-config/binding-table/softwire[ipv4=1.2.3.4][psid=7]')
+            '/softwire-config/binding-table/softwire[ipv4=1.2.3.4][psid=7]'
+            '/b4-ipv6')
         output = self.run_cmd(get_args)
         # run_cmd checks the exit code and fails the test if it is not zero.
-        get_args[-1] += '/b4-ipv6'
         self.assertEqual(
-            output.strip(), b'b4-ipv6 ::1;\nbr-address 2001:db8::;',
+            output.strip(), b'::1',
             '\n'.join(('OUTPUT', str(output, ENC))))
 
     def test_get_state(self):


### PR DESCRIPTION
This fixes a small nit in the test where it was suppose to be validating the value of the `b4-ipv6` address however the specific leaf address was being added to the command after it was being run, so it wasn't actually testing that.

This also needs merging on the `lwaftr` branch however that will come in a follow-up PR. This is required for work on #796 as this issue came to light when developing that.