### PR TITLE
[YANG] Copy typedef.type.unions to node.unions

### DIFF
--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -705,12 +705,14 @@ function resolve(schema, features)
          -- lookup_lazy because we don't want the pcall to hide errors
          -- from the lazy expansion.
          typedef = typedef()
+         assert(typedef.kind == "typedef")
          node.base_type = typedef
          node.primitive_type = assert(typedef.primitive_type)
          node.enums = {}
          for _, enum in ipairs(typedef.type.enums) do
             node.enums[enum.name] = true
          end
+         node.union = typedef.type.union
       else
          -- If the type name wasn't bound, it must be primitive.
          assert(primitive_types[node.id], 'unknown type: '..node.id)

--- a/src/lib/yang/yang.lua
+++ b/src/lib/yang/yang.lua
@@ -125,9 +125,10 @@ function load_configuration(filename, opts)
                               source_mtime)
    if not success then
       log('error saving compiled configuration %s: %s', compiled_filename, err)
+   else
+      log('wrote compiled configuration %s', compiled_filename)
    end
 
-   log('wrote compiled configuration %s', compiled_filename)
    -- Done.
    return conf
 end


### PR DESCRIPTION
Consider the following schema:

```
typedef type1 {
   type union {
     type string;
     type int;
   }
}

leaf node {
   type type1;
}
```

node.unions is empty when it should include {string, int}. It's necessary to copy typedef.type.unions to node.union.

The PR also include a commit that fixes a print out message.