### PR TITLE
Yang enumerations

### DIFF
--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -440,9 +440,7 @@ function selftest()
 
       typedef severity  {
          type enumeration {
-            enum indetermiante {
-               value 2;
-            }
+            enum indeterminate;
             enum minor {
                value 3;
             }

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -212,20 +212,23 @@ local function data_emitter(production)
    end
    function handlers.scalar(production)
       local primitive_type = production.argument_type.primitive_type
+      local type = assert(value.types[primitive_type], "unsupported type: "..primitive_type)
       -- FIXME: needs a case for unions
-      if primitive_type == 'string' then
+      if primitive_type == 'string' or primitive_type == 'enumeration' then
          return function(data, stream)
             stream:write_stringref('stringref')
             stream:write_stringref(data)
          end
-      else
-         local ctype = assert(assert(value.types[primitive_type]).ctype)
+      elseif type.ctype then
+         local ctype = type.ctype
          local emit_value = value_emitter(ctype)
          return function(data, stream)
             stream:write_stringref('cdata')
             stream:write_stringref(ctype)
             emit_value(data, stream)
          end
+      else
+         error("unimplemented: "..primitive_type)
       end
    end
 

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -437,11 +437,29 @@ function selftest()
 
       leaf-list integers { type uint32; }
       leaf-list addrs { type inet:ipv4-address; }
+
+      typedef severity  {
+         type enumeration {
+            enum indetermiante {
+               value 2;
+            }
+            enum minor {
+               value 3;
+            }
+            enum warning {
+               value 4;
+            }
+         }
+      }
+
       container routes {
          list route {
             key addr;
             leaf addr { type inet:ipv4-address; mandatory true; }
             leaf port { type uint8 { range 0..11; } mandatory true; }
+         }
+         leaf severity {
+            type severity;
          }
       }
    }]])
@@ -456,6 +474,7 @@ function selftest()
         route { addr 1.2.3.4; port 1; }
         route { addr 2.3.4.5; port 10; }
         route { addr 3.4.5.6; port 2; }
+        severity minor;
       }
    ]])
 

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -241,7 +241,7 @@ local function length_validator(range, f) return f end
 local function pattern_validator(range, f) return f end
 local function bit_validator(range, f) return f end
 local function enum_validator(enums, f)
-   if not enums or #enums == 0 then return f end
+   if not enums then return f end
    return function (val)
       if not enums[val] then
          error('enumeration '..val..' is not a valid value')
@@ -267,11 +267,14 @@ local function value_parser(typ)
    local prim = typ.primitive_type
    local parse = assert(value.types[prim], prim).parse
    local validate = function(val) return val end
+   local function enums (node)
+      return node.primitive_type == 'enumeration' and node.enums or nil
+   end
    validate = range_validator(typ.range, validate)
    validate = length_validator(typ.length, validate)
    validate = pattern_validator(typ.pattern, validate)
    validate = bit_validator(typ.bit, validate)
-   validate = enum_validator(typ.enums, validate)
+   validate = enum_validator(enums(typ), validate)
    validate = identityref_validator(typ.bases, typ.default_prefix, validate)
    -- TODO: union, require-instance.
    return function(str, k)

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -243,10 +243,10 @@ local function bit_validator(range, f) return f end
 local function enum_validator(enums, f)
    if not enums or #enums == 0 then return f end
    return function (val)
-      for _, enum in ipairs(enums) do
-         if enum.value == val then return val end
+      if not enums[val] then
+         error('enumeration '..val..' is not a valid value')
       end
-      error('enumeration '..val..' is not a valid value')
+      return val
    end
 end
 local function identityref_validator(bases, default_prefix, f)

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -240,7 +240,15 @@ local function range_validator(range, f) return f end
 local function length_validator(range, f) return f end
 local function pattern_validator(range, f) return f end
 local function bit_validator(range, f) return f end
-local function enum_validator(range, f) return f end
+local function enum_validator(enums, f)
+   if not enums or #enums == 0 then return f end
+   return function (val)
+      for _, enum in ipairs(enums) do
+         if enum.value == val then return val end
+      end
+      error('enumeration '..val..' is not a valid value')
+   end
+end
 local function identityref_validator(bases, default_prefix, f)
    if not default_prefix then return f end
    return function(val)

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -405,9 +405,9 @@ local function init_range(node, loc, argument, children)
    node.reference = maybe_child_property(loc, children, 'reference', 'value')
 end
 local function init_enum(node, loc, argument, children)
-   node.value = require_argument(loc, argument)
-   local intvalue = maybe_child_property(loc, children, 'value', 'value')
-   if intvalue then node.intvalue = tonumber(intvalue) end
+   node.name = require_argument(loc, argument)
+   local value = maybe_child_property(loc, children, 'value', 'value')
+   if value then node.value = tonumber(value) end
    node.description = maybe_child_property(loc, children, 'description', 'value')
    node.reference = maybe_child_property(loc, children, 'reference', 'value')
    node.status = maybe_child_property(loc, children, 'status', 'value')
@@ -708,7 +708,10 @@ function resolve(schema, features)
          typedef = typedef()
          node.base_type = typedef
          node.primitive_type = assert(typedef.primitive_type)
-         node.enums = typedef.type.enums
+         node.enums = {}
+         for _, enum in pairs(typedef.type.enums) do
+            node.enums[enum] = true
+         end
       else
          -- If the type name wasn't bound, it must be primitive.
          assert(primitive_types[node.id], 'unknown type: '..node.id)

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -453,7 +453,6 @@ local function init_type(node, loc, argument, children)
    node.length = maybe_child_property(loc, children, 'length', 'value')
    node.patterns = collect_children(children, 'pattern')
    node.enums = collect_children(children, 'enum')
-   node.enumerations = collect_children(children, 'enum')
    -- !!! path
    node.leafref = maybe_child_property(loc, children, 'path', 'value')
    node.require_instances = collect_children(children, 'require-instance')
@@ -709,8 +708,8 @@ function resolve(schema, features)
          node.base_type = typedef
          node.primitive_type = assert(typedef.primitive_type)
          node.enums = {}
-         for _, enum in pairs(typedef.type.enums) do
-            node.enums[enum] = true
+         for _, enum in ipairs(typedef.type.enums) do
+            node.enums[enum.name] = true
          end
       else
          -- If the type name wasn't bound, it must be primitive.

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -404,6 +404,15 @@ local function init_range(node, loc, argument, children)
    node.description = maybe_child_property(loc, children, 'description', 'value')
    node.reference = maybe_child_property(loc, children, 'reference', 'value')
 end
+local function init_enum(node, loc, argument, children)
+   node.value = require_argument(loc, argument)
+   local intvalue = maybe_child_property(loc, children, 'value', 'value')
+   if intvalue then node.intvalue = tonumber(intvalue) end
+   node.description = maybe_child_property(loc, children, 'description', 'value')
+   node.reference = maybe_child_property(loc, children, 'reference', 'value')
+   node.status = maybe_child_property(loc, children, 'status', 'value')
+   node.if_features = collect_child_properties(children, 'if-feature', 'value')
+end
 local function init_refine(node, loc, argument, children)
    node.node_id = require_argument(loc, argument)
    -- All subnode kinds.
@@ -444,6 +453,7 @@ local function init_type(node, loc, argument, children)
    node.length = maybe_child_property(loc, children, 'length', 'value')
    node.patterns = collect_children(children, 'pattern')
    node.enums = collect_children(children, 'enum')
+   node.enumerations = collect_children(children, 'enum')
    -- !!! path
    node.leafref = maybe_child_property(loc, children, 'path', 'value')
    node.require_instances = collect_children(children, 'require-instance')
@@ -537,6 +547,7 @@ declare_initializer(init_output, 'output')
 declare_initializer(init_path, 'path')
 declare_initializer(init_pattern, 'pattern')
 declare_initializer(init_range, 'range')
+declare_initializer(init_enum, 'enum')
 declare_initializer(init_refine, 'refine')
 declare_initializer(init_revision, 'revision')
 declare_initializer(init_rpc, 'rpc')
@@ -697,6 +708,7 @@ function resolve(schema, features)
          typedef = typedef()
          node.base_type = typedef
          node.primitive_type = assert(typedef.primitive_type)
+         node.enums = typedef.type.enums
       else
          -- If the type name wasn't bound, it must be primitive.
          assert(primitive_types[node.id], 'unknown type: '..node.id)


### PR DESCRIPTION
`compile_data_for_schema` (lib/yang/binary.lua) breaks if YANG data contains an enumeration. The problem is that the code expect enumerations to have a ctype. Enumerations should be treated as strings.