### PR TITLE
[WIP] [YANG] Implement leafref

### DIFF
--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -21,10 +21,12 @@ require("lib.lua.class")
 
 -- ljsyscall returns error as a cdata instead of a string, and the standard
 -- assert doesn't use tostring on it.
+--[[
 _G.assert = function (v, ...)
    if v then return v, ... end
    error(tostring(... or "assertion failed!"))
 end
+--]]
 
 -- Reserve names that we want to use for global module.
 -- (This way we avoid errors from the 'strict' module.)

--- a/src/leafref-test.lua
+++ b/src/leafref-test.lua
@@ -1,0 +1,44 @@
+module(..., package.seeall)
+
+local yang = require("lib.yang.yang")
+local data = require('lib.yang.data')
+
+local leafref_schema = [[module test-schema {
+   namespace "urn:ietf:params:xml:ns:yang:test-schema";
+   prefix "test";
+
+   container test {
+      list interface {
+         leaf name {
+            type string;
+         }
+      }
+
+      leaf mgmt {
+         type leafref {
+            path "../interface/name";
+         }
+      }
+   }
+}]]
+
+function selftest (args)
+   local leafref_conf = [[
+      test {
+         interface {
+            name "eth0";
+         }
+         mgmt "eth0";
+      }
+   ]]
+
+   local loaded_schema = yang.load_schema(leafref_schema)
+   assert(loaded_schema.body.test.body.mgmt.type.kind == "leaf")
+
+   local grammar = data.data_grammar_from_schema(loaded_schema)
+   local parse = data.data_parser_from_grammar(grammar)
+   local model = parse(leafref_conf)
+   assert(model)
+
+   print("selftest: ok")
+end

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -96,7 +96,14 @@ function types.identityref.tostring(val)
 end
 
 types['instance-identifier'] = unimplemented('instance-identifier')
-leafref = unimplemented('leafref')
+
+types.leafref = {}
+function types.leafref.parse(str, what)
+   return assert(str, 'missing value for '..what)
+end
+function types.leafref.toleafref(val)
+   return val
+end
 
 types.string = {}
 function types.string.parse(str, what)

--- a/src/program/lwaftr/quickcheck/quickcheck.lua
+++ b/src/program/lwaftr/quickcheck/quickcheck.lua
@@ -65,8 +65,7 @@ function run (args)
    local opts, prop_name, prop_args = parse_args(args)
    local rerun_usage = function (i)
       print(("Rerun as: snabb lwaftr quickcheck --seed=%s --iterations=%s %s %s"):
-            format(program_name, opts.seed, i + 1,
-                   prop_name, table.concat(prop_args, " ")))
+            format(opts.seed, i + 1, prop_name, table.concat(prop_args, " ")))
    end
    math.randomseed(opts.seed)
 

--- a/src/program/lwaftr/tests/propbased/genyang.lua
+++ b/src/program/lwaftr/tests/propbased/genyang.lua
@@ -213,9 +213,16 @@ local function value_from_type(a_type)
       return string.format("%f", tonumber(int64 * (10 ^ -exp)))
    elseif prim == "boolean" then
       return choose({ true, false })
-   elseif prim == "ipv4-address" then
-      return math.random(0, 255) .. "." .. math.random(0, 255) .. "." ..
-             math.random(0, 255) .. "." .. math.random(0, 255)
+   elseif prim == "ipv4-address" or prim == "ipv4-prefix" then
+      local addr = {}
+      for i=1,4 do
+         table.insert(addr, math.random(255))
+      end
+      addr = table.concat(addr, ".")
+      if prim == "ipv4-prefix" then
+         return ("%s/%d"):format(addr, math.random(32))
+      end
+      return addr
    elseif prim == "ipv6-address" or prim == "ipv6-prefix" then
       local addr = random_hexes()
       for i=1, 7 do
@@ -285,7 +292,7 @@ local function value_from_type(a_type)
    -- instance-identifier
    -- leafref
 
-   error("NYI or unknown type")
+   error("NYI or unknown type: "..prim)
 end
 
 -- from a config schema, generate an xpath query string


### PR DESCRIPTION
An attempt to fix #802, likely it needs more work.

I added a new pass in schema to resolve leafrefs. The path expression in leafrefs is a xpath subexpression (see path-arg in https://tools.ietf.org/html/rfc6020#section-12). At this moment, I'm OK with supporting absolute and relative paths.

Maybe the leafrefs could be resolved as the tree is traversed (just visit a target node lazily as the path is consumed), but I added a new pass as it's simpler and this is still a proof-of-concept.