### PR TITLE
Disable bus-mastering cleanup for intel_mp

### DIFF
--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -726,6 +726,7 @@ function Intel1g:init ()
    if not self.master then return end
    pci.unbind_device_from_linux(self.pciaddress)
    pci.set_bus_master(self.pciaddress, true)
+   pci.disable_bus_master_cleanup(self.pciaddress)
 
    -- 4.5.3  Initialization Sequence
    self:disable_interrupts()
@@ -865,6 +866,7 @@ function Intel82599:init ()
    if not self.master then return end
    pci.unbind_device_from_linux(self.pciaddress)
    pci.set_bus_master(self.pciaddress, true)
+   pci.disable_bus_master_cleanup(self.pciaddress)
 
    for i=1,math.floor(self.linkup_wait/2) do
       self:disable_interrupts()

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -175,6 +175,12 @@ function set_bus_master (device, enable)
    f:close()
 end
 
+-- For devices used by some Snabb apps, PCI bus mastering should
+-- outlive the life of the process.
+function disable_bus_master_cleanup (device)
+   shm.unlink('group/dma/pci/'..canonical(device))
+end
+
 -- Shutdown DMA to prevent "dangling" requests for PCI devices opened
 -- by pid (or other processes in its process group).
 --


### PR DESCRIPTION
See https://github.com/snabbco/snabb/issues/1145 for more discussion.