### PR TITLE
lwaftr: main process should not run at 100% CPU

### DIFF
--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -217,7 +217,8 @@ function run(args)
       end
    end
 
-   engine.busywait = true
+   if not opts.reconfigurable then engine.busywait = true end
+
    if opts.duration then
       engine.main({duration=opts.duration, report={showlinks=true}})
    else


### PR DESCRIPTION
There was a logic error in which the main process was always running at 100% CPU.  This PR only turns on busywait in run.lua in the single-process mode; otherwise setup.lua turns it on.