### PR TITLE
Worker processes have useful process name

### DIFF
--- a/src/core/worker.lua
+++ b/src/core/worker.lua
@@ -47,7 +47,9 @@ function start (name, luacode)
       for key, value in pairs(S.environ()) do
          table.insert(env, key.."="..value)
       end
-      S.execve(("/proc/%d/exe"):format(S.getpid()), {}, env)
+      local filename = ("/proc/%d/exe"):format(S.getpid())
+      local argv = { ("[snabb worker '%s' for %d]"):format(name, S.getppid()) }
+      S.execve(filename, argv, env)
    else
       -- Parent process
       children[name] = { pid = pid }


### PR DESCRIPTION
This fixes the "ps" output which was like this (pstree):

```
 | |       \-+- 04282 root ./snabb lwaftr run --reconfigurable --cpu 3 --conf program/lwaftr/tests/data/icmp_on_fail.conf --v4 02:00.0 --v6 02:00.1 
 | |         \--- 04284 root (exe)
```

and now looks like this:

```
 | |       \-+- 05941 root ./snabb lwaftr run --reconfigurable --cpu 3 --conf program/lwaftr/tests/data/icmp_on_fail.conf --v4 02:00.0 --v6 02:00.1 
 | |         \--- 05943 root [snabb worker 'follower' for 5941] 
```