### PR TITLE
Add multiprocess support to snabb-softwire-v2

### DIFF
--- a/src/apps/config/action_codec.lua
+++ b/src/apps/config/action_codec.lua
@@ -131,22 +131,13 @@ local function encoder()
    end
    function encoder:config(class, arg)
       local file_name = random_file_name()
-      local schema_file
       if class.yang_schema then
-         schema_file = random_file_name()
-         if class.config_arg then
-            yang.compile_data_for_schema_by_name(class.yang_schema,
-                                             arg[class.config_arg], schema_file)
-            arg[class.config_arg] = nil
-         else
-            yang.compile_data_for_schema_by_name(class.yang_schema, arg, schema_file)
-            arg = nil
-         end
+         yang.compile_data_for_schema_by_name(class.yang_schema, arg,
+                                              file_name)
+      else
+         if arg == nil then arg = {} end
+         binary.compile_ad_hoc_lua_data_to_file(file_name, arg)
       end
-      local prepped_arg = {
-         config_arg = class.config_arg, config=schema_file, args=arg
-      }
-      binary.compile_ad_hoc_lua_data_to_file(file_name, prepped_arg)
       self:string(file_name)
    end
    function encoder:finish()
@@ -197,11 +188,7 @@ local function decoder(buf, len)
       return assert(require(require_path)[name])
    end
    function decoder:config()
-      local raw = binary.load_compiled_data_file(self:string()).data
-      if raw.config_arg then
-         raw.args[raw.config_arg] = binary.load_compiled_data_file(raw.config).data
-      end
-      return raw.args
+      return binary.load_compiled_data_file(self:string()).data
    end
    function decoder:finish(...)
       return { ... }

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -238,12 +238,29 @@ local function init_transmit_icmpv4_reply (rate_limiting)
    end
 end
 
+function select_instance(conf, device)
+   -- Merges t1 into t2 by mutating t1 with t2's values. This is quicker than
+   -- producing a new table with the combination of t1 & t2 like I'd have liked.
+   local function table_merge(t1, t2)
+      for k,v in pairs(t2) do t1[k] = v end
+   end
+
+   instance = assert(conf.softwire_config.instance[device])
+
+   table_merge(conf.softwire_config.external_interface,
+               instance.queue.values[1].external_interface)
+   table_merge(conf.softwire_config.internal_interface,
+               instance.queue.values[1].internal_interface)
+   return conf
+end
+
 LwAftr = { yang_schema = 'snabb-softwire-v2' }
 
-function LwAftr:new(conf)
+function LwAftr:new(args)
+   local conf, device = args.conf, args.device
    if conf.debug then debug = true end
    local o = setmetatable({}, {__index=LwAftr})
-   conf = conf.softwire_config
+   conf = select_instance(conf, device).softwire_config
    o.conf = conf
 
    o.binding_table = bt.load(conf.binding_table)

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -257,7 +257,7 @@ end
 LwAftr = { yang_schema = 'snabb-softwire-v2' }
 
 function LwAftr:new(args)
-   local conf, device = args.conf, args.device
+   local conf, device = assert(args.conf, "conf"), assert(args.device, "device")
    if conf.debug then debug = true end
    local o = setmetatable({}, {__index=LwAftr})
    conf = select_instance(conf, device).softwire_config

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -8,7 +8,6 @@ local lwdebug = require("apps.lwaftr.lwdebug")
 local lwheader = require("apps.lwaftr.lwheader")
 local lwutil = require("apps.lwaftr.lwutil")
 
-local cltable = require("lib.cltable")
 local checksum = require("lib.checksum")
 local ethernet = require("lib.protocol.ethernet")
 local counter = require("core.counter")

--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -6,7 +6,6 @@ local S = require("syscall")
 local bit = require("bit")
 local ffi = require("ffi")
 local lib = require("core.lib")
-local corelib = require("core.lib")
 
 
 local band = bit.band
@@ -27,7 +26,7 @@ local ntohs = lib.ntohs
 function produce_instance_configs(conf)
    local ret = {}
    for device, queues in pairs(conf.softwire_config.instance) do
-      ret[device] = corelib.deepcopy(conf)
+      ret[device] = lib.deepcopy(conf)
       ret[device].softwire_config.instance = {[device]=queues}
    end
    return ret

--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -18,6 +18,19 @@ local ehs = constants.ethernet_header_size
 local o_ipv4_flags = constants.o_ipv4_flags
 local ntohs = lib.ntohs
 
+-- Produces configuration for each instance.
+-- Provided a multi-process configuration it will iterate over each instance
+-- and produce a configuration for each device with a single instance in. This
+-- is then able to be provided to the lwaftr app.
+function produce_instance_configs(conf)
+   local ret = {}
+   for device, queues in pairs(conf.softwire_config.instance) do
+      ret[device] = lib.deepcopy(conf)
+      ret[device].softwire_config.instance = {[device]=queues}
+   end
+   return ret
+end
+
 function get_ihl_from_offset(pkt, offset)
    local ver_and_ihl = pkt.data[offset]
    return band(ver_and_ihl, 0xf) * 4

--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -6,6 +6,8 @@ local S = require("syscall")
 local bit = require("bit")
 local ffi = require("ffi")
 local lib = require("core.lib")
+local corelib = require("core.lib")
+
 
 local band = bit.band
 local cast = ffi.cast
@@ -17,6 +19,19 @@ local constants_ipv6_frag = constants.ipv6_frag
 local ehs = constants.ethernet_header_size
 local o_ipv4_flags = constants.o_ipv4_flags
 local ntohs = lib.ntohs
+
+-- Produces configuration for each instance.
+-- Provided a multi-process configuration it will iterate over each instance
+-- and produce a configuration for each device with a single instance in. This
+-- is then able to be provided to the lwaftr app.
+function produce_instance_configs(conf)
+   local ret = {}
+   for device, queues in pairs(conf.softwire_config.instance) do
+      ret[device] = corelib.deepcopy(conf)
+      ret[device].softwire_config.instance = {[device]=queues}
+   end
+   return ret
+end
 
 function get_ihl_from_offset(pkt, offset)
    local ver_and_ihl = pkt.data[offset]

--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -7,7 +7,6 @@ local bit = require("bit")
 local ffi = require("ffi")
 local lib = require("core.lib")
 
-
 local band = bit.band
 local cast = ffi.cast
 
@@ -18,19 +17,6 @@ local constants_ipv6_frag = constants.ipv6_frag
 local ehs = constants.ethernet_header_size
 local o_ipv4_flags = constants.o_ipv4_flags
 local ntohs = lib.ntohs
-
--- Produces configuration for each instance.
--- Provided a multi-process configuration it will iterate over each instance
--- and produce a configuration for each device with a single instance in. This
--- is then able to be provided to the lwaftr app.
-function produce_instance_configs(conf)
-   local ret = {}
-   for device, queues in pairs(conf.softwire_config.instance) do
-      ret[device] = lib.deepcopy(conf)
-      ret[device].softwire_config.instance = {[device]=queues}
-   end
-   return ret
-end
 
 function get_ihl_from_offset(pkt, offset)
    local ver_and_ihl = pkt.data[offset]

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -34,7 +34,7 @@ module snabb-softwire-v2 {
   }
 
   grouping state-counters {
-    container state {
+    container softwire-state {
 
       description "State data about interface.";
       config false;
@@ -845,8 +845,5 @@ module snabb-softwire-v2 {
     }
   }
 
-  container softwire-state {
-    description "Counters for all configured interfaces.";
-    uses state-counters;
-  }
+  uses state-counters;
 }

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -10,11 +10,6 @@ module snabb-softwire-v2 {
   description
    "Configuration for the Snabb Switch lwAFTR.";
 
-  revision 2016-11-04 {
-    description
-     "Initial revision.";
-  }
-
   revision 2017-04-17 {
     description
       "Removal of br-address leaf-list and  br leaf. It adds the
@@ -26,12 +21,116 @@ module snabb-softwire-v2 {
        This also removes the psid-map list and adds a new port-set
        container on the softwire container instead. This will help
        adding the softwires as well as bring it more inline with the
-       ietf-softwire schema.";
+       ietf-softwire schema.
+
+       The addition of /softwire-config/instance allows for configuring
+       multiple instances of the lwAFTR with a shared binding table and
+       other common configuration properties.";
+  }
+
+  revision 2016-11-04 {
+    description
+     "Initial revision.";
   }
 
   container softwire-config {
     description
      "Configuration for Snabb lwaftr.";
+
+    list instance {
+      description
+       "Provides configuration for specific instances of the lwAFTR.
+        These configuration options will only affect the specific lwaftr
+        with the given name specified in the name leaf. The other options
+        not present in this list are shared amongst all instances.";
+
+      key "name";
+
+      leaf name {
+        type string;
+        description
+         "Name of lwAFTR instance. This must be unique amongst the Snabb
+          processes on the system. This may be specified either here, in the
+          YANG configuration or via the command line when the lwAFTR is started.
+
+          The order of presidence for this leaf is as followers:
+          1. The name set on an already running lwAFTR instance via snabb set.
+          2. A command line option to specify the name upon starting the lwAFTR
+              instance (i.e. overriding this value).
+          3. The value here in the configuration when starting a lwaftr instance.
+
+          If no name is specified the lwaftr can be referred to using the PID of
+          the lwAFTR process on the system.";
+      }
+
+      container external-interface {
+        leaf ip {
+          type inet:ipv4-address;
+          mandatory true;
+          description
+           "L3 Address of the internet-facing network interface.  Used
+            when generating error messages and responding to ICMP echo
+            requests.";
+        }
+
+        leaf mac {
+          type yang:mac-address;
+          mandatory true;
+          description
+            "MAC address of the internet-facing NIC.";
+        }
+
+        container next-hop {
+          leaf ip {
+            type inet:ipv4-address;
+            description
+             "IPv4 address of the next hop for the internet-facing NIC.
+              The lwAFTR will resolve this to a MAC address using ARP.";
+          }
+
+          leaf mac {
+            type yang:mac-address;
+            description
+             "Statically configured MAC address of the next hop for the
+              internet-facing NIC.";
+          }
+        }
+      }
+
+      container internal-interface {
+        leaf ip {
+          type inet:ipv6-address;
+          mandatory true;
+          description
+           "L3 Address of the internal-facing network interface.  Used
+            when generating error messages and responding to ICMP echo
+            requests.";
+        }
+
+        leaf mac {
+          type yang:mac-address;
+          mandatory true;
+          description
+           "MAC address of the internal-facing NIC.";
+        }
+
+        container next-hop {
+          leaf ip {
+            type inet:ipv6-address;
+            description
+             "IPv6 address of the next hop for the internal-facing NIC.
+              The lwAFTR will resolve this to a MAC address using NDP.";
+          }
+
+          leaf mac {
+            type yang:mac-address;
+            description
+             "Statically configured MAC address of the next hop for the
+              internal-facing NIC.";
+          }
+        }
+      }
+    }
 
     grouping traffic-filters {
       description
@@ -140,27 +239,11 @@ module snabb-softwire-v2 {
       }
     }
 
-
-
     container external-interface {
       description
        "Configuration for the external, internet-facing IPv4
         interface.";
 
-      leaf ip {
-        type inet:ipv4-address;
-        mandatory true;
-        description
-         "L3 Address of the internet-facing network interface.  Used
-          when generating error messages and responding to ICMP echo
-          requests.";
-      }
-      leaf mac {
-        type yang:mac-address;
-        mandatory true;
-        description
-         "MAC address of the internet-facing NIC.";
-      }
       leaf mtu {
         type uint16;
         default 1460;
@@ -174,40 +257,13 @@ module snabb-softwire-v2 {
       uses error-rate-limiting;
       uses reassembly;
 
-      container next-hop {
-        leaf ip {
-          type inet:ipv4-address;
-          description
-           "IPv4 address of the next hop for the internet-facing NIC.
-            The lwAFTR will resolve this to a MAC address using ARP.";
-        }
-        leaf mac {
-          type yang:mac-address;
-          description
-           "Statically configured MAC address of the next hop for the
-            internet-facing NIC.";
-        }
-      }
+
     }
 
     container internal-interface {
       description
        "Configuration for the internal IPv6 interface.";
 
-      leaf ip {
-        type inet:ipv6-address;
-        mandatory true;
-        description
-         "L3 Address of the internal-facing network interface.  Used
-          when generating error messages and responding to ICMP echo
-          requests.";
-      }
-      leaf mac {
-        type yang:mac-address;
-        mandatory true;
-        description
-         "MAC address of the internal-facing NIC.";
-      }
       leaf mtu {
         type uint16;
         default 1500;
@@ -220,21 +276,6 @@ module snabb-softwire-v2 {
       uses vlan-tagging;
       uses error-rate-limiting;
       uses reassembly;
-
-      container next-hop {
-        leaf ip {
-          type inet:ipv6-address;
-          description
-           "IPv6 address of the next hop for the internal-facing NIC.
-            The lwAFTR will resolve this to a MAC address using NDP.";
-        }
-        leaf mac {
-          type yang:mac-address;
-          description
-           "Statically configured MAC address of the next hop for the
-            internal-facing NIC.";
-        }
-      }
 
       leaf hairpinning {
         type boolean;
@@ -259,7 +300,7 @@ module snabb-softwire-v2 {
           description
            "Public IPv4 address of the softwire.";
         }
-        
+
         leaf padding {
           type uint16;
           default 0;

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -37,6 +37,23 @@ module snabb-softwire-v2 {
     description
      "Configuration for Snabb lwaftr.";
 
+    leaf name {
+      type string;
+      description
+        "Name of lwAFTR instance. This must be unique amongst the Snabb
+        processes on the system. This may be specified either here, in the
+        YANG configuration or via the command line when the lwAFTR is started.
+
+        The order of presidence for this leaf is as followers:
+        1. The name set on an already running lwAFTR instance via snabb set.
+        2. A command line option to specify the name upon starting the lwAFTR
+            instance (i.e. overriding this value).
+        3. The value here in the configuration when starting a lwaftr instance.
+
+        If no name is specified the lwaftr can be referred to using the PID of
+        the lwAFTR process on the system.";
+    }
+
     list instance {
       description
        "Provides configuration for specific instances of the lwAFTR.
@@ -44,92 +61,78 @@ module snabb-softwire-v2 {
         with the given name specified in the name leaf. The other options
         not present in this list are shared amongst all instances.";
 
-      key "name";
+      key "device";
 
-      leaf name {
+      leaf device {
         type string;
-        description
-         "Name of lwAFTR instance. This must be unique amongst the Snabb
-          processes on the system. This may be specified either here, in the
-          YANG configuration or via the command line when the lwAFTR is started.
-
-          The order of presidence for this leaf is as followers:
-          1. The name set on an already running lwAFTR instance via snabb set.
-          2. A command line option to specify the name upon starting the lwAFTR
-              instance (i.e. overriding this value).
-          3. The value here in the configuration when starting a lwaftr instance.
-
-          If no name is specified the lwaftr can be referred to using the PID of
-          the lwAFTR process on the system.";
+        description "PCI device name.";
       }
 
-      container external-interface {
-        leaf ip {
-          type inet:ipv4-address;
-          mandatory true;
-          description
-           "L3 Address of the internet-facing network interface.  Used
-            when generating error messages and responding to ICMP echo
-            requests.";
+      list queue {
+        description
+         "List of Receive-Side Scaling (RSS) queues.";
+        key "id";
+
+        leaf id {
+          type uint8;
         }
 
-        leaf mac {
-          type yang:mac-address;
-          mandatory true;
-          description
-            "MAC address of the internet-facing NIC.";
-        }
-
-        container next-hop {
+        container external-interface {
           leaf ip {
             type inet:ipv4-address;
+            mandatory true;
             description
-             "IPv4 address of the next hop for the internet-facing NIC.
-              The lwAFTR will resolve this to a MAC address using ARP.";
+            "L3 Address of the internet-facing network interface.  Used
+              when generating error messages and responding to ICMP echo
+              requests.";
           }
 
-          leaf mac {
-            type yang:mac-address;
-            description
-             "Statically configured MAC address of the next hop for the
-              internet-facing NIC.";
+          container next-hop {
+            leaf ip {
+              type inet:ipv4-address;
+              description
+              "IPv4 address of the next hop for the internet-facing NIC.
+                The lwAFTR will resolve this to a MAC address using ARP.";
+            }
+
+            leaf mac {
+              type yang:mac-address;
+              description
+              "Statically configured MAC address of the next hop for the
+                internet-facing NIC.";
+            }
           }
         }
-      }
 
-      container internal-interface {
-        leaf ip {
-          type inet:ipv6-address;
-          mandatory true;
-          description
-           "L3 Address of the internal-facing network interface.  Used
-            when generating error messages and responding to ICMP echo
-            requests.";
-        }
-
-        leaf mac {
-          type yang:mac-address;
-          mandatory true;
-          description
-           "MAC address of the internal-facing NIC.";
-        }
-
-        container next-hop {
+        container internal-interface {
           leaf ip {
             type inet:ipv6-address;
+            mandatory true;
             description
-             "IPv6 address of the next hop for the internal-facing NIC.
-              The lwAFTR will resolve this to a MAC address using NDP.";
+            "L3 Address of the internal-facing network interface.  Used
+              when generating error messages and responding to ICMP echo
+              requests.";
           }
 
-          leaf mac {
-            type yang:mac-address;
-            description
-             "Statically configured MAC address of the next hop for the
-              internal-facing NIC.";
+          container next-hop {
+            leaf ip {
+              type inet:ipv6-address;
+              description
+              "IPv6 address of the next hop for the internal-facing NIC.
+                The lwAFTR will resolve this to a MAC address using NDP.";
+            }
+
+            leaf mac {
+              type yang:mac-address;
+              description
+              "Statically configured MAC address of the next hop for the
+                internal-facing NIC.";
+            }
           }
         }
       }
+
+
     }
 
     grouping traffic-filters {

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -33,6 +33,377 @@ module snabb-softwire-v2 {
      "Initial revision.";
   }
 
+  grouping state-counters {
+    container state {
+
+      description "State data about interface.";
+      config false;
+
+      leaf drop-all-ipv4-iface-bytes {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv4 interfaces,
+          whether or not they actually IPv4 (they only include data about
+          packets that go in/out over the wires, excluding internally generated
+          ICMP packets).";
+      }
+      leaf drop-all-ipv4-iface-packets {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv4 interfaces,
+          whether or not they actually IPv4 (they only include data about
+          packets that go in/out over the wires, excluding internally generated
+          ICMP packets).";
+      }
+      leaf drop-all-ipv6-iface-bytes {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv6 interfaces,
+          whether or not they actually IPv6 (they only include data about packets
+          that go in/out over the wires, excluding internally generated ICMP
+          packets).";
+      }
+      leaf drop-all-ipv6-iface-packets {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv6 interfaces,
+          whether or not they actually IPv6 (they only include data about packets
+          that go in/out over the wires, excluding internally generated ICMP
+          packets).";
+      }
+      leaf drop-bad-checksum-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description "ICMPv4 packets dropped because of a bad checksum.";
+      }
+      leaf drop-bad-checksum-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description "ICMPv4 packets dropped because of a bad checksum.";
+      }
+      leaf drop-in-by-policy-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv4 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-policy-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv4 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-policy-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv6 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-policy-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv6 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-rfc7596-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
+      }
+      leaf drop-in-by-rfc7596-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
+      }
+      leaf drop-ipv4-frag-disabled {
+        type yang:zero-based-counter64;
+        description
+          "If fragmentation is disabled, the only potentially non-zero IPv4
+          fragmentation counter is drop-ipv4-frag-disabled. If fragmentation is
+          enabled, it will always be zero.";
+      }
+      leaf drop-ipv4-frag-invalid-reassembly {
+        type yang:zero-based-counter64;
+        description
+          "Two or more IPv4 fragments were received, and reassembly was started,
+          but was invalid and dropped. Causes include multiple fragments claiming
+          they are the last fragment, overlapping fragment offsets, or the packet
+          was being reassembled from too many fragments (the setting is
+          max_fragments_per_reassembly_packet, and the default is that no packet
+          should be reassembled from more than 40).";
+      }
+      leaf drop-ipv4-frag-random-evicted {
+        type yang:zero-based-counter64;
+        description
+          "Reassembling an IPv4 packet from fragments was in progress, but the
+          configured amount of packets to reassemble at once was exceeded, so one
+          was dropped at random. Consider increasing the setting
+          max_ipv4_reassembly_packets.";
+      }
+      leaf drop-ipv6-frag-disabled {
+        type yang:zero-based-counter64;
+        description
+          "If fragmentation is disabled, the only potentially non-zero IPv6
+          fragmentation counter is drop-ipv6-frag-disabled. If fragmentation is
+          enabled, it will always be zero.";
+      }
+      leaf drop-ipv6-frag-invalid-reassembly {
+        type yang:zero-based-counter64;
+        description
+          "Two or more IPv6 fragments were received, and reassembly was started,
+          but was invalid and dropped. Causes include multiple fragments claiming
+          they are the last fragment, overlapping fragment offsets, or the packet
+          was being reassembled from too many fragments (the setting is
+          max_fragments_per_reassembly_packet, and the default is that no packet
+          should be reassembled from more than 40).";
+      }
+      leaf drop-ipv6-frag-random-evicted {
+        type yang:zero-based-counter64;
+        description
+          "Reassembling an IPv6 packet from fragments was in progress, but the
+          configured amount of packets to reassemble at once was exceeded, so one
+          was dropped at random. Consider increasing the setting
+          max_ipv6_reassembly_packets.";
+      }
+      leaf drop-misplaced-not-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "Non-IPv4 packets incoming on the IPv4 link.";
+      }
+      leaf drop-misplaced-not-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "Non-IPv4 packets incoming on the IPv4 link.";
+      }
+      leaf drop-misplaced-not-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "Non-IPv6 packets incoming on IPv6 link.";
+      }
+      leaf drop-misplaced-not-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "Non-IPv6 packets incoming on IPv6 link.";
+      }
+      leaf drop-no-dest-softwire-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description
+          "No matching destination softwire in the binding table; incremented
+          whether or not the reason was RFC7596.";
+      }
+      leaf drop-no-dest-softwire-ipv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "No matching destination softwire in the binding table; incremented
+          whether or not the reason was RFC7596.";
+      }
+      leaf drop-no-source-softwire-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "No matching source softwire in the binding table; incremented whether
+          or not the reason was RFC7596.";
+      }
+      leaf drop-no-source-softwire-ipv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "No matching source softwire in the binding table; incremented whether
+          or not the reason was RFC7596.";
+      }
+      leaf drop-out-by-policy-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "Internally generated ICMPv4 error packets dropped because of current
+          policy.";
+      }
+      leaf drop-out-by-policy-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Internally generated ICMPv6 packets dropped because of current
+          policy.";
+      }
+      leaf drop-over-mtu-but-dont-fragment-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description
+          "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
+          flag was set.";
+      }
+      leaf drop-over-mtu-but-dont-fragment-ipv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
+          flag was set.";
+      }
+      leaf drop-over-rate-limit-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
+      }
+      leaf drop-over-rate-limit-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
+      }
+      leaf drop-over-time-but-not-hop-limit-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Packet's time limit was exceeded, but the hop limit was not.";
+      }
+      leaf drop-over-time-but-not-hop-limit-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Packet's time limit was exceeded, but the hop limit was not.";
+      }
+      leaf drop-too-big-type-but-not-code-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
+          acceptable one for this type.";
+      }
+      leaf drop-too-big-type-but-not-code-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
+          acceptable one for this type.";
+      }
+      leaf drop-ttl-zero-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "IPv4 packets dropped because their TTL was zero.";
+      }
+      leaf drop-ttl-zero-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "IPv4 packets dropped because their TTL was zero.";
+      }
+      leaf drop-unknown-protocol-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown ICMPv6 protocol.";
+      }
+      leaf drop-unknown-protocol-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown ICMPv6 protocol.";
+      }
+      leaf drop-unknown-protocol-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown IPv6 protocol.";
+      }
+      leaf drop-unknown-protocol-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown IPv6 protocol.";
+      }
+      leaf hairpin-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "IPv4 packets going to a known b4 (hairpinned).";
+      }
+      leaf hairpin-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "IPv4 packets going to a known b4 (hairpinned).";
+      }
+      leaf in-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf in-ipv4-frag-needs-reassembly {
+        type yang:zero-based-counter64;
+        description "An IPv4 fragment was received.";
+      }
+      leaf in-ipv4-frag-reassembled {
+        type yang:zero-based-counter64;
+        description "A packet was successfully reassembled from IPv4 fragments.";
+      }
+      leaf in-ipv4-frag-reassembly-unneeded {
+        type yang:zero-based-counter64;
+        description
+          "An IPv4 packet which was not a fragment was received - consequently,
+          it did not need to be reassembled. This should be the usual case.";
+      }
+      leaf in-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf in-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf in-ipv6-frag-needs-reassembly {
+        type yang:zero-based-counter64;
+        description "An IPv6 fragment was received.";
+      }
+      leaf in-ipv6-frag-reassembled {
+        type yang:zero-based-counter64;
+        description "A packet was successfully reassembled from IPv6 fragments.";
+      }
+      leaf in-ipv6-frag-reassembly-unneeded {
+        type yang:zero-based-counter64;
+        description
+          "An IPv6 packet which was not a fragment was received - consequently, it
+          did not need to be reassembled. This should be the usual case.";
+      }
+      leaf in-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf ingress-packet-drops {
+        type yang:zero-based-counter64;
+        description "Packets dropped due to ingress filters.";
+      }
+      leaf memuse-ipv4-frag-reassembly-buffer {
+        type yang:zero-based-counter64;
+        description
+          "The amount of memory being used by the statically sized data structure
+          for reassembling IPv4 fragments. This is directly proportional to the
+          setting max_ipv4_reassembly_packets.";
+      }
+      leaf memuse-ipv6-frag-reassembly-buffer {
+        type yang:zero-based-counter64;
+        description
+          "The amount of memory being used by the statically sized data structure
+          for reassembling IPv6 fragments. This is directly proportional to the
+          setting max_ipv6_reassembly_packets.";
+      }
+      leaf out-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description "Internally generated ICMPv4 packets.";
+      }
+      leaf out-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description "Internally generated ICMPv4 packets.";
+      }
+      leaf out-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description "Internally generted ICMPv6 error packets.";
+      }
+      leaf out-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description "Internally generted ICMPv6 error packets.";
+      }
+      leaf out-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "Valid outgoing IPv4 packets.";
+      }
+      leaf out-ipv4-frag {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet exceeded the configured IPv4 MTU, so needed to be
+          fragmented. This may happen, but should be unusual.";
+      }
+      leaf out-ipv4-frag-not {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet was small enough to pass through unfragmented - this
+          should be the usual case.";
+      }
+      leaf out-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "Valid outgoing IPv4 packets.";
+      }
+      leaf out-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv6 packets.";
+      }
+      leaf out-ipv6-frag {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet exceeded the configured IPv6 MTU, so needed to be
+          fragmented. This may happen, but should be unusual.";
+      }
+      leaf out-ipv6-frag-not {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet was small enough to pass through unfragmented - this
+          should be the usual case.";
+      }
+      leaf out-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv6 packets.";
+      }
+    }
+  }
+
   container softwire-config {
     description
      "Configuration for Snabb lwaftr.";
@@ -52,87 +423,6 @@ module snabb-softwire-v2 {
 
         If no name is specified the lwaftr can be referred to using the PID of
         the lwAFTR process on the system.";
-    }
-
-    list instance {
-      description
-       "Provides configuration for specific instances of the lwAFTR.
-        These configuration options will only affect the specific lwaftr
-        with the given name specified in the name leaf. The other options
-        not present in this list are shared amongst all instances.";
-
-      key "device";
-
-      leaf device {
-        type string;
-        description "PCI device name.";
-      }
-
-      list queue {
-        description
-         "List of Receive-Side Scaling (RSS) queues.";
-        key "id";
-
-        leaf id {
-          type uint8;
-        }
-
-        container external-interface {
-          leaf ip {
-            type inet:ipv4-address;
-            mandatory true;
-            description
-            "L3 Address of the internet-facing network interface.  Used
-              when generating error messages and responding to ICMP echo
-              requests.";
-          }
-
-          container next-hop {
-            leaf ip {
-              type inet:ipv4-address;
-              description
-              "IPv4 address of the next hop for the internet-facing NIC.
-                The lwAFTR will resolve this to a MAC address using ARP.";
-            }
-
-            leaf mac {
-              type yang:mac-address;
-              description
-              "Statically configured MAC address of the next hop for the
-                internet-facing NIC.";
-            }
-          }
-        }
-
-        container internal-interface {
-          leaf ip {
-            type inet:ipv6-address;
-            mandatory true;
-            description
-            "L3 Address of the internal-facing network interface.  Used
-              when generating error messages and responding to ICMP echo
-              requests.";
-          }
-
-          container next-hop {
-            leaf ip {
-              type inet:ipv6-address;
-              description
-              "IPv6 address of the next hop for the internal-facing NIC.
-                The lwAFTR will resolve this to a MAC address using NDP.";
-            }
-
-            leaf mac {
-              type yang:mac-address;
-              description
-              "Statically configured MAC address of the next hop for the
-                internal-facing NIC.";
-            }
-          }
-        }
-      }
-
-
     }
 
     grouping traffic-filters {
@@ -242,6 +532,131 @@ module snabb-softwire-v2 {
       }
     }
 
+
+    list instance {
+      description
+       "Provides configuration for specific instances of the lwAFTR.
+        These configuration options will only affect the specific lwaftr
+        with the given name specified in the name leaf. The other options
+        not present in this list are shared amongst all instances.";
+
+      key "device";
+
+      leaf device {
+        type string;
+        description "PCI device name.";
+      }
+
+      list queue {
+        description "List of Receive-Side Scaling (RSS) queues.";
+        key "id";
+
+        leaf id {
+          type uint8;
+        }
+
+        container external-interface {
+          leaf ip {
+            type inet:ipv4-address;
+            mandatory true;
+            description
+            "L3 Address of the internet-facing network interface.  Used
+              when generating error messages and responding to ICMP echo
+              requests.";
+          }
+          leaf device {
+            description
+             "PCI device name";
+            type string;
+          }
+          leaf mac {
+            type yang:mac-address;
+            mandatory true;
+            description
+              "MAC address of the internet-facing NIC.";
+          }
+
+          uses vlan-tagging;
+
+          container next-hop {
+            choice address {
+              mandatory true;
+              case ip {
+                leaf ip {
+                  type inet:ipv4-address;
+                  description
+                  "IPv4 address of the next hop for the internet-facing NIC.
+                    The lwAFTR will resolve this to a MAC address using ARP.";
+                }
+                leaf mac {
+                  config false;
+                  description "Resolved next-hop mac address found by ARP."
+                  type yang:mac-address;
+                }
+              }
+              case mac {
+                leaf mac {
+                type yang:mac-address;
+                description
+                "Statically configured MAC address of the next hop for the
+                  internet-facing NIC.";
+              }
+              }
+            }
+          }
+        }
+
+        container internal-interface {
+          leaf ip {
+            type inet:ipv6-address;
+            mandatory true;
+            description
+            "L3 Address of the internal-facing network interface.  Used
+              when generating error messages and responding to ICMP echo
+              requests.";
+          }
+          leaf mac {
+            type yang:mac-address;
+            mandatory true;
+            description
+              "MAC address of the internal-facing NIC.";
+          }
+
+          uses vlan-tagging;
+
+
+          container next-hop {
+            choice address {
+              mandatory true;
+              case ip {
+                leaf ip {
+                  type inet:ipv6-address;
+                  description
+                  "IPv4 address of the next hop for the internet-facing NIC.
+                    The lwAFTR will resolve this to a MAC address using ARP.";
+                }
+                leaf mac {
+                  config false;
+                  description "Resolved next-hop mac address found by ARP."
+                  type yang:mac-address;
+                }
+              }
+              case mac {
+                leaf mac {
+                type yang:mac-address;
+                description
+                "Statically configured MAC address of the next hop for the
+                  internet-facing NIC.";
+              }
+              }
+            }
+          }
+        }
+      }
+
+      uses state-counters;
+    }
+
     container external-interface {
       description
        "Configuration for the external, internet-facing IPv4
@@ -254,9 +669,15 @@ module snabb-softwire-v2 {
          "Maximum packet size to send on the IPv4 interface.";
       }
 
+      leaf mru {
+        type uint16;
+        default 1460;
+        description
+         "Maximm packet size to recieve on the IPv4 interface.";
+      }
+
       uses traffic-filters;
       uses icmp-policy;
-      uses vlan-tagging;
       uses error-rate-limiting;
       uses reassembly;
 
@@ -272,6 +693,13 @@ module snabb-softwire-v2 {
         default 1500;
         description
          "Maximum packet size to sent on the IPv6 interface.";
+      }
+
+      leaf mru {
+        type uint16;
+        default 1460;
+        description
+         "Maximm packet size to recieve on the IPv6 interface.";
       }
 
       uses traffic-filters;
@@ -392,374 +820,25 @@ module snabb-softwire-v2 {
           }
         }
       }
+
+      container binding-table-version {
+        description
+         "Optional versioning for binding table. The vesioning information
+          will change on every update or change to the binding table.";
+
+        leaf binding-table-version{
+          type uint64;
+          description "Incremental version number.";
+        }
+        leaf binding-table-date {
+          type yang:date-and-time;
+          description "Timestamp of last change.";
+        }
     }
   }
 
   container softwire-state {
-    description "State data about lwaftr.";
-    config false;
-
-    leaf drop-all-ipv4-iface-bytes {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv4 interfaces,
-         whether or not they actually IPv4 (they only include data about
-         packets that go in/out over the wires, excluding internally generated
-         ICMP packets).";
-    }
-    leaf drop-all-ipv4-iface-packets {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv4 interfaces,
-         whether or not they actually IPv4 (they only include data about
-         packets that go in/out over the wires, excluding internally generated
-         ICMP packets).";
-    }
-    leaf drop-all-ipv6-iface-bytes {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv6 interfaces,
-         whether or not they actually IPv6 (they only include data about packets
-         that go in/out over the wires, excluding internally generated ICMP
-         packets).";
-    }
-    leaf drop-all-ipv6-iface-packets {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv6 interfaces,
-         whether or not they actually IPv6 (they only include data about packets
-         that go in/out over the wires, excluding internally generated ICMP
-         packets).";
-    }
-    leaf drop-bad-checksum-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description "ICMPv4 packets dropped because of a bad checksum.";
-    }
-    leaf drop-bad-checksum-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description "ICMPv4 packets dropped because of a bad checksum.";
-    }
-    leaf drop-in-by-policy-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv4 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-policy-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv4 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-policy-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv6 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-policy-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv6 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-rfc7596-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
-    }
-    leaf drop-in-by-rfc7596-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
-    }
-    leaf drop-ipv4-frag-disabled {
-      type yang:zero-based-counter64;
-      description
-        "If fragmentation is disabled, the only potentially non-zero IPv4
-         fragmentation counter is drop-ipv4-frag-disabled. If fragmentation is
-         enabled, it will always be zero.";
-    }
-    leaf drop-ipv4-frag-invalid-reassembly {
-      type yang:zero-based-counter64;
-      description
-        "Two or more IPv4 fragments were received, and reassembly was started,
-         but was invalid and dropped. Causes include multiple fragments claiming
-         they are the last fragment, overlapping fragment offsets, or the packet
-         was being reassembled from too many fragments (the setting is
-         max_fragments_per_reassembly_packet, and the default is that no packet
-         should be reassembled from more than 40).";
-    }
-    leaf drop-ipv4-frag-random-evicted {
-      type yang:zero-based-counter64;
-      description
-        "Reassembling an IPv4 packet from fragments was in progress, but the
-         configured amount of packets to reassemble at once was exceeded, so one
-         was dropped at random. Consider increasing the setting
-         max_ipv4_reassembly_packets.";
-    }
-    leaf drop-ipv6-frag-disabled {
-      type yang:zero-based-counter64;
-      description
-        "If fragmentation is disabled, the only potentially non-zero IPv6
-         fragmentation counter is drop-ipv6-frag-disabled. If fragmentation is
-         enabled, it will always be zero.";
-    }
-    leaf drop-ipv6-frag-invalid-reassembly {
-      type yang:zero-based-counter64;
-      description
-        "Two or more IPv6 fragments were received, and reassembly was started,
-         but was invalid and dropped. Causes include multiple fragments claiming
-         they are the last fragment, overlapping fragment offsets, or the packet
-         was being reassembled from too many fragments (the setting is
-         max_fragments_per_reassembly_packet, and the default is that no packet
-         should be reassembled from more than 40).";
-    }
-    leaf drop-ipv6-frag-random-evicted {
-      type yang:zero-based-counter64;
-      description
-        "Reassembling an IPv6 packet from fragments was in progress, but the
-        configured amount of packets to reassemble at once was exceeded, so one
-        was dropped at random. Consider increasing the setting
-        max_ipv6_reassembly_packets.";
-    }
-    leaf drop-misplaced-not-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "Non-IPv4 packets incoming on the IPv4 link.";
-    }
-    leaf drop-misplaced-not-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "Non-IPv4 packets incoming on the IPv4 link.";
-    }
-    leaf drop-misplaced-not-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "Non-IPv6 packets incoming on IPv6 link.";
-    }
-    leaf drop-misplaced-not-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "Non-IPv6 packets incoming on IPv6 link.";
-    }
-    leaf drop-no-dest-softwire-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description
-        "No matching destination softwire in the binding table; incremented
-         whether or not the reason was RFC7596.";
-    }
-    leaf drop-no-dest-softwire-ipv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "No matching destination softwire in the binding table; incremented
-         whether or not the reason was RFC7596.";
-    }
-    leaf drop-no-source-softwire-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "No matching source softwire in the binding table; incremented whether
-         or not the reason was RFC7596.";
-    }
-    leaf drop-no-source-softwire-ipv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "No matching source softwire in the binding table; incremented whether
-         or not the reason was RFC7596.";
-    }
-    leaf drop-out-by-policy-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "Internally generated ICMPv4 error packets dropped because of current
-         policy.";
-    }
-    leaf drop-out-by-policy-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Internally generated ICMPv6 packets dropped because of current
-         policy.";
-    }
-    leaf drop-over-mtu-but-dont-fragment-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description
-        "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
-         flag was set.";
-    }
-    leaf drop-over-mtu-but-dont-fragment-ipv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
-         flag was set.";
-    }
-    leaf drop-over-rate-limit-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
-    }
-    leaf drop-over-rate-limit-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
-    }
-    leaf drop-over-time-but-not-hop-limit-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Packet's time limit was exceeded, but the hop limit was not.";
-    }
-    leaf drop-over-time-but-not-hop-limit-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Packet's time limit was exceeded, but the hop limit was not.";
-    }
-    leaf drop-too-big-type-but-not-code-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
-         acceptable one for this type.";
-    }
-    leaf drop-too-big-type-but-not-code-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
-         acceptable one for this type.";
-    }
-    leaf drop-ttl-zero-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "IPv4 packets dropped because their TTL was zero.";
-    }
-    leaf drop-ttl-zero-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "IPv4 packets dropped because their TTL was zero.";
-    }
-    leaf drop-unknown-protocol-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown ICMPv6 protocol.";
-    }
-    leaf drop-unknown-protocol-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown ICMPv6 protocol.";
-    }
-    leaf drop-unknown-protocol-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown IPv6 protocol.";
-    }
-    leaf drop-unknown-protocol-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown IPv6 protocol.";
-    }
-    leaf hairpin-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "IPv4 packets going to a known b4 (hairpinned).";
-    }
-    leaf hairpin-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "IPv4 packets going to a known b4 (hairpinned).";
-    }
-    leaf in-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf in-ipv4-frag-needs-reassembly {
-      type yang:zero-based-counter64;
-      description "An IPv4 fragment was received.";
-    }
-    leaf in-ipv4-frag-reassembled {
-      type yang:zero-based-counter64;
-      description "A packet was successfully reassembled from IPv4 fragments.";
-    }
-    leaf in-ipv4-frag-reassembly-unneeded {
-      type yang:zero-based-counter64;
-      description
-        "An IPv4 packet which was not a fragment was received - consequently,
-         it did not need to be reassembled. This should be the usual case.";
-    }
-    leaf in-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf in-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf in-ipv6-frag-needs-reassembly {
-      type yang:zero-based-counter64;
-      description "An IPv6 fragment was received.";
-    }
-    leaf in-ipv6-frag-reassembled {
-      type yang:zero-based-counter64;
-      description "A packet was successfully reassembled from IPv6 fragments.";
-    }
-    leaf in-ipv6-frag-reassembly-unneeded {
-      type yang:zero-based-counter64;
-      description
-        "An IPv6 packet which was not a fragment was received - consequently, it
-         did not need to be reassembled. This should be the usual case.";
-    }
-    leaf in-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf ingress-packet-drops {
-      type yang:zero-based-counter64;
-      description "Packets dropped due to ingress filters.";
-    }
-    leaf memuse-ipv4-frag-reassembly-buffer {
-      type yang:zero-based-counter64;
-      description
-        "The amount of memory being used by the statically sized data structure
-         for reassembling IPv4 fragments. This is directly proportional to the
-        setting max_ipv4_reassembly_packets.";
-    }
-    leaf memuse-ipv6-frag-reassembly-buffer {
-      type yang:zero-based-counter64;
-      description
-        "The amount of memory being used by the statically sized data structure
-         for reassembling IPv6 fragments. This is directly proportional to the
-         setting max_ipv6_reassembly_packets.";
-    }
-    leaf out-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description "Internally generated ICMPv4 packets.";
-    }
-    leaf out-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description "Internally generated ICMPv4 packets.";
-    }
-    leaf out-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description "Internally generted ICMPv6 error packets.";
-    }
-    leaf out-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description "Internally generted ICMPv6 error packets.";
-    }
-    leaf out-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "Valid outgoing IPv4 packets.";
-    }
-    leaf out-ipv4-frag {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet exceeded the configured IPv4 MTU, so needed to be
-         fragmented. This may happen, but should be unusual.";
-    }
-    leaf out-ipv4-frag-not {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet was small enough to pass through unfragmented - this
-         should be the usual case.";
-    }
-    leaf out-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "Valid outgoing IPv4 packets.";
-    }
-    leaf out-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv6 packets.";
-    }
-    leaf out-ipv6-frag {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet exceeded the configured IPv6 MTU, so needed to be
-        fragmented. This may happen, but should be unusual.";
-    }
-    leaf out-ipv6-frag-not {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet was small enough to pass through unfragmented - this
-         should be the usual case.";
-    }
-    leaf out-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv6 packets.";
-    }
+    description "Counters for all configured interfaces.";
+    uses state-counters;
   }
 }

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -706,7 +706,7 @@ module snabb-softwire-v2 {
         type uint16;
         default 1460;
         description
-         "Maximm packet size to recieve on the IPv6 interface.";
+         "Maximum packet size to recieve on the IPv6 interface.";
       }
 
       uses traffic-filters;

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -544,7 +544,12 @@ module snabb-softwire-v2 {
 
       leaf device {
         type string;
-        description "PCI device name.";
+        description
+          "The PCI device the instance should use during lwAFTR operation. If
+           device is configured in on-a-stick mode, the 'external-interface'
+           device should not be configured. If the 'external-interface is
+           specified this option should specify the PCI device of the
+           'internal-interface' (IPv6 traffic only).";
       }
 
       list queue {
@@ -566,7 +571,9 @@ module snabb-softwire-v2 {
           }
           leaf device {
             description
-             "PCI device name";
+             "PCI device of the instance uses for external IPv6 traffic. If this
+              is left unspecified the lwAFTR configures itself in on-a-stick
+              mode.";
             type string;
           }
           leaf mac {
@@ -588,19 +595,19 @@ module snabb-softwire-v2 {
                   "IPv4 address of the next hop for the internet-facing NIC.
                     The lwAFTR will resolve this to a MAC address using ARP.";
                 }
-                leaf mac {
+                leaf resolved-mac {
                   config false;
-                  description "Resolved next-hop mac address found by ARP."
+                  description "Resolved next-hop mac address found by ARP.";
                   type yang:mac-address;
                 }
               }
               case mac {
                 leaf mac {
-                type yang:mac-address;
-                description
-                "Statically configured MAC address of the next hop for the
-                  internet-facing NIC.";
-              }
+                  type yang:mac-address;
+                  description
+                  "Statically configured MAC address of the next hop for the
+                    internet-facing NIC.";
+                }
               }
             }
           }
@@ -635,19 +642,19 @@ module snabb-softwire-v2 {
                   "IPv4 address of the next hop for the internet-facing NIC.
                     The lwAFTR will resolve this to a MAC address using ARP.";
                 }
-                leaf mac {
+                leaf resolved-mac {
                   config false;
-                  description "Resolved next-hop mac address found by ARP."
+                  description "Resolved next-hop mac address found by ARP.";
                   type yang:mac-address;
                 }
               }
               case mac {
                 leaf mac {
-                type yang:mac-address;
-                description
-                "Statically configured MAC address of the next hop for the
-                  internet-facing NIC.";
-              }
+                  type yang:mac-address;
+                  description
+                  "Statically configured MAC address of the next hop for the
+                    internet-facing NIC.";
+                }
               }
             }
           }
@@ -673,7 +680,7 @@ module snabb-softwire-v2 {
         type uint16;
         default 1460;
         description
-         "Maximm packet size to recieve on the IPv4 interface.";
+         "Maximum packet size to receive on the IPv4 interface.";
       }
 
       uses traffic-filters;
@@ -821,19 +828,20 @@ module snabb-softwire-v2 {
         }
       }
 
-      container binding-table-version {
+      container version {
         description
          "Optional versioning for binding table. The vesioning information
           will change on every update or change to the binding table.";
 
-        leaf binding-table-version{
+        leaf number {
           type uint64;
           description "Incremental version number.";
         }
-        leaf binding-table-date {
+        leaf date {
           type yang:date-and-time;
           description "Timestamp of last change.";
         }
+      }
     }
   }
 

--- a/src/program/lwaftr/doc/CHANGELOG.md
+++ b/src/program/lwaftr/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [3.2.0]
+
+* Added multiprocess support to snabb-softwire-v2 schema (not lwaftr itself).
+
 ## [3.1.8] - 2017-03-10
 
 * Retry ARP and NDP resolution indefinitely.

--- a/src/program/lwaftr/doc/CHANGELOG.md
+++ b/src/program/lwaftr/doc/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change Log
 
-## [3.2.0]
+## [2017.07.01]
 
 * Added multiprocess support to snabb-softwire-v2 schema (not lwaftr itself).
+
+* New version numbering which includes the Snabb version the lwaftr is based off
+  and a lwaftr specific version number which is reset upon merging a newer
+  version of Snabb from upstream.
 
 ## [3.1.8] - 2017-03-10
 

--- a/src/program/lwaftr/doc/benchmarking.md
+++ b/src/program/lwaftr/doc/benchmarking.md
@@ -10,12 +10,20 @@ example assumes NICs `02:00.0` and `02:00.1` and wired to NICs `02:00.0` and
 Please, change the PCI addresses to match the settings in your current system; 
 See [running.md](running.md).
 
+Make a configuration with the PCI devices we're using:
+
+```
+$ sudo ./src/snabb lwaftr migrate-configuration -f pci-device \
+    -o "from[device=test]" -o "internal[device=0000:02:00.0]" \
+    -o "external[device=0000:02:00.1]" \
+    src/program/lwaftr/tests/data/icmp_on_fail.conf >> /tmp/icmp_on_fail.conf
+````
+
 In one server, start the lwAFTR:
 
 ```
 $ sudo numactl -m 0 taskset -c 1 ./src/snabb lwaftr run -v \
-    --conf program/lwaftr/tests/data/icmp_on_fail.conf \
-    --v4 0000:02:00.0 --v6 0000:02:00.1
+    --conf /tmp/icmp_on_fail.conf
 ```
 
 See [performance.md](performance.md) for a discussion of `numactl`,

--- a/src/program/lwaftr/doc/benchmarking.md
+++ b/src/program/lwaftr/doc/benchmarking.md
@@ -10,20 +10,11 @@ example assumes NICs `02:00.0` and `02:00.1` and wired to NICs `02:00.0` and
 Please, change the PCI addresses to match the settings in your current system; 
 See [running.md](running.md).
 
-Make a configuration with the PCI devices we're using:
-
-```
-$ sudo ./src/snabb lwaftr migrate-configuration -f pci-device \
-    -o "from[device=test]" -o "internal[device=0000:02:00.0]" \
-    -o "external[device=0000:02:00.1]" \
-    src/program/lwaftr/tests/data/icmp_on_fail.conf >> /tmp/icmp_on_fail.conf
-````
-
 In one server, start the lwAFTR:
 
 ```
 $ sudo numactl -m 0 taskset -c 1 ./src/snabb lwaftr run -v \
-    --conf /tmp/icmp_on_fail.conf
+    --v4 0000:02:00.0 --v6 0000:02:00.1 --conf /tmp/icmp_on_fail.conf
 ```
 
 See [performance.md](performance.md) for a discussion of `numactl`,

--- a/src/program/lwaftr/doc/configuration.md
+++ b/src/program/lwaftr/doc/configuration.md
@@ -11,6 +11,32 @@ Here's an example:
 
 ```
 softwire-config {
+  instances {
+    device "00:05.0"
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        // vlan-tag 42;
+        next-hop {
+          mac 68:68:68:68:68:68;
+          ip 1.2.3.4;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        // vlan-tag 64;
+        next-hop {
+          mac 44:44:44:44:44:44;
+          // NDP instead of ARP of course.
+          ip 7:8:9:a:b:c:d:e;
+        }
+      }
+    }
+  }
+
   // IPv4 interface.
   external-interface {
     allow-incoming-icmp true;
@@ -22,16 +48,9 @@ softwire-config {
     // Generate ICMP errors at all?
     generate-icmp-errors true;
     // Basic parameters.
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 1460;
-    // vlan-tag 42;
     // Where to go next.  Either one will suffice; if you specify the IP,
     // the next-hop MAC will be determined by ARP.
-    next-hop {
-      mac 68:68:68:68:68:68;
-      ip 1.2.3.4;
-    }
     // Control the size of the fragment reassembly buffer.
     reassembly {
       max-fragments-per-packet 40;
@@ -50,15 +69,7 @@ softwire-config {
     // One more interesting thing -- here we control whether to support
     // routing traffic between two B4s.
     hairpinning true;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
     mtu 1500;
-    // vlan-tag 64;
-    next-hop {
-      mac 44:44:44:44:44:44;
-      // NDP instead of ARP of course.
-      ip 7:8:9:a:b:c:d:e;
-    }
     reassembly {
       max-fragments-per-packet 40;
       max-packets 20000;

--- a/src/program/lwaftr/doc/configuration.md
+++ b/src/program/lwaftr/doc/configuration.md
@@ -117,11 +117,21 @@ softwire-config {
 }
 ```
 
-Basically there's an `external-interface` section defining the
-parameters around the IPv4 interface that communicates with the
-internet, an `internal-interface` section doing the same for the IPv6
-side that communicates with the B4s, and then the `binding-table` that
-declares the set of softwires.  The whole thing is surrounded in a
+The lwaftr will soon be able to support multiple processes and thus there is a
+`instance` list which when it does will be populated with all the configuration
+options which are specific to a given instance. The rest of the configuration
+including the binding table will be shared with the other instances. Until the
+multiprocess support is available, there should only be one instance configured
+and the lwAFTR will simply use the one, and only instance specified in the
+`instance` list. Specifying more than one instance (or less than one) will
+result in an error.
+
+The `external-interface` define parameters around the IPv4 interface that
+communicates with the internet and the `internal-interface` section does the
+same but for the IPv6 side that communicates with the B4s. Anything that is in
+the `external-interface` or `internal-interface` blocks outside of the
+`instance` list are shared amongst all instances. The binding table then
+declares the set of softwires and the whole thing is surrounded in the
 `softwire-config { ... }` block.
 
 ## Compiling conigurations

--- a/src/program/lwaftr/doc/filters-performance.md
+++ b/src/program/lwaftr/doc/filters-performance.md
@@ -48,7 +48,7 @@ $ cat ~/bin/run-lwaftr
 BASEDIR=/home/kbarone/snabbswitch/src/
 CONF="`realpath $1`"
 cd ${BASEDIR} && sudo numactl -m 0 taskset -c 1 \
- ./snabb lwaftr run --conf ${CONF} --v4-pci 0000:02:00.0 --v6-pci 0000:02:00.1
+ ./snabb lwaftr run --conf ${CONF}
 ```
 
 ## Load generation

--- a/src/program/lwaftr/doc/filters-performance.md
+++ b/src/program/lwaftr/doc/filters-performance.md
@@ -48,7 +48,7 @@ $ cat ~/bin/run-lwaftr
 BASEDIR=/home/kbarone/snabbswitch/src/
 CONF="`realpath $1`"
 cd ${BASEDIR} && sudo numactl -m 0 taskset -c 1 \
- ./snabb lwaftr run --conf ${CONF}
+ ./snabb lwaftr run --conf ${CONF} --v4-pci 0000:02:00.0 --v6-pci 0000:02:00.1
 ```
 
 ## Load generation

--- a/src/program/lwaftr/doc/running.md
+++ b/src/program/lwaftr/doc/running.md
@@ -57,7 +57,7 @@ First, start the lwAFTR:
 
 ```
 $ sudo ./snabb lwaftr run \
-    --conf /tmp/icmp_on_fail.conf --v4 0000:01:00.1 --v6 0000:02:00.1
+    --conf program/lwaftr/tests/data/icmp_on_fail.conf --v4 0000:01:00.1 --v6 0000:02:00.1
 ```
 
 Then run a load generator:

--- a/src/program/lwaftr/doc/running.md
+++ b/src/program/lwaftr/doc/running.md
@@ -27,13 +27,46 @@ with the appropriate prefix (`0000:`, in this example).
 Note: Compile Snabb (see [build.md](build.md)) before attempting
 the following.
 
+## Creating a configuration to test with
+
+The PCI devices are specified in the configuration file. This means the PCI
+addresses of your NICs must be a part of your configuration file. If you're
+using the test data configs which come with the lwAFTR then you must make
+a copy and modify the configuration to include your PCI addresses. These config
+files use a `test` token in-place of the actual PCI device.
+
+This can be done one of two ways, simply editing the file by hand or you can
+use a one off migration provided as part of the
+`snabb lwaftr migrate-configuration` command. This takes in the old
+PCI device and the new one(s).
+
+This example converts the default `icmp_on_fail.conf` provided with the lwAFTR
+to a specific version with my PCI device specified. The following example
+assumes `0000:01:00.1` is my IPv4 internet facing NIC and `0000:02:00.1` is my
+IPv6 B4 facing NIC:
+
+```
+$ sudo ./src/snabb lwaftr migrate-configuration -f pci-device \
+    -o "from[device=test]" -o "internal[device=0000:02:00.0]" \
+    -o "external[device=0000:02:00.1]" \
+    src/program/lwaftr/tests/data/icmp_on_fail.conf >> /tmp/icmp_on_fail.conf
+```
+
+If you would like to remove or simply not supply a `external` device, for
+example when running on-a-stick mode simply omit the
+`-o "external[device=DEVICe]"` option. The new configuration is now stored in a
+file located at `/tmp/icmp_on_fail.conf`.
+
 ## Running a load generator and the lwaftr (2 lwaftr NICs)
 
 To run a load generator and an `lwaftr`, you will need four
 interfaces. The following example assumes that `01:00.0` is cabled to
 `01:00.1`, and that `02:00.0` is cabled to `02:00.1`. Change the
 concrete PCI devices specified to match the current system; See [Section
-1](Section 1. Finding out the PCI addresses of your NICs).
+1](Section 1. Finding out the PCI addresses of your NICs). Once you've
+found your PCI devices please refer to
+[Section 2](Section 2. Creating a configuration to test with) to produce the
+config.
 
 Note that unless the load generator and the lwaftr are running on the
 same NUMA nodes that their NICs are connected to, performance will be
@@ -43,9 +76,7 @@ terrible.  See [benchmarking.md](benchmarking.md) and
 First, start the lwAFTR:
 
 ```
-$ sudo ./snabb lwaftr run \
-    --conf program/lwaftr/tests/data/icmp_on_fail.conf \
-    --v4 0000:01:00.1 --v6 0000:02:00.1
+$ sudo ./snabb lwaftr run --conf /tmp/icmp_on_fail.conf
 ```
 
 Then run a load generator:
@@ -69,9 +100,7 @@ just one NIC, because traffic is not symmetric. To do this, use --on-a-stick,
 and specify only one PCI address:
 
 ```
-$ sudo ./snabb lwaftr run \
-    --conf program/lwaftr/tests/data/icmp_on_fail.conf \
-    --on-a-stick 0000:02:00.1
+$ sudo ./snabb lwaftr run --conf /tmp/icmp_on_fail.conf \
 ```
 
 You can run a load generator in on-a-stick mode:

--- a/src/program/lwaftr/doc/running.md
+++ b/src/program/lwaftr/doc/running.md
@@ -27,35 +27,15 @@ with the appropriate prefix (`0000:`, in this example).
 Note: Compile Snabb (see [build.md](build.md)) before attempting
 the following.
 
-## Creating a configuration to test with
+## PCI addresses and the configuration file
 
-The PCI devices are specified in the configuration file. This means the PCI
-addresses of your NICs must be a part of your configuration file. If you're
-using the test data configs which come with the lwAFTR then you must make
-a copy and modify the configuration to include your PCI addresses. These config
-files use a `test` token in-place of the actual PCI device.
-
-This can be done one of two ways, simply editing the file by hand or you can
-use a one off migration provided as part of the
-`snabb lwaftr migrate-configuration` command. This takes in the old
-PCI device and the new one(s).
-
-This example converts the default `icmp_on_fail.conf` provided with the lwAFTR
-to a specific version with my PCI device specified. The following example
-assumes `0000:01:00.1` is my IPv4 internet facing NIC and `0000:02:00.1` is my
-IPv6 B4 facing NIC:
-
-```
-$ sudo ./src/snabb lwaftr migrate-configuration -f pci-device \
-    -o "from[device=test]" -o "internal[device=0000:02:00.0]" \
-    -o "external[device=0000:02:00.1]" \
-    src/program/lwaftr/tests/data/icmp_on_fail.conf >> /tmp/icmp_on_fail.conf
-```
-
-If you would like to remove or simply not supply a `external` device, for
-example when running on-a-stick mode simply omit the
-`-o "external[device=DEVICe]"` option. The new configuration is now stored in a
-file located at `/tmp/icmp_on_fail.conf`.
+The PCI addresses of the NICs are specified in the configuration file (for more
+information see [configuration.md](configuration.md)). You can either specify
+them in the configuration file or if there is only a single instance specified
+you can specify them with `--v4` and `--v6` flags. These will perform a
+in-memory migration of the configuration, however leaving your configuration
+on-disk intact. If only one of the flags is specified then other option is
+left as is.
 
 ## Running a load generator and the lwaftr (2 lwaftr NICs)
 
@@ -65,7 +45,7 @@ interfaces. The following example assumes that `01:00.0` is cabled to
 concrete PCI devices specified to match the current system; See [Section
 1](Section 1. Finding out the PCI addresses of your NICs). Once you've
 found your PCI devices please refer to
-[Section 2](Section 2. Creating a configuration to test with) to produce the
+[Section 2](PCI addresses and the configuration file) to produce the
 config.
 
 Note that unless the load generator and the lwaftr are running on the
@@ -76,7 +56,8 @@ terrible.  See [benchmarking.md](benchmarking.md) and
 First, start the lwAFTR:
 
 ```
-$ sudo ./snabb lwaftr run --conf /tmp/icmp_on_fail.conf
+$ sudo ./snabb lwaftr run \
+    --conf /tmp/icmp_on_fail.conf --v4 0000:01:00.1 --v6 0000:02:00.1
 ```
 
 Then run a load generator:

--- a/src/program/lwaftr/doc/running.md
+++ b/src/program/lwaftr/doc/running.md
@@ -57,7 +57,8 @@ First, start the lwAFTR:
 
 ```
 $ sudo ./snabb lwaftr run \
-    --conf program/lwaftr/tests/data/icmp_on_fail.conf --v4 0000:01:00.1 --v6 0000:02:00.1
+    --conf program/lwaftr/tests/data/icmp_on_fail.conf \
+    --v4 0000:01:00.1 --v6 0000:02:00.1
 ```
 
 Then run a load generator:
@@ -82,6 +83,7 @@ and specify only one PCI address:
 
 ```
 $ sudo ./snabb lwaftr run --conf /tmp/icmp_on_fail.conf \
+    --on-a-stick 0000:02:00.1
 ```
 
 You can run a load generator in on-a-stick mode:

--- a/src/program/lwaftr/migrate_configuration/README
+++ b/src/program/lwaftr/migrate_configuration/README
@@ -22,7 +22,7 @@ configuration.  Available VERSION values are:
   3.2.0
     lwAFTR versions where "br" fields were indexes for the "br-address"
     leaf-list instead of "br-address" IPv6 entries on the softwire.
-  3.3.0
+  2017.07.01
     lwAFTR changes to multiprcoess configuration with the introduction of the
     instance list.
 

--- a/src/program/lwaftr/migrate_configuration/README
+++ b/src/program/lwaftr/migrate_configuration/README
@@ -3,6 +3,8 @@ Usage: migrate-configuration LWAFTR.CONF
 Options:
   -h, --help                 Print usage information.
   -f, --from=VERSION         Specify version from which to migrate.
+  -o, --option=option        Specify an option (additional data) for the
+                             migration.
 
 Migrate an old-style configuration and binding table to the new YANG
 configuration.  LWAFTR.CONF should be the name of an old lwAFTR
@@ -20,6 +22,29 @@ configuration.  Available VERSION values are:
   3.2.0
     lwAFTR versions where "br" fields were indexes for the "br-address"
     leaf-list instead of "br-address" IPv6 entries on the softwire.
+  3.3.0
+    lwAFTR changes to multiprcoess configuration with the introduction of the
+    instance list.
+
+  pci-device
+    This option is different from the other options in that it does not migrate
+    the configuration from a specific version to a newer one but it migrates the
+    configuration from one device configuration to another.
+
+    This allows you to feed in a configuration file and modify the device of a
+    instance block and/or add/modify the external IPv6 device too.
+
+    This VERSION option takes two required additional options:
+      - "from[device=DEVICE]" the current internal IPv4 PCI device listed.
+      - "internal[device=DEVICE]" the internal IPv4 PCI device
+
+    and one optional argument:
+      - "external[device=DEVICE]" the external IPv4 PCI device
+
+    DEVICE should be replaced with the PCI device. The from device must exist or
+    an error will occur.
+
+    This option is only compatible with the latest configuration version.
 
 The default version is "legacy".
 

--- a/src/program/lwaftr/migrate_configuration/README
+++ b/src/program/lwaftr/migrate_configuration/README
@@ -26,26 +26,6 @@ configuration.  Available VERSION values are:
     lwAFTR changes to multiprcoess configuration with the introduction of the
     instance list.
 
-  pci-device
-    This option is different from the other options in that it does not migrate
-    the configuration from a specific version to a newer one but it migrates the
-    configuration from one device configuration to another.
-
-    This allows you to feed in a configuration file and modify the device of a
-    instance block and/or add/modify the external IPv6 device too.
-
-    This VERSION option takes two required additional options:
-      - "from[device=DEVICE]" the current internal IPv4 PCI device listed.
-      - "internal[device=DEVICE]" the internal IPv4 PCI device
-
-    and one optional argument:
-      - "external[device=DEVICE]" the external IPv4 PCI device
-
-    DEVICE should be replaced with the PCI device. The from device must exist or
-    an error will occur.
-
-    This option is only compatible with the latest configuration version.
-
 The default version is "legacy".
 
 The resulting up-to-date configuration will be printed on standard

--- a/src/program/lwaftr/migrate_configuration/migrate_configuration.lua
+++ b/src/program/lwaftr/migrate_configuration/migrate_configuration.lua
@@ -594,7 +594,7 @@ local function migrate_3_2_0(conf_file, options)
    return multiprocess_migration(v2_migration(src, conf_file), options)
 end
 
-local function migrate_3_3_0(conf_file, options)
+local function migrate_2017_07_01(conf_file, options)
    local src = io.open(conf_file, "r"):read("*a")
    return multiprocess_migration(src, conf_file, options)
 end
@@ -627,7 +627,7 @@ end
 local migrators = { legacy = migrate_legacy, ['3.0.1'] = migrate_3_0_1,
                     ['3.0.1.1'] = migrate_3_0_1bis,
                     ['3.2.0'] = migrate_3_2_0,
-                    ["3.3.0"] = migrate_3_3_0,
+                    ["2017.07.01"] = migrate_2017_07_01,
                     ["pci-device"] = map_pci_device,}
 function run(args)
    local conf_file, version, options = parse_args(args)

--- a/src/program/lwaftr/migrate_configuration/migrate_configuration.lua
+++ b/src/program/lwaftr/migrate_configuration/migrate_configuration.lua
@@ -599,36 +599,12 @@ local function migrate_2017_07_01(conf_file, options)
    return multiprocess_migration(src, conf_file, options)
 end
 
--- This will take a configuration file with options and map one device to
--- another. One useful use case of this is producing tests specific to the
--- server.
-local function map_pci_device(conf_file, options)
-   -- Validate options and load configuration
-   local old = assert(find_option(options, "from", "device"),
-                     "Must specify device to map from.")
-   local new = assert(find_option(options, "internal", "device"),
-                      "Must specify a internal (ipv6) device to map to.")
-   local src = io.open(conf_file, "r"):read("*a")
-   local config = yang.load_data_for_schema_by_name(
-                     "snabb-softwire-v2", src, conf_file)
-
-   -- Migrate configuration
-   assert(config.softwire_config.instance[old], "Device '"..old.."' missing")
-   config.softwire_config.instance[new] = config.softwire_config.instance[old]
-   config.softwire_config.instance[old] = nil
-   local external = find_option(options, "external", "device")
-   if external ~= nil then
-      local queue = config.softwire_config.instance[new].queue.values[1]
-      queue.external_interface.device = external
-   end
-   return config
-end
 
 local migrators = { legacy = migrate_legacy, ['3.0.1'] = migrate_3_0_1,
                     ['3.0.1.1'] = migrate_3_0_1bis,
                     ['3.2.0'] = migrate_3_2_0,
-                    ["2017.07.01"] = migrate_2017_07_01,
-                    ["pci-device"] = map_pci_device,}
+                    ["2017.07.01"] = migrate_2017_07_01,}
+
 function run(args)
    local conf_file, version, options = parse_args(args)
    local migrate = migrators[version]

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -16,6 +16,34 @@ local function show_usage(exit_code)
    print(require("program.lwaftr.run.README_inc"))
    if exit_code then main.exit(exit_code) end
 end
+local function migrate_device_on_config(config, v4, v6)
+   -- Validate there is only one instance, otherwise the option is ambiguous.
+   local device, instance
+   for pci_addr, inst in pairs(config.softwire_config.instance) do
+      assert(device == nil, "Unable to migrate config to '"..pci_addr.."' as"..
+                             "there are multiple instances configured.")
+      device, instance = pci_addr, inst
+   end
+
+   local migrated = config
+   migrated.softwire_config.instance = lib.deepcopy(
+      migrated.softwire_config.instance
+   )
+   local instances = migrated.softwire_config.instance
+
+   if v4 and v4 ~= device then
+      print("Migrating instance '"..device.."' to '"..v4.."'")
+      instances[v4] = instances[device]
+      instances[device] = nil
+   end
+
+   if v6 then
+      local device, instance = next(instances)
+      instance.queue.values[1].external_interface.device = v6
+   end
+
+   return migrated
+end
 
 function parse_args(args)
    if #args == 0 then show_usage(1) end
@@ -60,6 +88,8 @@ function parse_args(args)
    handlers["mirror"] = function (ifname)
       opts["mirror"] = ifname
    end
+   function handlers.v4(arg) v4 = arg end
+   function handlers.v6(arg) v6 = arg end
    function handlers.y() opts.hydra = true end
    function handlers.b(arg) opts.bench_file = arg end
    handlers["ingress-drop-monitor"] = function (arg)
@@ -75,10 +105,11 @@ function parse_args(args)
    function handlers.reconfigurable() opts.reconfigurable = true end
    function handlers.h() show_usage(0) end
    lib.dogetopt(args, handlers, "b:c:vD:yhir:n:",
-      { conf = "c", verbose = "v", duration = "D", help = "h", virtio = "i",
-        cpu = 1, ["ring-buffer-size"] = "r", ["real-time"] = 0,
-        ["bench-file"] = "b", ["ingress-drop-monitor"] = 1, ["on-a-stick"] = 1,
-        mirror = 1, hydra = "y", reconfigurable = 0, name="n" })
+   { conf = "c", v4 = 1, v6 = 1, ["v4-pci"] = 1, ["v6-pci"] = 1,
+     verbose = "v", duration = "D", help = "h", virtio = "i", cpu = 1,
+     ["ring-buffer-size"] = "r", ["real-time"] = 0, ["bench-file"] = "b",
+     ["ingress-drop-monitor"] = 1, ["on-a-stick"] = 1, mirror = 1,
+     hydra = "y", reconfigurable = 0, name="n" })
    if ring_buffer_size ~= nil then
       if opts.virtio_net then
          fatal("setting --ring-buffer-size does not work with --virtio")
@@ -93,8 +124,6 @@ function parse_args(args)
       scheduling.pci_addrs = { v4 }
       return opts, scheduling, conf_file, v4
    else
-      if not v4 then fatal("Missing required --v4 argument.") end
-      if not v6 then fatal("Missing required --v6 argument.") end
       scheduling.pci_addrs = { v4, v6 }
       return opts, scheduling, conf_file, v4, v6
    end
@@ -112,8 +141,16 @@ local function requires_splitter (opts, conf)
 end
 
 function run(args)
-   local opts, scheduling, conf_file = parse_args(args)
+   local opts, scheduling, conf_file, v4, v6 = parse_args(args)
    local conf = require('apps.lwaftr.conf').load_lwaftr_config(conf_file)
+
+   -- If there are v4 or v6 options we need to migrate the configuration in
+   -- memory from the PCI device specified, later we'll want to support
+   -- selecting multiple devices, this is where you will do it.
+   if v4 or v6 then
+      conf = migrate_device_on_config(conf, v4, v6)
+   end
+
    local use_splitter = requires_splitter(opts, conf)
 
    -- If there is a name defined on the command line, it should override

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -105,7 +105,7 @@ function parse_args(args)
    function handlers.reconfigurable() opts.reconfigurable = true end
    function handlers.h() show_usage(0) end
    lib.dogetopt(args, handlers, "b:c:vD:yhir:n:",
-   { conf = "c", v4 = 1, v6 = 1, ["v4-pci"] = 1, ["v6-pci"] = 1,
+     { conf = "c", v4 = 1, v6 = 1, ["v4-pci"] = 1, ["v6-pci"] = 1,
      verbose = "v", duration = "D", help = "h", virtio = "i", cpu = 1,
      ["ring-buffer-size"] = "r", ["real-time"] = 0, ["bench-file"] = "b",
      ["ingress-drop-monitor"] = 1, ["on-a-stick"] = 1, mirror = 1,

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -47,26 +47,6 @@ function parse_args(args)
    handlers['real-time'] = function(arg)
       scheduling.real_time = true
    end
-   function handlers.v4(arg)
-      v4 = arg
-      if not nic_exists(v4) then
-         fatal(("Couldn't locate NIC with PCI address '%s'"):format(v4))
-      end
-   end
-   handlers["v4-pci"] = function(arg)
-      print("WARNING: Deprecated argument '--v4-pci'. Use '--v4' instead.")
-      handlers.v4(arg)
-   end
-   function handlers.v6(arg)
-      v6 = arg
-      if not nic_exists(v6) then
-         fatal(("Couldn't locate NIC with PCI address '%s'"):format(v6))
-      end
-   end
-   handlers["v6-pci"] = function(arg)
-      print("WARNING: Deprecated argument '--v6-pci'. Use '--v6' instead.")
-      handlers.v6(arg)
-   end
    function handlers.r (arg)
       ring_buffer_size = tonumber(arg)
    end
@@ -95,11 +75,10 @@ function parse_args(args)
    function handlers.reconfigurable() opts.reconfigurable = true end
    function handlers.h() show_usage(0) end
    lib.dogetopt(args, handlers, "b:c:vD:yhir:n:",
-      { conf = "c", v4 = 1, v6 = 1, ["v4-pci"] = 1, ["v6-pci"] = 1,
-        verbose = "v", duration = "D", help = "h", virtio = "i", cpu = 1,
-        ["ring-buffer-size"] = "r", ["real-time"] = 0, ["bench-file"] = "b",
-        ["ingress-drop-monitor"] = 1, ["on-a-stick"] = 1, mirror = 1,
-        hydra = "y", reconfigurable = 0, name="n" })
+      { conf = "c", verbose = "v", duration = "D", help = "h", virtio = "i",
+        cpu = 1, ["ring-buffer-size"] = "r", ["real-time"] = 0,
+        ["bench-file"] = "b", ["ingress-drop-monitor"] = 1, ["on-a-stick"] = 1,
+        mirror = 1, hydra = "y", reconfigurable = 0, name="n" })
    if ring_buffer_size ~= nil then
       if opts.virtio_net then
          fatal("setting --ring-buffer-size does not work with --virtio")
@@ -133,7 +112,7 @@ local function requires_splitter (opts, conf)
 end
 
 function run(args)
-   local opts, scheduling, conf_file, v4, v6 = parse_args(args)
+   local opts, scheduling, conf_file = parse_args(args)
    local conf = require('apps.lwaftr.conf').load_lwaftr_config(conf_file)
    local use_splitter = requires_splitter(opts, conf)
 
@@ -146,15 +125,14 @@ function run(args)
    local c = config.new()
    local setup_fn, setup_args
    if opts.virtio_net then
-      setup_fn, setup_args = setup.load_virt, { 'inetNic', v4, 'b4sideNic', v6 }
+      setup_fn, setup_args = setup.load_virt, { 'inetNic', 'b4sideNic' }
    elseif opts["on-a-stick"] then
       setup_fn = setup.load_on_a_stick
       setup_args =
          { { v4_nic_name = 'inetNic', v6_nic_name = 'b4sideNic',
-             v4v6 = use_splitter and 'v4v6', pciaddr = v4,
-             mirror = opts.mirror } }
+             v4v6 = use_splitter and 'v4v6', mirror = opts.mirror } }
    else
-      setup_fn, setup_args = setup.load_phy, { 'inetNic', v4, 'b4sideNic', v6 }
+      setup_fn, setup_args = setup.load_phy, { 'inetNic', 'b4sideNic' }
    end
 
    if opts.reconfigurable then

--- a/src/program/lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/lwaftr/run_nohw/run_nohw.lua
@@ -62,9 +62,12 @@ function run(parameters)
    local conf_file, b4_if, inet_if, opts = parse_args(parameters)
    local conf = require('apps.lwaftr.conf').load_lwaftr_config(conf_file)
    local c = config.new()
+   local lwaftr_class =  LwAftr
+   lwaftr_class.config_arg = "conf"
+   local device = next(assert(conf.softwire_config.instance))
 
    -- AFTR
-   config.app(c, "aftr", LwAftr, conf)
+   config.app(c, "aftr", lwaftr_class, {conf=conf, device=device})
 
    -- B4 side interface
    config.app(c, "b4if", RawSocket, b4_if)

--- a/src/program/lwaftr/run_nohw/run_nohw.lua
+++ b/src/program/lwaftr/run_nohw/run_nohw.lua
@@ -62,12 +62,10 @@ function run(parameters)
    local conf_file, b4_if, inet_if, opts = parse_args(parameters)
    local conf = require('apps.lwaftr.conf').load_lwaftr_config(conf_file)
    local c = config.new()
-   local lwaftr_class =  LwAftr
-   lwaftr_class.config_arg = "conf"
    local device = next(assert(conf.softwire_config.instance))
 
    -- AFTR
-   config.app(c, "aftr", lwaftr_class, {conf=conf, device=device})
+   config.app(c, "aftr", LwAftr, conf)
 
    -- B4 side interface
    config.app(c, "b4if", RawSocket, b4_if)

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -25,6 +25,8 @@ local ethernet   = require("lib.protocol.ethernet")
 local ipv4_ntop  = require("lib.yang.util").ipv4_ntop
 local S          = require("syscall")
 local engine     = require("core.app")
+local lib        = require("core.lib")
+
 
 local capabilities = {['ietf-softwire']={feature={'binding', 'br'}}}
 require('lib.yang.schema').set_default_capabilities(capabilities)

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -262,7 +262,7 @@ function load_on_a_stick(c, conf, args)
    end
 end
 
-function load_virt(c, conf, v4_nic_name, v4_nic_pci, v6_nic_name, v6_nic_pci)
+function load_virt(c, conf, v4_nic_name, v6_nic_name)
    local v4_pci, v6_pci = lwaftr_app(c, conf)
    config.app(c, v4_nic_name, VirtioNet, {
       pciaddr=v4_pci,

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -222,7 +222,7 @@ end
 function load_phy(c, conf, v4_nic_name, v6_nic_name)
    local inst_configs = lwutil.produce_instance_configs(conf)
    local v4_pci, lwaftr_config = next(inst_configs)
-   local queue = lwaftr_config.softwire_config.instance.test.queue.values[1]
+   local queue = lwaftr_config.softwire_config.instance[v4_pci].queue.values[1]
    local v6_pci = queue.external_interface.device
    validate_pci_devices({v4_pci, v6_pci})
    lwaftr_app(c, lwaftr_config, v4_pci)
@@ -232,13 +232,13 @@ function load_phy(c, conf, v4_nic_name, v6_nic_name)
       vmdq=queue.external_interface.vlan_tag,
       vlan=queue.external_interface.vlan_tag,
       rxcounter=1,
-      macaddr=ethernet:ntop(external_if.mac)})
+      macaddr=ethernet:ntop(queue.external_interface.mac)})
    config.app(c, v6_nic_name, Intel82599, {
       pciaddr=v6_pci,
       vmdq=queue.internal_interface.vlan_tag,
       vlan=queue.internal_interface.vlan_tag,
       rxcounter=1,
-      macaddr = ethernet:ntop(internal_if.mac)})
+      macaddr = ethernet:ntop(queue.internal_interface.mac)})
 
    link_source(c, v4_nic_name..'.tx', v6_nic_name..'.tx')
    link_sink(c, v4_nic_name..'.rx', v6_nic_name..'.rx')
@@ -295,19 +295,19 @@ end
 function load_virt(c, conf, v4_nic_name, v6_nic_name)
    local inst_configs = lwutil.produce_instance_configs(conf)
    local v4_pci, lwaftr_config = next(inst_configs)
-   local queue = lwaftr_config.softwire_config.instance.test.queue.values[1]
+   local queue = lwaftr_config.softwire_config.instance[v4_pci].queue.values[1]
    local v6_pci = queue.external_device.device
    lwaftr_app(c, lwaftr_config, device)
 
    validate_pci_devices({v4_pci, v6_pci})
    config.app(c, v4_nic_name, VirtioNet, {
       pciaddr=v4_pci,
-      vlan=external_if.vlan_tag,
-      macaddr=ethernet:ntop(external_if.mac)})
+      vlan=queue.external_interface.vlan_tag,
+      macaddr=ethernet:ntop(queue.external_interface.mac)})
    config.app(c, v6_nic_name, VirtioNet, {
       pciaddr=v6_pci,
-      vlan=internal_if.vlan_tag,
-      macaddr = ethernet:ntop(internal_if.mac)})
+      vlan=queue.internal_interface.vlan_tag,
+      macaddr = ethernet:ntop(queue.internal_interface.mac)})
 
    link_source(c, v4_nic_name..'.tx', v6_nic_name..'.tx')
    link_sink(c, v4_nic_name..'.rx', v6_nic_name..'.rx')
@@ -316,7 +316,7 @@ end
 function load_bench(c, conf, v4_pcap, v6_pcap, v4_sink, v6_sink)
    local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
-   local queue = lwaftr_config.softwire_config.instance.test.queue.values[1]
+   local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
    lwaftr_app(c, lwaftr_config, device)
 
    config.app(c, "capturev4", pcap.PcapReader, v4_pcap)
@@ -353,7 +353,7 @@ end
 function load_check_on_a_stick (c, conf, inv4_pcap, inv6_pcap, outv4_pcap, outv6_pcap)
    local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
-   local queue = lwaftr_config.softwire_config.instance.test.queue.values[1]
+   local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
    lwaftr_app(c, lwaftr_config, device)
 
    config.app(c, "capturev4", pcap.PcapReader, inv4_pcap)
@@ -407,7 +407,7 @@ end
 function load_check(c, conf, inv4_pcap, inv6_pcap, outv4_pcap, outv6_pcap)
    local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
-   local queue = lwaftr_config.softwire_config.instance.test.queue.values[1]
+   local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
    lwaftr_app(c, lwaftr_config, device)
 
    config.app(c, "capturev4", pcap.PcapReader, inv4_pcap)
@@ -447,7 +447,7 @@ end
 function load_soak_test(c, conf, inv4_pcap, inv6_pcap)
    local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
-   local queue = lwaftr_config.softwire_config.instance.test.queue.values[1]
+   local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
    lwaftr_app(c, lwaftr_config, device)
 
    config.app(c, "capturev4", pcap.PcapReader, inv4_pcap)
@@ -491,7 +491,7 @@ end
 function load_soak_test_on_a_stick (c, conf, inv4_pcap, inv6_pcap)
    local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
-   local queue = lwaftr_config.softwire_config.instance.test.queue.values[1]
+   local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
    lwaftr_app(c, lwaftr_config, device)
 
    config.app(c, "capturev4", pcap.PcapReader, inv4_pcap)

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -56,7 +56,7 @@ function lwaftr_app(c, conf)
    local function prepend(t, elem) table.insert(t, 1, elem) end
 
    -- If this is modified, please remember to modify the config_arg below.
-   lwaftr_class = lwaftr.LwAftr
+   local lwaftr_class = lwaftr.LwAftr
    lwaftr_class.config_arg = "conf"
 
    -- Claim the name if one is defined.
@@ -320,15 +320,15 @@ function load_check_on_a_stick (c, conf, inv4_pcap, inv6_pcap, outv4_pcap, outv6
    config.app(c, "output_filev6", pcap.PcapWriter, outv6_pcap)
    if conf.softwire_config.external_interface.vlan_tag then
       config.app(c, "untagv4", vlan.Untagger,
-                 { tag=external_interface.vlan_tag })
+                 { tag=conf.softwire_config.external_interface.vlan_tag })
       config.app(c, "tagv4", vlan.Tagger,
-                 { tag=external_interface.vlan_tag })
+                 { tag=conf.softwire_config.external_interface.vlan_tag })
    end
    if conf.softwire_config.internal_interface.vlan_tag then
       config.app(c, "untagv6", vlan.Untagger,
-                 { tag=internal_interface.vlan_tag })
+                 { tag=conf.softwire_config.internal_interface.vlan_tag })
       config.app(c, "tagv6", vlan.Tagger,
-                 { tag=internal_interface.vlan_tag })
+                 { tag=conf.softwire_config.internal_interface.vlan_tag })
    end
 
    config.app(c, 'v4v6', V4V6)
@@ -338,7 +338,7 @@ function load_check_on_a_stick (c, conf, inv4_pcap, inv6_pcap, outv4_pcap, outv6
    local sources = { "v4v6.v4", "v4v6.v6" }
    local sinks = { "v4v6.v4", "v4v6.v6" }
 
-   if external_interface.vlan_tag then
+   if conf.softwire_config.external_interface.vlan_tag then
       config.link(c, "capturev4.output -> untagv4.input")
       config.link(c, "capturev6.output -> untagv6.input")
       config.link(c, "untagv4.output -> join.in1")
@@ -369,11 +369,11 @@ function load_check(c, conf, inv4_pcap, inv6_pcap, outv4_pcap, outv6_pcap)
    config.app(c, "capturev6", pcap.PcapReader, inv6_pcap)
    config.app(c, "output_filev4", pcap.PcapWriter, outv4_pcap)
    config.app(c, "output_filev6", pcap.PcapWriter, outv6_pcap)
-   if external_interface.vlan_tag then
+   if conf.softwire_config.external_interface.vlan_tag then
       config.app(c, "untagv4", vlan.Untagger,
-                 { tag=external_interface.vlan_tag })
+                 { tag=conf.softwire_config.external_interface.vlan_tag })
       config.app(c, "tagv4", vlan.Tagger,
-                 { tag=external_interface.vlan_tag })
+                 { tag=conf.softwire_config.external_interface.vlan_tag })
    end
    if conf.softwire_config.internal_interface.vlan_tag then
       config.app(c, "untagv6", vlan.Untagger,
@@ -385,7 +385,7 @@ function load_check(c, conf, inv4_pcap, inv6_pcap, outv4_pcap, outv6_pcap)
    local sources = { "capturev4.output", "capturev6.output" }
    local sinks = { "output_filev4.input", "output_filev6.input" }
 
-   if external_interface.vlan_tag then
+   if conf.softwire_config.external_interface.vlan_tag then
       sources = { "untagv4.output", "untagv6.output" }
       sinks = { "tagv4.input", "tagv6.input" }
 

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -37,13 +37,11 @@ end
 
 -- Checks the existance and NUMA affinity of PCI devices
 -- NB: "nil" can be passed in and will be siliently ignored.
-local function validate_pci_devices(...)
-   for device in pairs(...) do
-      if device then
-         assert(lwutil.nic_exists(address),
-                ("Could not locate PCI device '%s'"):format(address))
-         numa.check_affinity_for_pci_addresses(address)
-      end
+local function validate_pci_devices(devices)
+   for _, address in pairs(devices) do
+      assert(lwutil.nic_exists(address),
+             ("Could not locate PCI device '%s'"):format(address))
+      numa.check_affinity_for_pci_addresses(address)
    end
 end
 
@@ -226,7 +224,7 @@ function load_phy(c, conf, v4_nic_name, v6_nic_name)
    local v4_pci, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance.test.queue.values[1]
    local v6_pci = queue.external_interface.device
-   validate_pci_devices(v4_pci, v6_pci)
+   validate_pci_devices({v4_pci, v6_pci})
    lwaftr_app(c, lwaftr_config, v4_pci)
 
    config.app(c, v4_nic_name, Intel82599, {
@@ -250,7 +248,7 @@ function load_on_a_stick(c, conf, args)
    local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance.test.queue.values[1]
-   validate_pci_devices(pciaddr)
+   validate_pci_devices({pciaddr})
    lwaftr_app(c, lwaftr_config, device)
    local v4_nic_name, v6_nic_name, v4v6, mirror = args.v4_nic_name,
       args.v6_nic_name, args.v4v6, args.mirror
@@ -301,7 +299,7 @@ function load_virt(c, conf, v4_nic_name, v6_nic_name)
    local v6_pci = queue.external_device.device
    lwaftr_app(c, lwaftr_config, device)
 
-   validate_pci_devices(v4_pci, v6_pci)
+   validate_pci_devices({v4_pci, v6_pci})
    config.app(c, v4_nic_name, VirtioNet, {
       pciaddr=v4_pci,
       vlan=external_if.vlan_tag,

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -246,10 +246,10 @@ end
 
 function load_on_a_stick(c, conf, args)
    local inst_configs = lwutil.produce_instance_configs(conf)
-   local device, lwaftr_config = next(inst_configs)
-   local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
+   local pciaddr, lwaftr_config = next(inst_configs)
+   local queue = lwaftr_config.softwire_config.instance[pciaddr].queue.values[1]
    validate_pci_devices({pciaddr})
-   lwaftr_app(c, lwaftr_config, device)
+   lwaftr_app(c, lwaftr_config, pciaddr)
    local v4_nic_name, v6_nic_name, v4v6, mirror = args.v4_nic_name,
       args.v6_nic_name, args.v4v6, args.mirror
 

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -45,19 +45,6 @@ local function validate_pci_devices(devices)
    end
 end
 
--- Produces configuration for each instance.
--- Provided a multi-process configuration it will iterate over each instance
--- and produce a configuration for each device with a single instance in. This
--- is then able to be provided to the lwaftr app.
-local function produce_instance_configs(conf)
-   local ret = {}
-   for device, queues in pairs(conf.softwire_config.instance) do
-      ret[device] = lib.deepcopy(conf)
-      ret[device].softwire_config.instance = {[device]=queues}
-   end
-   return ret
-end
-
 -- Temporary function to validate that there is only a single instance.
 -- In the future this should be remove in favour of simply configuring
 -- multiple instqances when specified.
@@ -233,7 +220,7 @@ local function link_sink(c, v4_out, v6_out)
 end
 
 function load_phy(c, conf, v4_nic_name, v6_nic_name)
-   local inst_configs = produce_instance_configs(conf)
+   local inst_configs = lwutil.produce_instance_configs(conf)
    local v4_pci, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance[v4_pci].queue.values[1]
    local v6_pci = queue.external_interface.device
@@ -258,7 +245,7 @@ function load_phy(c, conf, v4_nic_name, v6_nic_name)
 end
 
 function load_on_a_stick(c, conf, args)
-   local inst_configs = produce_instance_configs(conf)
+   local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
    validate_pci_devices({pciaddr})
@@ -306,7 +293,7 @@ function load_on_a_stick(c, conf, args)
 end
 
 function load_virt(c, conf, v4_nic_name, v6_nic_name)
-   local inst_configs = produce_instance_configs(conf)
+   local inst_configs = lwutil.produce_instance_configs(conf)
    local v4_pci, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance[v4_pci].queue.values[1]
    local v6_pci = queue.external_device.device
@@ -327,7 +314,7 @@ function load_virt(c, conf, v4_nic_name, v6_nic_name)
 end
 
 function load_bench(c, conf, v4_pcap, v6_pcap, v4_sink, v6_sink)
-   local inst_configs = produce_instance_configs(conf)
+   local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
    lwaftr_app(c, lwaftr_config, device)
@@ -364,7 +351,7 @@ function load_bench(c, conf, v4_pcap, v6_pcap, v4_sink, v6_sink)
 end
 
 function load_check_on_a_stick (c, conf, inv4_pcap, inv6_pcap, outv4_pcap, outv6_pcap)
-   local inst_configs = produce_instance_configs(conf)
+   local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
    lwaftr_app(c, lwaftr_config, device)
@@ -418,7 +405,7 @@ function load_check_on_a_stick (c, conf, inv4_pcap, inv6_pcap, outv4_pcap, outv6
 end
 
 function load_check(c, conf, inv4_pcap, inv6_pcap, outv4_pcap, outv6_pcap)
-   local inst_configs = produce_instance_configs(conf)
+   local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
    lwaftr_app(c, lwaftr_config, device)
@@ -458,7 +445,7 @@ function load_check(c, conf, inv4_pcap, inv6_pcap, outv4_pcap, outv6_pcap)
 end
 
 function load_soak_test(c, conf, inv4_pcap, inv6_pcap)
-   local inst_configs = produce_instance_configs(conf)
+   local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
    lwaftr_app(c, lwaftr_config, device)
@@ -502,7 +489,7 @@ function load_soak_test(c, conf, inv4_pcap, inv6_pcap)
 end
 
 function load_soak_test_on_a_stick (c, conf, inv4_pcap, inv6_pcap)
-   local inst_configs = produce_instance_configs(conf)
+   local inst_configs = lwutil.produce_instance_configs(conf)
    local device, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
    lwaftr_app(c, lwaftr_config, device)

--- a/src/program/lwaftr/tests/data/big_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/big_mtu_no_icmp.conf
@@ -115,14 +115,29 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 1960;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
@@ -131,12 +146,7 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
     mtu 2000;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }

--- a/src/program/lwaftr/tests/data/big_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/big_mtu_no_icmp.conf
@@ -121,7 +121,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/icmp_endaddr.conf
+++ b/src/program/lwaftr/tests/data/icmp_endaddr.conf
@@ -48,7 +48,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/icmp_endaddr.conf
+++ b/src/program/lwaftr/tests/data/icmp_endaddr.conf
@@ -42,14 +42,29 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 2000;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
@@ -57,12 +72,7 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
     mtu 2000;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }

--- a/src/program/lwaftr/tests/data/icmp_on_fail.conf
+++ b/src/program/lwaftr/tests/data/icmp_on_fail.conf
@@ -119,7 +119,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/icmp_on_fail.conf
+++ b/src/program/lwaftr/tests/data/icmp_on_fail.conf
@@ -114,24 +114,34 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
     allow-incoming-icmp false;
     error-rate-limiting {
       packets 600000;
-    }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
     }
     reassembly {
       max-fragments-per-packet 40;

--- a/src/program/lwaftr/tests/data/lwaftr-vlan.conf
+++ b/src/program/lwaftr/tests/data/lwaftr-vlan.conf
@@ -21,7 +21,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/lwaftr-vlan.conf
+++ b/src/program/lwaftr/tests/data/lwaftr-vlan.conf
@@ -16,15 +16,31 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.0.1.1;
-    mac 02:aa:aa:aa:aa:aa;
-    next-hop {
-      mac 02:99:99:99:99:99;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 164;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.0.1.1;
+        mac 02:aa:aa:aa:aa:aa;
+        next-hop {
+          mac 02:99:99:99:99:99;
+        }
+        vlan-tag 164;
+      }
+      internal-interface {
+        ip fe80::100;
+        mac 02:aa:aa:aa:aa:aa;
+        next-hop {
+          mac 02:99:99:99:99:99;
+        }
+        vlan-tag 125;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
@@ -32,15 +48,9 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip fe80::100;
-    mac 02:aa:aa:aa:aa:aa;
     mtu 9500;
-    next-hop {
-      mac 02:99:99:99:99:99;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 125;
   }
 }

--- a/src/program/lwaftr/tests/data/no_hairpin.conf
+++ b/src/program/lwaftr/tests/data/no_hairpin.conf
@@ -120,7 +120,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/no_hairpin.conf
+++ b/src/program/lwaftr/tests/data/no_hairpin.conf
@@ -115,13 +115,28 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
@@ -131,11 +146,6 @@ softwire-config {
     }
     generate-icmp-errors false;
     hairpinning false;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }

--- a/src/program/lwaftr/tests/data/no_icmp.conf
+++ b/src/program/lwaftr/tests/data/no_icmp.conf
@@ -115,13 +115,28 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
@@ -130,11 +145,6 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }

--- a/src/program/lwaftr/tests/data/no_icmp.conf
+++ b/src/program/lwaftr/tests/data/no_icmp.conf
@@ -120,7 +120,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/no_icmp_maxfrags1.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_maxfrags1.conf
@@ -115,13 +115,28 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 1;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
@@ -130,11 +145,6 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 1;
       max-packets 10;

--- a/src/program/lwaftr/tests/data/no_icmp_maxfrags1.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_maxfrags1.conf
@@ -120,7 +120,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_accept.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_accept.conf
@@ -122,7 +122,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_accept.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_accept.conf
@@ -117,13 +117,28 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter ip;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
@@ -134,11 +149,6 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter ip6;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_accept.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_accept.conf
@@ -117,15 +117,31 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter ip;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
@@ -135,14 +151,8 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter ip6;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_accept.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_accept.conf
@@ -122,7 +122,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_drop.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_drop.conf
@@ -117,15 +117,31 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter "len < 0";
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
@@ -135,14 +151,8 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter "len < 0";
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_drop.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_and_vlan_drop.conf
@@ -122,7 +122,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_drop.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_drop.conf
@@ -117,13 +117,28 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter "len < 0";
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
@@ -134,11 +149,6 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter "len < 0";
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }

--- a/src/program/lwaftr/tests/data/no_icmp_with_filters_drop.conf
+++ b/src/program/lwaftr/tests/data/no_icmp_with_filters_drop.conf
@@ -122,7 +122,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/small_ipv4_mtu_icmp.conf
+++ b/src/program/lwaftr/tests/data/small_ipv4_mtu_icmp.conf
@@ -113,24 +113,34 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 576;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
-    }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
     }
     reassembly {
       max-fragments-per-packet 40;

--- a/src/program/lwaftr/tests/data/small_ipv4_mtu_icmp.conf
+++ b/src/program/lwaftr/tests/data/small_ipv4_mtu_icmp.conf
@@ -119,7 +119,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp.conf
@@ -115,14 +115,29 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 1500;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
@@ -131,12 +146,7 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
     mtu 1280;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp.conf
@@ -121,7 +121,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_allow.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_allow.conf
@@ -119,7 +119,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_allow.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_allow.conf
@@ -113,26 +113,36 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 1500;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
     mtu 1280;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_vlan_allow.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_vlan_allow.conf
@@ -119,7 +119,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_vlan_allow.conf
+++ b/src/program/lwaftr/tests/data/small_ipv6_mtu_no_icmp_vlan_allow.conf
@@ -113,30 +113,40 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 1500;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
     mtu 1280;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/tunnel_icmp.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp.conf
@@ -118,7 +118,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/tunnel_icmp.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp.conf
@@ -113,23 +113,33 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
-    }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
     }
     reassembly {
       max-fragments-per-packet 40;

--- a/src/program/lwaftr/tests/data/tunnel_icmp_without_mac4.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp_without_mac4.conf
@@ -118,7 +118,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/tunnel_icmp_without_mac4.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp_without_mac4.conf
@@ -113,23 +113,33 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      ip 4.5.6.7;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          ip 4.5.6.7;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
     }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
-    }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
     }
     reassembly {
       max-fragments-per-packet 40;

--- a/src/program/lwaftr/tests/data/tunnel_icmp_withoutmac.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp_withoutmac.conf
@@ -118,7 +118,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/tunnel_icmp_withoutmac.conf
+++ b/src/program/lwaftr/tests/data/tunnel_icmp_withoutmac.conf
@@ -113,23 +113,33 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          ip 8:9:a:b:4:3:2:1;
+        }
+      }
     }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
-    }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      ip 8:9:a:b:4:3:2:1;
     }
     reassembly {
       max-fragments-per-packet 40;

--- a/src/program/lwaftr/tests/data/vlan.conf
+++ b/src/program/lwaftr/tests/data/vlan.conf
@@ -118,7 +118,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan.conf
+++ b/src/program/lwaftr/tests/data/vlan.conf
@@ -113,28 +113,38 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     error-rate-limiting {
       packets 6000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/big_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/big_mtu_no_icmp.conf
@@ -115,16 +115,32 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 1960;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
@@ -132,15 +148,9 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
     mtu 2000;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/big_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/big_mtu_no_icmp.conf
@@ -121,7 +121,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/icmp_endaddr.conf
+++ b/src/program/lwaftr/tests/data/vlan/icmp_endaddr.conf
@@ -42,31 +42,41 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 2000;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
     error-rate-limiting {
       packets 600000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
     mtu 2000;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/icmp_endaddr.conf
+++ b/src/program/lwaftr/tests/data/vlan/icmp_endaddr.conf
@@ -48,7 +48,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/icmp_on_fail.conf
+++ b/src/program/lwaftr/tests/data/vlan/icmp_on_fail.conf
@@ -119,7 +119,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/icmp_on_fail.conf
+++ b/src/program/lwaftr/tests/data/vlan/icmp_on_fail.conf
@@ -114,29 +114,39 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
     error-rate-limiting {
       packets 600000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/no_hairpin.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_hairpin.conf
@@ -120,7 +120,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/no_hairpin.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_hairpin.conf
@@ -115,15 +115,31 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
@@ -132,14 +148,8 @@ softwire-config {
     }
     generate-icmp-errors false;
     hairpinning false;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp.conf
@@ -115,15 +115,31 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
@@ -131,14 +147,8 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp.conf
@@ -120,7 +120,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_maxfrags1.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_maxfrags1.conf
@@ -120,7 +120,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_maxfrags1.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_maxfrags1.conf
@@ -115,15 +115,31 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 1;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
@@ -131,15 +147,9 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 1;
       max-packets 10;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_accept.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_accept.conf
@@ -117,15 +117,31 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter ip;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
@@ -135,14 +151,8 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter ip6;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_accept.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_accept.conf
@@ -122,7 +122,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_drop.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_drop.conf
@@ -117,15 +117,31 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter "len < 0";
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
@@ -135,14 +151,8 @@ softwire-config {
     }
     generate-icmp-errors false;
     ingress-filter "len < 0";
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_drop.conf
+++ b/src/program/lwaftr/tests/data/vlan/no_icmp_with_filters_drop.conf
@@ -122,7 +122,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/small_ipv4_mtu_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv4_mtu_icmp.conf
@@ -119,7 +119,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/small_ipv4_mtu_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv4_mtu_icmp.conf
@@ -113,29 +113,39 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 576;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp.conf
@@ -115,16 +115,32 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 1500;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     allow-incoming-icmp false;
@@ -132,15 +148,9 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
     mtu 1280;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp.conf
@@ -121,7 +121,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp_allow.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp_allow.conf
@@ -119,7 +119,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp_allow.conf
+++ b/src/program/lwaftr/tests/data/vlan/small_ipv6_mtu_no_icmp_allow.conf
@@ -113,30 +113,40 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
     mtu 1500;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
     mtu 1280;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp.conf
@@ -118,7 +118,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp.conf
@@ -113,28 +113,38 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp_without_mac4.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp_without_mac4.conf
@@ -118,7 +118,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp_without_mac4.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp_without_mac4.conf
@@ -113,28 +113,38 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      ip 4.5.6.7;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          ip 4.5.6.7;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp_withoutmac.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp_withoutmac.conf
@@ -118,7 +118,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/tunnel_icmp_withoutmac.conf
+++ b/src/program/lwaftr/tests/data/vlan/tunnel_icmp_withoutmac.conf
@@ -113,28 +113,38 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          ip 8:9:a:b:4:3:2:1;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      ip 8:9:a:b:4:3:2:1;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/data/vlan/vlan.conf
+++ b/src/program/lwaftr/tests/data/vlan/vlan.conf
@@ -118,7 +118,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/lwaftr/tests/data/vlan/vlan.conf
+++ b/src/program/lwaftr/tests/data/vlan/vlan.conf
@@ -113,28 +113,38 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 10.10.10.10;
-    mac 12:12:12:12:12:12;
-    next-hop {
-      mac 68:68:68:68:68:68;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     error-rate-limiting {
       packets 6000;
     }
-    ip 8:9:a:b:c:d:e:f;
-    mac 22:22:22:22:22:22;
-    next-hop {
-      mac 44:44:44:44:44:44;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }

--- a/src/program/lwaftr/tests/selftest.sh
+++ b/src/program/lwaftr/tests/selftest.sh
@@ -13,6 +13,15 @@ else
     TEST_WHAT="*"
 fi
 
+# Create a directory for JIT migrated configs so that each configuration file
+# can be contain the correct PCI device we need to test with. If it doesn't
+# already exist (it shouldn't really) then make it.
+export JIT_CONFIG_DIR="/tmp/snabb-configs"
+
+if [ ! -d $JIT_CONFIG_DIR ]; then
+    mkdir $JIT_CONFIG_DIR
+fi
+
 # Start discovery from this script's directory, the root of the "tests" subtree.
 # Look for unittests in all files whose name ends with "_test.py", or just one
 # of them, if its prefix (without _test.py) was passed as first argument.
@@ -21,3 +30,6 @@ python3 -m unittest discover \
     --start-directory "${TESTS_DIR}" \
     --pattern "${TEST_WHAT}_test.py" \
     --verbose
+
+# Remove the config dir as part of the cleanup.
+rm -r $JIT_CONFIG_DIR

--- a/src/program/lwaftr/tests/selftest.sh
+++ b/src/program/lwaftr/tests/selftest.sh
@@ -13,15 +13,6 @@ else
     TEST_WHAT="*"
 fi
 
-# Create a directory for JIT migrated configs so that each configuration file
-# can be contain the correct PCI device we need to test with. If it doesn't
-# already exist (it shouldn't really) then make it.
-export JIT_CONFIG_DIR="/tmp/snabb-configs"
-
-if [ ! -d $JIT_CONFIG_DIR ]; then
-    mkdir $JIT_CONFIG_DIR
-fi
-
 # Start discovery from this script's directory, the root of the "tests" subtree.
 # Look for unittests in all files whose name ends with "_test.py", or just one
 # of them, if its prefix (without _test.py) was passed as first argument.
@@ -31,5 +22,3 @@ python3 -m unittest discover \
     --pattern "${TEST_WHAT}_test.py" \
     --verbose
 
-# Remove the config dir as part of the cleanup.
-rm -r $JIT_CONFIG_DIR

--- a/src/program/lwaftr/tests/subcommands/bench_test.py
+++ b/src/program/lwaftr/tests/subcommands/bench_test.py
@@ -7,17 +7,16 @@ import unittest
 from test_env import (BENCHMARK_FILENAME, BENCHMARK_PATH, DATA_DIR,
     BENCHDATA_DIR, SNABB_CMD, BaseTestCase)
 
-
 class TestBench(BaseTestCase):
 
-    cmd_args = (
+    cmd_args = [
         str(SNABB_CMD), 'lwaftr', 'bench',
         '--duration', '0.1',
         '--bench-file', BENCHMARK_FILENAME,
-        str(DATA_DIR / 'icmp_on_fail.conf'),
+        BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf')),
         str(BENCHDATA_DIR / 'ipv4-0550.pcap'),
         str(BENCHDATA_DIR / 'ipv6-0550.pcap'),
-    )
+    ]
 
     def execute_bench_test(self, cmd_args):
         self.run_cmd(cmd_args)

--- a/src/program/lwaftr/tests/subcommands/bench_test.py
+++ b/src/program/lwaftr/tests/subcommands/bench_test.py
@@ -13,7 +13,7 @@ class TestBench(BaseTestCase):
         str(SNABB_CMD), 'lwaftr', 'bench',
         '--duration', '0.1',
         '--bench-file', BENCHMARK_FILENAME,
-        BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf')),
+        str(DATA_DIR / 'icmp_on_fail.conf'),
         str(BENCHDATA_DIR / 'ipv4-0550.pcap'),
         str(BENCHDATA_DIR / 'ipv6-0550.pcap'),
     ]

--- a/src/program/lwaftr/tests/subcommands/check_test.py
+++ b/src/program/lwaftr/tests/subcommands/check_test.py
@@ -10,7 +10,7 @@ class TestCheck(BaseTestCase):
 
     cmd_args = (
         str(SNABB_CMD), 'lwaftr', 'check',
-        BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf')),
+        str(DATA_DIR / 'icmp_on_fail.conf'),
         str(DATA_DIR / 'empty.pcap'), str(DATA_DIR / 'empty.pcap'),
         '/dev/null', '/dev/null',
         str(COUNTERS_DIR / 'empty.lua'),

--- a/src/program/lwaftr/tests/subcommands/check_test.py
+++ b/src/program/lwaftr/tests/subcommands/check_test.py
@@ -6,12 +6,11 @@ import unittest
 
 from test_env import COUNTERS_DIR, DATA_DIR, SNABB_CMD, BaseTestCase
 
-
 class TestCheck(BaseTestCase):
 
     cmd_args = (
         str(SNABB_CMD), 'lwaftr', 'check',
-        str(DATA_DIR / 'icmp_on_fail.conf'),
+        BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf')),
         str(DATA_DIR / 'empty.pcap'), str(DATA_DIR / 'empty.pcap'),
         '/dev/null', '/dev/null',
         str(COUNTERS_DIR / 'empty.lua'),

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -20,22 +20,13 @@ DAEMON_ARGS = [
     str(SNABB_CMD), 'lwaftr', 'bench', '--reconfigurable',
     '--bench-file', '/dev/null',
     '--name', DAEMON_PROC_NAME,
-    BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf')),
+    str(DATA_DIR / 'icmp_on_fail.conf'),
     str(BENCHDATA_DIR / 'ipv4-0550.pcap'),
     str(BENCHDATA_DIR / 'ipv6-0550.pcap'),
 ]
 SOCKET_PATH = '/tmp/snabb-lwaftr-listen-sock-%s' % DAEMON_PROC_NAME
 
-class BaseConfigTestCase(BaseTestCase):
-
-    @property
-    def instance_path(self):
-        ipv4_nic, ipv6_nic = nic_names()
-        return '/softwire-config/instance[device={device}]/queue[id=1]'.format(
-            device=(ipv4_nic or "test")
-        )
-
-class TestConfigGet(BaseConfigTestCase):
+class TestConfigGet(BaseTestCase):
     """
     Test querying from a known config, testing basic "getting".
     It performs numerous gets on different paths.
@@ -46,7 +37,8 @@ class TestConfigGet(BaseConfigTestCase):
 
     def test_get_internal_iface(self):
         cmd_args = list(self.config_args)
-        cmd_args.append(self.instance_path + '/internal-interface/ip')
+        cmd_args.append('/softwire-config/instance[device=test/queue[id=1]'
+                        '/internal-interface/ip')
         output = self.run_cmd(cmd_args)
         self.assertEqual(
             output.strip(), b'8:9:a:b:c:d:e:f',
@@ -54,7 +46,8 @@ class TestConfigGet(BaseConfigTestCase):
 
     def test_get_external_iface(self):
         cmd_args = list(self.config_args)
-        cmd_args.append(self.instance_path + '/external-interface/ip')
+        cmd_args.append('/softwire-config/instance[device=test/queue[id=1]/'
+                        'external-interface/ip')
         output = self.run_cmd(cmd_args)
         self.assertEqual(
             output.strip(), b'10.10.10.10',
@@ -86,7 +79,7 @@ class TestConfigGet(BaseConfigTestCase):
             '\n'.join(('OUTPUT', str(output, ENC))))
 
 
-class TestConfigListen(BaseConfigTestCase):
+class TestConfigListen(BaseTestCase):
     """
     Test it can listen, send a command and get a response. Only test the
     socket method of communicating with the listen command, due to the
@@ -128,7 +121,7 @@ class TestConfigListen(BaseConfigTestCase):
         os.unlink(SOCKET_PATH)
 
 
-class TestConfigMisc(BaseConfigTestCase):
+class TestConfigMisc(BaseTestCase):
 
     daemon_args = DAEMON_ARGS
 
@@ -204,7 +197,8 @@ class TestConfigMisc(BaseConfigTestCase):
         test_ipv4 = '208.118.235.148'
         set_args = self.get_cmd_args('set')
         set_args.extend((
-            self.instance_path + "/external-interface/ip", test_ipv4
+            "/softwire-config/instance[device=test/queue[id=1]/"
+            "external-interface/ip", test_ipv4
         ))
         self.run_cmd(set_args)
         get_args = list(set_args)[:-1]

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -37,7 +37,7 @@ class TestConfigGet(BaseTestCase):
 
     def test_get_internal_iface(self):
         cmd_args = list(self.config_args)
-        cmd_args.append('/softwire-config/instance[device=test/queue[id=1]'
+        cmd_args.append('/softwire-config/instance[device=test]/queue[id=1]'
                         '/internal-interface/ip')
         output = self.run_cmd(cmd_args)
         self.assertEqual(
@@ -46,7 +46,7 @@ class TestConfigGet(BaseTestCase):
 
     def test_get_external_iface(self):
         cmd_args = list(self.config_args)
-        cmd_args.append('/softwire-config/instance[device=test/queue[id=1]/'
+        cmd_args.append('/softwire-config/instance[device=test]/queue[id=1]/'
                         'external-interface/ip')
         output = self.run_cmd(cmd_args)
         self.assertEqual(
@@ -197,7 +197,7 @@ class TestConfigMisc(BaseTestCase):
         test_ipv4 = '208.118.235.148'
         set_args = self.get_cmd_args('set')
         set_args.extend((
-            "/softwire-config/instance[device=test/queue[id=1]/"
+            "/softwire-config/instance[device=test]/queue[id=1]/"
             "external-interface/ip", test_ipv4
         ))
         self.run_cmd(set_args)

--- a/src/program/lwaftr/tests/subcommands/loadtest_test.py
+++ b/src/program/lwaftr/tests/subcommands/loadtest_test.py
@@ -12,6 +12,7 @@ from test_env import BENCHDATA_DIR, DATA_DIR, SNABB_CMD, BaseTestCase, nic_names
 
 
 SNABB_PCI0, SNABB_PCI1 = nic_names()
+CONFIG_PATH = BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf'))
 
 
 @unittest.skipUnless(SNABB_PCI0 and SNABB_PCI1, 'NICs not configured')
@@ -20,7 +21,7 @@ class TestLoadtest(BaseTestCase):
     daemon_args = (
         str(SNABB_CMD), 'lwaftr', 'run',
         '--bench-file', '/dev/null',
-        '--conf', str(DATA_DIR / 'icmp_on_fail.conf'),
+        '--conf', CONFIG_PATH,
         '--on-a-stick', SNABB_PCI0,
     )
     loadtest_args = (

--- a/src/program/lwaftr/tests/subcommands/loadtest_test.py
+++ b/src/program/lwaftr/tests/subcommands/loadtest_test.py
@@ -12,8 +12,6 @@ from test_env import BENCHDATA_DIR, DATA_DIR, SNABB_CMD, BaseTestCase, nic_names
 
 
 SNABB_PCI0, SNABB_PCI1 = nic_names()
-CONFIG_PATH = BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf'))
-
 
 @unittest.skipUnless(SNABB_PCI0 and SNABB_PCI1, 'NICs not configured')
 class TestLoadtest(BaseTestCase):
@@ -21,7 +19,7 @@ class TestLoadtest(BaseTestCase):
     daemon_args = (
         str(SNABB_CMD), 'lwaftr', 'run',
         '--bench-file', '/dev/null',
-        '--conf', CONFIG_PATH,
+        '--conf', str(DATA_DIR / 'icmp_on_fail.conf'),
         '--on-a-stick', SNABB_PCI0,
     )
     loadtest_args = (

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -14,8 +14,6 @@ from test_env import DATA_DIR, SNABB_CMD, BaseTestCase, nic_names
 
 DAEMON_PROC_NAME = 'monitor-test-daemon'
 SNABB_PCI0 = nic_names()[0]
-CONFIG_PATH = BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf'))
-
 
 @unittest.skipUnless(SNABB_PCI0, 'NIC not configured')
 class TestMonitor(BaseTestCase):
@@ -24,7 +22,7 @@ class TestMonitor(BaseTestCase):
         str(SNABB_CMD), 'lwaftr', 'run',
         '--name', DAEMON_PROC_NAME,
         '--bench-file', '/dev/null',
-        '--conf', CONFIG_PATH,
+        '--conf', str(DATA_DIR / 'icmp_on_fail.conf'),
         '--on-a-stick', SNABB_PCI0,
         '--mirror',  # TAP interface name added in setUpClass.
     ]

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -14,6 +14,7 @@ from test_env import DATA_DIR, SNABB_CMD, BaseTestCase, nic_names
 
 DAEMON_PROC_NAME = 'monitor-test-daemon'
 SNABB_PCI0 = nic_names()[0]
+CONFIG_PATH = BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf'))
 
 
 @unittest.skipUnless(SNABB_PCI0, 'NIC not configured')
@@ -23,7 +24,7 @@ class TestMonitor(BaseTestCase):
         str(SNABB_CMD), 'lwaftr', 'run',
         '--name', DAEMON_PROC_NAME,
         '--bench-file', '/dev/null',
-        '--conf', str(DATA_DIR / 'icmp_on_fail.conf'),
+        '--conf', CONFIG_PATH,
         '--on-a-stick', SNABB_PCI0,
         '--mirror',  # TAP interface name added in setUpClass.
     ]

--- a/src/program/lwaftr/tests/subcommands/query_test.py
+++ b/src/program/lwaftr/tests/subcommands/query_test.py
@@ -23,8 +23,6 @@ class TestQueryStandard(BaseTestCase):
         str(SNABB_CMD), 'lwaftr', 'run',
         '--name', DAEMON_PROC_NAME,
         '--conf', CONFIG_PATH,
-        '--v4', SNABB_PCI0,
-        '--v6', SNABB_PCI1,
     )
 
     query_args = (str(SNABB_CMD), 'lwaftr', 'query')
@@ -82,8 +80,6 @@ class TestQueryReconfigurable(TestQueryStandard):
         str(SNABB_CMD), 'lwaftr', 'run', '--reconfigurable',
         '--name', DAEMON_PROC_NAME,
         '--conf', str(DATA_DIR / 'no_icmp.conf'),
-        '--v4', SNABB_PCI0,
-        '--v6', SNABB_PCI1,
     )
 
     def get_all_leader_pids(self):

--- a/src/program/lwaftr/tests/subcommands/query_test.py
+++ b/src/program/lwaftr/tests/subcommands/query_test.py
@@ -12,6 +12,8 @@ from test_env import DATA_DIR, ENC, SNABB_CMD, BaseTestCase, nic_names
 DAEMON_PROC_NAME = 'query-test-daemon'
 SNABB_PCI0, SNABB_PCI1 = nic_names()
 RUN_DIR = Path('/var/run/snabb')
+CONFIG_PATH = BaseTestCase.get_config_path(str(DATA_DIR / 'no_icmp.conf'))
+
 
 
 @unittest.skipUnless(SNABB_PCI0 and SNABB_PCI1, 'NICs not configured')
@@ -20,7 +22,7 @@ class TestQueryStandard(BaseTestCase):
     daemon_args = (
         str(SNABB_CMD), 'lwaftr', 'run',
         '--name', DAEMON_PROC_NAME,
-        '--conf', str(DATA_DIR / 'no_icmp.conf'),
+        '--conf', CONFIG_PATH,
         '--v4', SNABB_PCI0,
         '--v6', SNABB_PCI1,
     )

--- a/src/program/lwaftr/tests/subcommands/query_test.py
+++ b/src/program/lwaftr/tests/subcommands/query_test.py
@@ -12,9 +12,6 @@ from test_env import DATA_DIR, ENC, SNABB_CMD, BaseTestCase, nic_names
 DAEMON_PROC_NAME = 'query-test-daemon'
 SNABB_PCI0, SNABB_PCI1 = nic_names()
 RUN_DIR = Path('/var/run/snabb')
-CONFIG_PATH = BaseTestCase.get_config_path(str(DATA_DIR / 'no_icmp.conf'))
-
-
 
 @unittest.skipUnless(SNABB_PCI0 and SNABB_PCI1, 'NICs not configured')
 class TestQueryStandard(BaseTestCase):
@@ -22,7 +19,9 @@ class TestQueryStandard(BaseTestCase):
     daemon_args = (
         str(SNABB_CMD), 'lwaftr', 'run',
         '--name', DAEMON_PROC_NAME,
-        '--conf', CONFIG_PATH,
+        '--conf', str(DATA_DIR / 'no_icmp.conf'),
+        '--v4', SNABB_PCI0,
+        '--v6', SNABB_PCI1
     )
 
     query_args = (str(SNABB_CMD), 'lwaftr', 'query')
@@ -80,6 +79,8 @@ class TestQueryReconfigurable(TestQueryStandard):
         str(SNABB_CMD), 'lwaftr', 'run', '--reconfigurable',
         '--name', DAEMON_PROC_NAME,
         '--conf', str(DATA_DIR / 'no_icmp.conf'),
+        '--v4', SNABB_PCI0,
+        '--v6', SNABB_PCI1,
     )
 
     def get_all_leader_pids(self):

--- a/src/program/lwaftr/tests/subcommands/run_nohw_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_nohw_test.py
@@ -8,7 +8,7 @@ from random import randint
 from subprocess import check_call
 from test_env import DATA_DIR, SNABB_CMD, BaseTestCase
 
-CONFIG_PATH = BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf'))
+CONFIG_PATH = str(DATA_DIR / 'icmp_on_fail.conf')
 
 
 class TestRunNoHW(BaseTestCase):

--- a/src/program/lwaftr/tests/subcommands/run_nohw_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_nohw_test.py
@@ -8,6 +8,8 @@ from random import randint
 from subprocess import check_call
 from test_env import DATA_DIR, SNABB_CMD, BaseTestCase
 
+CONFIG_PATH = BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf'))
+
 
 class TestRunNoHW(BaseTestCase):
 
@@ -17,7 +19,7 @@ class TestRunNoHW(BaseTestCase):
     cmd_options = {
         '--duration': '1',
         '--bench-file': '/dev/null',
-        '--conf': str(DATA_DIR / 'icmp_on_fail.conf'),
+        '--conf': CONFIG_PATH,
         '--inet-if': '',
         '--b4-if': '',
     }

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -9,8 +9,6 @@ from test_env import DATA_DIR, SNABB_CMD, BaseTestCase, nic_names
 
 SNABB_PCI0, SNABB_PCI1 = nic_names()
 
-CONFIG_PATH = BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf'))
-
 @unittest.skipUnless(SNABB_PCI0 and SNABB_PCI1, 'NICs not configured')
 class TestRun(BaseTestCase):
 
@@ -18,7 +16,9 @@ class TestRun(BaseTestCase):
         str(SNABB_CMD), 'lwaftr', 'run',
         '--duration', '1',
         '--bench-file', '/dev/null',
-        '--conf', CONFIG_PATH,
+        '--conf', str(DATA_DIR / 'icmp_on_fail.conf'),
+        '--v4', SNABB_PCI0,
+        '--v6', SNABB_PCI1
     )
 
     def execute_run_test(self, cmd_args):

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -9,6 +9,7 @@ from test_env import DATA_DIR, SNABB_CMD, BaseTestCase, nic_names
 
 SNABB_PCI0, SNABB_PCI1 = nic_names()
 
+CONFIG_PATH = BaseTestCase.get_config_path(str(DATA_DIR / 'icmp_on_fail.conf'))
 
 @unittest.skipUnless(SNABB_PCI0 and SNABB_PCI1, 'NICs not configured')
 class TestRun(BaseTestCase):
@@ -17,7 +18,7 @@ class TestRun(BaseTestCase):
         str(SNABB_CMD), 'lwaftr', 'run',
         '--duration', '1',
         '--bench-file', '/dev/null',
-        '--conf', str(DATA_DIR / 'icmp_on_fail.conf'),
+        '--conf', CONFIG_PATH,
         '--v4', SNABB_PCI0,
         '--v6', SNABB_PCI1,
     )

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -19,8 +19,6 @@ class TestRun(BaseTestCase):
         '--duration', '1',
         '--bench-file', '/dev/null',
         '--conf', CONFIG_PATH,
-        '--v4', SNABB_PCI0,
-        '--v6', SNABB_PCI1,
     )
 
     def execute_run_test(self, cmd_args):

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -19,7 +19,6 @@ local pci = require("lib.hardware.pci")
 local raw = require("apps.socket.raw")
 local tap = require("apps.tap.tap")
 local pcap = require("apps.pcap.pcap")
-local lwaftr_setup = require("program.lwaftr.setup")
 
 local fatal, file_exists = lwutil.fatal, lwutil.file_exists
 local dir_exists, nic_exists = lwutil.dir_exists, lwutil.nic_exists
@@ -43,7 +42,7 @@ end
 
 local function load_virt (c, nic_id, lwconf, interface)
    -- Validate the lwaftr and split the interfaces into global and instance.
-   local inst_configs = lwaftr_setup.produce_instance_configs(lwconf)
+   local inst_configs = lwutil.produce_instance_configs(lwconf)
    local device, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
 

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -19,6 +19,7 @@ local pci = require("lib.hardware.pci")
 local raw = require("apps.socket.raw")
 local tap = require("apps.tap.tap")
 local pcap = require("apps.pcap.pcap")
+local lwaftr_setup = require("program.lwaftr.setup")
 
 local fatal, file_exists = lwutil.fatal, lwutil.file_exists
 local dir_exists, nic_exists = lwutil.dir_exists, lwutil.nic_exists
@@ -42,7 +43,7 @@ end
 
 local function load_virt (c, nic_id, lwconf, interface)
    -- Validate the lwaftr and split the interfaces into global and instance.
-   local inst_configs = lwutil.produce_instance_configs(lwconf)
+   local inst_configs = lwaftr_setup.produce_instance_configs(lwconf)
    local device, lwaftr_config = next(inst_configs)
    local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
 

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -41,10 +41,16 @@ local function load_driver (pciaddr)
 end
 
 local function load_virt (c, nic_id, lwconf, interface)
-   local nic_id = next(lwconf.softwire_config.instance)
-   local new_config = lwaftr.select_instance(lwconf, nic_id)
-   local external_interface = new_config.softwire_config.external_interface
-   local internal_interface = new_config.softwire_config.internal_interface
+   -- Validate the lwaftr and split the interfaces into global and instance.
+   local inst_configs = lwutil.produce_instance_configs(lwconf)
+   local device, lwaftr_config = next(inst_configs)
+   local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
+
+   local gexternal_interface = lwaftr_config.softwire_config.external_interface
+   local ginternal_interface = lwaftr_config.softwire_config.internal_interface
+   local iexternal_interface = queue.external_interface
+   local iinternal_interface = queue.internal_interface
+
    assert(type(interface) == 'table')
    assert(nic_exists(interface.pci), "Couldn't find NIC: "..interface.pci)
    local driver = assert(load_driver(interface.pci))
@@ -54,7 +60,7 @@ local function load_virt (c, nic_id, lwconf, interface)
 
    local v4_nic_name, v6_nic_name = nic_id..'_v4', nic_id..'v6'
    local v4_mtu = external_interface.mtu + constants.ethernet_header_size
-   if external_interface.vlan_tag then
+   if iexternal_interface.vlan_tag then
      v4_mtu = v4_mtu + 4
    end
    print(("Setting %s interface MTU to %d"):format(v4_nic_name, v4_mtu))
@@ -62,10 +68,10 @@ local function load_virt (c, nic_id, lwconf, interface)
       pciaddr = interface.pci,
       vmdq = interface.vlan and true,
       vlan = interface.vlan and interface.vlan.v4_vlan_tag,
-      macaddr = ethernet:ntop(external_interface.mac),
+      macaddr = ethernet:ntop(iexternal_interface.mac),
       mtu = v4_mtu })
-   local v6_mtu = internal_interface.mtu + constants.ethernet_header_size
-   if internal_interface.vlan_tag then
+   local v6_mtu = ginternal_interface.mtu + constants.ethernet_header_size
+   if iinternal_interface.vlan_tag then
      v6_mtu = v6_mtu + 4
    end
    print(("Setting %s interface MTU to %d"):format(v6_nic_name, v6_mtu))
@@ -73,7 +79,7 @@ local function load_virt (c, nic_id, lwconf, interface)
       pciaddr = interface.pci,
       vmdq = interface.vlan and true,
       vlan = interface.vlan and interface.vlan.v6_vlan_tag,
-      macaddr = ethernet:ntop(internal_interface.mac),
+      macaddr = ethernet:ntop(iinternal_interface.mac),
       mtu = v6_mtu})
 
    return v4_nic_name, v6_nic_name
@@ -129,22 +135,27 @@ function lwaftr_app(c, conf, lwconf, sock_path)
    assert(type(conf) == 'table')
    assert(type(lwconf) == 'table')
 
-   local device = next(lwconf.softwire_config.instance)
-   local new_config = lwaftr.select_instance(lwconf, device)
-   local external_interface = new_config.softwire_config.external_interface
-   local internal_interface = new_config.softwire_config.internal_interface
+   -- Validate the lwaftr and split the interfaces into global and instance.
+   local inst_configs = lwutil.produce_instance_configs(lwconf)
+   local device, lwaftr_config = next(inst_configs)
+   local queue = lwaftr_config.softwire_config.instance[device].queue.values[1]
 
-   local lwaftr_class = lwaftr.LwAftr
-   lwaftr_class.config_arg = "conf"
+   local gexternal_interface = lwaftr_config.softwire_config.external_interface
+   local ginternal_interface = lwaftr_config.softwire_config.internal_interface
+   local iexternal_interface = queue.external_interface
+   local iinternal_interface = queue.internal_interface
 
-   print(("Hairpinning: %s"):format(yesno(internal_interface.hairpinning)))
+   local external_interface = lwconf.softwire_config.external_interface
+   local internal_interface = lwconf.softwire_config.internal_interface
+
+   print(("Hairpinning: %s"):format(yesno(ginternal_interface.hairpinning)))
    local virt_id = "vm_" .. conf.interface.id
    local phy_id = "nic_" .. conf.interface.id
 
    local chain_input, chain_output
    local v4_input, v4_output, v6_input, v6_output
 
-   local use_splitter = requires_splitter(internal_interface, external_interface)
+   local use_splitter = requires_splitter(iinternal_interface, iexternal_interface)
    if not use_splitter then
       local v4, v6 = load_virt(c, phy_id, lwconf, conf.interface)
       v4_output, v6_output = v4..".tx", v6..".tx"
@@ -181,9 +192,9 @@ function lwaftr_app(c, conf, lwconf, sock_path)
          local mtu = conf.ipv6_interface.mtu or internal_interface.mtu
          config.app(c, "reassemblerv6", ipv6_apps.ReassembleV6, {
             max_ipv6_reassembly_packets =
-               internal_interface.reassembly.max_packets,
+               ginternal_interface.reassembly.max_packets,
             max_fragments_per_reassembly_packet =
-               internal_interface.reassembly.max_fragments_per_packet
+               ginternal_interface.reassembly.max_fragments_per_packet
          })
          config.app(c, "fragmenterv6", ipv6_apps.Fragmenter, {
             mtu = mtu,
@@ -213,12 +224,12 @@ function lwaftr_app(c, conf, lwconf, sock_path)
       print(("IPv4 fragmentation and reassembly: %s"):format(yesno(
              conf.ipv4_interface.fragmentation)))
       if conf.ipv4_interface.fragmentation then
-         local mtu = conf.ipv4_interface.mtu or external_interface.mtu
+         local mtu = conf.ipv4_interface.mtu or gexternal_interface.mtu
          config.app(c, "reassemblerv4", ipv4_apps.Reassembler, {
             max_ipv4_reassembly_packets =
-               external_interface.reassembly.max_packets,
+               gexternal_interface.reassembly.max_packets,
             max_fragments_per_reassembly_packet =
-               external_interface.reassembly.max_fragments_per_packet
+               gexternal_interface.reassembly.max_fragments_per_packet
          })
          config.app(c, "fragmenterv4", ipv4_apps.Fragmenter, {
             mtu = mtu
@@ -257,7 +268,7 @@ function lwaftr_app(c, conf, lwconf, sock_path)
       config.link(c, "nh_fwd4.wire -> " .. v4_input)
       v4_input, v4_output = "nh_fwd4.vm", "nh_fwd4.vm"
 
-      config.app(c, "lwaftr", lwaftr_class, {conf=lwconf, device=device})
+      config.app(c, "lwaftr", lwaftr.LwAftr, lwconf)
       config.link(c, "nh_fwd6.service -> lwaftr.v6")
       config.link(c, "lwaftr.v6 -> nh_fwd6.service")
       config.link(c, "nh_fwd4.service -> lwaftr.v4")
@@ -330,13 +341,8 @@ end
 local function lwaftr_app_check (c, conf, lwconf, sources, sinks)
    assert(type(conf) == "table")
    assert(type(lwconf) == "table")
-   local device = next(lwconf.softwire_config.instance)
-   local new_config = lwaftr.select_instance(lwconf, device)
-   local external_interface = new_config.softwire_config.external_interface
-   local internal_interface = new_config.softwire_config.internal_interface
-
-   local lwaftr_class = lwaftr.LwAftr
-   lwaftr_class.config_arg = "conf"
+   local external_interface = lwconf.softwire_config.external_interface
+   local internal_interface = lwconf.softwire_config.internal_interface
 
    local v4_src, v6_src = unpack(sources)
    local v4_sink, v6_sink = unpack(sinks)
@@ -412,7 +418,7 @@ local function lwaftr_app_check (c, conf, lwconf, sources, sinks)
       config.link(c, v4_src.."-> nh_fwd4.wire")
       config.link(c, "nh_fwd4.wire -> "..v4_sink)
 
-      config.app(c, "lwaftr", lwaftr_class, {conf=lwconf, device=device})
+      config.app(c, "lwaftr", lwaftr.LwAftr, lwconf)
       config.link(c, "nh_fwd6.service -> lwaftr.v6")
       config.link(c, "lwaftr.v6 -> nh_fwd6.service")
       config.link(c, "nh_fwd4.service -> lwaftr.v4")

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -129,8 +129,8 @@ function lwaftr_app(c, conf, lwconf, sock_path)
    assert(type(conf) == 'table')
    assert(type(lwconf) == 'table')
 
-   local device = next(conf.softwire_config.instance)
-   local new_config = lwaftr.select_instance(conf, device)
+   local device = next(lwconf.softwire_config.instance)
+   local new_config = lwaftr.select_instance(lwconf, device)
    local external_interface = new_config.softwire_config.external_interface
    local internal_interface = new_config.softwire_config.internal_interface
 

--- a/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr-xe0.conf
+++ b/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr-xe0.conf
@@ -1839,7 +1839,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr-xe0.conf
+++ b/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr-xe0.conf
@@ -1834,13 +1834,28 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.0.1.1;
-    mac 02:aa:aa:aa:aa:aa;
-    next-hop {
-      mac 02:99:99:99:99:99;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.0.1.1;
+        mac 02:aa:aa:aa:aa:aa;
+        next-hop {
+          mac 02:99:99:99:99:99;
+        }
+      }
+      internal-interface {
+        ip fc00::100;
+        mac 02:aa:aa:aa:aa:aa;
+        next-hop {
+          mac 02:99:99:99:99:99;
+        }
+      }
     }
   }
   internal-interface {
@@ -1849,12 +1864,7 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip fc00::100;
-    mac 02:aa:aa:aa:aa:aa;
     mtu 9500;
-    next-hop {
-      mac 02:99:99:99:99:99;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }

--- a/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr.conf
+++ b/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr.conf
@@ -1839,7 +1839,7 @@ softwire-config {
     }
   }
   instance {
-    device 0000:82:00.0;
+    device test;
     queue {
       id 1;
       external-interface {

--- a/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr.conf
+++ b/src/program/snabbvmx/tests/conf/snabbvmx-lwaftr.conf
@@ -1834,13 +1834,28 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip 10.0.1.1;
-    mac 02:aa:aa:aa:aa:aa;
-    next-hop {
-      mac 02:99:99:99:99:99;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device 0000:82:00.0;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.0.1.1;
+        mac 02:aa:aa:aa:aa:aa;
+        next-hop {
+          mac 02:99:99:99:99:99;
+        }
+      }
+      internal-interface {
+        ip fc00::100;
+        mac 02:aa:aa:aa:aa:aa;
+        next-hop {
+          mac 02:99:99:99:99:99;
+        }
+      }
     }
   }
   internal-interface {
@@ -1849,12 +1864,7 @@ softwire-config {
       packets 600000;
     }
     generate-icmp-errors false;
-    ip fc00::100;
-    mac 02:aa:aa:aa:aa:aa;
     mtu 9500;
-    next-hop {
-      mac 02:99:99:99:99:99;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }

--- a/src/program/snabbvmx/tests/end-to-end/data/snabbvmx-lwaftr-xe1.conf
+++ b/src/program/snabbvmx/tests/end-to-end/data/snabbvmx-lwaftr-xe1.conf
@@ -41,14 +41,29 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 192.168.10.2;
-    mac 02:cf:69:15:81:01;
     mtu 9000;
-    next-hop {
-      mac 90:e2:ba:94:2a:bc;
-    }
     reassembly {
       max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device test;
+    queue {
+      id 1;
+      external-interface {
+        ip 192.168.10.2;
+        mac 02:cf:69:15:81:01;
+        next-hop {
+          mac 90:e2:ba:94:2a:bc;
+        }
+      }
+      internal-interface {
+        ip fc00:168:10::2;
+        mac 02:cf:69:15:81:01;
+        next-hop {
+          mac 90:e2:ba:94:2a:bc;
+        }
+      }
     }
   }
   internal-interface {
@@ -56,12 +71,7 @@ softwire-config {
       packets 600000;
     }
     hairpinning false;
-    ip fc00:168:10::2;
-    mac 02:cf:69:15:81:01;
     mtu 9000;
-    next-hop {
-      mac 90:e2:ba:94:2a:bc;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }

--- a/src/program/snabbvmx/tests/end-to-end/data/vlan/snabbvmx-lwaftr-xe1.conf
+++ b/src/program/snabbvmx/tests/end-to-end/data/vlan/snabbvmx-lwaftr-xe1.conf
@@ -41,31 +41,41 @@ softwire-config {
     error-rate-limiting {
       packets 600000;
     }
-    ip 192.168.10.2;
-    mac 02:cf:69:15:81:01;
     mtu 9000;
-    next-hop {
-      mac 90:e2:ba:94:2a:bc;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1092;
+  }
+  instance {
+    device test;
+    queue {
+      id 1;
+      external-interface {
+        ip 192.168.10.2;
+        mac 02:cf:69:15:81:01;
+        next-hop {
+          mac 90:e2:ba:94:2a:bc;
+        }
+        vlan-tag 1092;
+      }
+      internal-interface {
+        ip fc00:168:10::2;
+        mac 02:cf:69:15:81:01;
+        next-hop {
+          mac 90:e2:ba:94:2a:bc;
+        }
+        vlan-tag 1638;
+      }
+    }
   }
   internal-interface {
     error-rate-limiting {
       packets 600000;
     }
     hairpinning false;
-    ip fc00:168:10::2;
-    mac 02:cf:69:15:81:01;
     mtu 9000;
-    next-hop {
-      mac 90:e2:ba:94:2a:bc;
-    }
     reassembly {
       max-fragments-per-packet 40;
     }
-    vlan-tag 1638;
   }
 }


### PR DESCRIPTION
This PR addresses the work in #820.

## Schema

It adds a new list element to the configuration allowing the configuration of multiple instances of the lwAFTR using the single configuration file. It also adds the configuration ability of specifying RSS (receive side scaling) queues when supported in the lwAFTR. The configuration changes allow for specifying specific properties in instance specific `external-interface` and `internal-interface` blocks as well as specifying the PCI device. It also allows for configuration of global properties across instances.

It also finally includes the state counters per instance as well as globally. This will allow one to get the counters across all instances (as aggregate) and instance specific to aid debugging and monitoring of the lwAFTR instances.

The new list block is as follows:
```yang
list instance {
  key "device";

  leaf device { type string; description "PCI device"; }

  list queue {
    key "id";

    leaf id { type uint8; }

    container external-interface {
    	leaf ip { type inet:ipv4-address;  mandatory true; }
    	leaf device { type string; }
    	leaf mac { type yang:mac-address; mandatory true; }

    	uses vlan-tagging;

    	container next-hop {
    		choice address {
    			mandatory true;
    			case ip {
    				leaf ip {  type inet:ipv4-address; }
    				leaf resolved-mac {  config false; type yang:mac-address; }
    			}
    			case mac {
    				leaf mac {
    					type yang:mac-address;
    				}
    			}
    		}
    	}
    }

    container internal-interface {
    	leaf ip { type inet:ipv6-address; mandatory true; }
    	leaf mac { type yang:mac-address; mandatory true; }

    	uses vlan-tagging;

    	container next-hop {
    		choice address {
    			mandatory true;
    			case ip {
    				leaf ip { type inet:ipv6-address; }
    				leaf resolved-mac { config false; type yang:mac-address; }
    			}
    			case mac {
    				leaf mac { type yang:mac-address; }
    			}
    		}
    	}
    }
  }

  uses state-counters;
}
```
_The schema above has had the descriptions removed or reduced for ease of reading_

## Migration

The migration requires additional information which is not in older versions of the config (i.e. the PCI device). This is fixed with the introduction of the `-o` or `--option` flag where one specifies an X-Path value to describe the new value. For example

```
$ snabb lwaftr migrate-configuration -f 3.3.0 -o "/softwire-config/instance[device=00:02.0]" my-config.conf
```

The migration converts it so that the new config has a single item in the instance list and a single RSS queue which holds the instance specific values. Additional instances can then be added manually. There is no option to take multiple configurations and convert them to a single configuration with multiple instances.

## Lwaftr changes

The Lwaftr in this PR still lacks multi-process support. This PR is only to add support for the configuration which will allow multi-process support later. The way the lwAFTR deals with this at current is it will error if provided with a configuration which has multiple instances.

The PR tries to keep changes to `apps.lwaftr` with the idea that very little for the specific instances has actually changed and handling multiple instances will be the job of the leader or the setup code. The setup code produces multiple versions of the configuration each with a single instance and provides them to the LwAFTR app.

### Future thinking

When multiprocess support is added, it is expected that the setup code produces multiple single instance configs for each instance specified.

E.g. For a config with three instances. The setup code would produce three configurations each with just one entry in `/softwire-config/instance` and pass that to `apps.lwaftr.LwAftr` which will then internally extract the interfaces and merge them with the global interface producing a config which resembles the config prior to this change.

## Testing

Testing caused a problem in that the tests must be able to be run on multiple servers or on different PCI devices. This previously was not a problem as it was passed in via flags however now it's in the configuration it caused a problem.

The solution I came up with was to migrate the test data to have a device of "test". This is then on converted JIT by the tests to be a configuration with the values that have been specified in `SNABB_PCI0` and `SNABB_PCI1`. If those have not been specified it does not migrate them as it does not use the PCI addresses.

To do this I added a user facing migration which is additional to the `3.3.0` migration discussed above. It is called `pci-device` and it migrates the PCI devices specified in a configuration. The migration takes in three parameters, these are in provided using `-o` or `--option`:

- `from[device=PCI DEVICE]` this is whatever exists in `/softwire-config/instance/device` 
- `internal[device=PCI DEVICE]` this is the new value for `/softwire-config/instance/device`
- `external[device=PCI DEVICE]` this is the new value for `/softwire-config/instance/queue/external-interface/device` if it is unspecified then the option is left empty.

This allows for both the tests to build JIT configurations.
