### PR TITLE
[WIP] Add YANG alarms schema

### DIFF
--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -21,10 +21,12 @@ require("lib.lua.class")
 
 -- ljsyscall returns error as a cdata instead of a string, and the standard
 -- assert doesn't use tostring on it.
+--[[
 _G.assert = function (v, ...)
    if v then return v, ... end
    error(tostring(... or "assertion failed!"))
 end
+--]]
 
 -- Reserve names that we want to use for global module.
 -- (This way we avoid errors from the 'strict' module.)

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -182,7 +182,7 @@ function data_grammar_from_schema(schema)
       local members=visit_body(node)
       local keys, values = {}, {}
       if node.key then
-         for k in node.key:split(' +') do keys[k] = assert(members[k]) end
+         for k in node.key:split(' +') do keys[k] = assert(members[k], "missing member '"..k.."' in node '"..node.id.."'") end
       end
       for k,v in pairs(members) do
          if not keys[k] then values[k] = v end

--- a/src/lib/yang/ietf-alarms.yang
+++ b/src/lib/yang/ietf-alarms.yang
@@ -856,7 +856,7 @@ module ietf-alarms {
                 uses common-alarm-parameters;
                 uses resource-alarm-parameters;
 
-                list operator-state-change {
+                list operator-state-revision {
                     if-feature operator-actions;
                     key time;
                     description

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -771,9 +771,10 @@ function resolve(schema, features)
       end
       if node.kind == 'feature' then
          node.module_id = lookup(env, 'module_id', '_')
-         if not (features[node.module_id] or {})[node.id] then
-            node.unavailable = true
+         if not features[node.module_id] then
+            features[node.module_id] = {}
          end
+         features[node.module_id][node.id] = node
       end
       for _,feature in ipairs(pop_prop(node, 'if_features') or {}) do
          local feature_node = lookup_lazy(env, 'features', feature)

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -705,12 +705,14 @@ function resolve(schema, features)
          -- lookup_lazy because we don't want the pcall to hide errors
          -- from the lazy expansion.
          typedef = typedef()
+         assert(typedef.kind == "typedef")
          node.base_type = typedef
          node.primitive_type = assert(typedef.primitive_type)
          node.enums = {}
          for _, enum in ipairs(typedef.type.enums) do
             node.enums[enum.name] = true
          end
+         node.union = typedef.type.union
       else
          -- If the type name wasn't bound, it must be primitive.
          assert(primitive_types[node.id], 'unknown type: '..node.id)

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -96,7 +96,7 @@ function types.identityref.tostring(val)
 end
 
 types['instance-identifier'] = unimplemented('instance-identifier')
-leafref = unimplemented('leafref')
+types.leafref = unimplemented('leafref')
 
 types.string = {}
 function types.string.parse(str, what)

--- a/src/lib/yang/yang.lua
+++ b/src/lib/yang/yang.lua
@@ -125,9 +125,10 @@ function load_configuration(filename, opts)
                               source_mtime)
    if not success then
       log('error saving compiled configuration %s: %s', compiled_filename, err)
+   else
+      log('wrote compiled configuration %s', compiled_filename)
    end
 
-   log('wrote compiled configuration %s', compiled_filename)
    -- Done.
    return conf
 end

--- a/src/load_schema.lua
+++ b/src/load_schema.lua
@@ -1,0 +1,12 @@
+local yang = require("lib.yang.yang")
+local data = require("lib.yang.data")
+
+function run (args)
+   print("load_schema")
+   local schema = yang.load_schema_by_name("ietf-alarms")
+   local grammar = data.data_grammar_from_schema(schema)
+   local parse = data.data_parser_from_grammar(grammar)
+   print("ok")
+end
+
+run(main.parameters)


### PR DESCRIPTION
This PR adds the YANG Alarm Module v1.1 schema as defined in https://www.ietf.org/id/draft-vallin-netmod-alarm-module-01.txt

In addition, some changes are required in the Snabb's YANG library to parse the schema correctly.
 
- [x] **Parse yang-version as a decimal number**. Couldn't parse "yang-version" as a decimal number.
- [x] **Assign type.unions in typedefs**. There was an issue when trying to parse `typedefs` defined as union types. The `typedef` node didn't contain the `unions` infor of the embed type.
- [x] **Add feature in features table if defined**. The `features` array only contains the default features properties, but not extra features defined in the module. As a result, the `if-feature` property is not honoured.
- [x] **Add leafref to the list of yang.value.types**. The `learef`type was not recognized because it wasn't present in the `yang.value.types` table.
- [x] **Fix YANG property-based tests**. CI complained about a NYI type in property-based tests which resulted into an exit code != 0. The unsupported type was 'ipv4-prefix'.
- [ ] **Cannot find attribute `time` in `operator-state-change`**. The alarms list contains a list called `opearator-state-change`. This list is identified with key `time`. The `time`attribute should be obtained indirectly via `uses operator-parameters`. However, after parsing the schema `operator-state-change` contains attribute `operator-parameters`of kind `uses` and it doesn't contain the `time`attribute in `node.body`. I found out the problem was having 2 lists named `operator-state-change` in the schema. If rename one of the lists the problem is fixed. This was work around and the issue should be properly fixed.

This PR is still WIP, `ietf-alarms.yang` can be parsed correctly now but it's necessary to fix the last subtask properly. To test it:

```bash
$ sudo ./snabb snsh load_schema.lua 
load_schema
ok
```