### PR TITLE
[YANG] Fix 'uses' expand

### DIFF
--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -182,7 +182,7 @@ function data_grammar_from_schema(schema)
       local members=visit_body(node)
       local keys, values = {}, {}
       if node.key then
-         for k in node.key:split(' +') do keys[k] = assert(members[k]) end
+         for k in node.key:split(' +') do keys[k] = assert(members[k], node.key) end
       end
       for k,v in pairs(members) do
          if not keys[k] then values[k] = v end

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -794,18 +794,19 @@ function resolve(schema, features)
          end
       end
       if node.body then
-         node.body = shallow_copy(node.body)
-         for k,v in pairs(node.body or {}) do
+         local body = node.body
+         node.body = {}
+         for k,v in pairs(body) do
             if v.kind == 'uses' then
                -- Inline "grouping" into "uses".
                local grouping = lookup_lazy(env, 'groupings', v.id)
-               node.body[k] = nil
                for k,v in pairs(grouping.body) do
                   assert(not node.body[k], 'duplicate identifier: '..k)
                   node.body[k] = v
                end
                -- TODO: Handle refine and augment statements.
             else
+               assert(not node.body[k], 'duplicate identifier: '..k)
                node.body[k] = visit(v, env)
             end
          end

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -96,7 +96,7 @@ function types.identityref.tostring(val)
 end
 
 types['instance-identifier'] = unimplemented('instance-identifier')
-leafref = unimplemented('leafref')
+types.leafref = unimplemented('leafref')
 
 types.string = {}
 function types.string.parse(str, what)


### PR DESCRIPTION
There's an error when parsing an alarms file instance. The parsing returns an assert break in core/main.lua. Deactivating the global assert shows the error is in lib/yang/data.lua.

test case (test.lua)

```lua
module(..., package.seeall)

local yang = require("lib.yang.yang")
local data = require("lib.yang.data")

local function load_conf (conf)
   local loaded_schema = yang.load_schema_by_name('ietf-alarms')
   local grammar = data.data_grammar_from_schema(loaded_schema)
   local parse = data.data_parser_from_grammar(grammar)
   return parse(conf)
end

local conf = [[ 
   alarms {
      summary {
         alarm-summary {
            total 50;
            severity minor;
         }
      }
   }
]]

function selftest (args)
   local obj = load_conf(conf)
   assert(obj)
   print("selftest: ok") 
end
```

```bash
$ sudo ./snabb snsh -t test
lib/yang/data.lua:185: time
stack traceback:
        core/main.lua:151: in function <core/main.lua:149>
        [C]: in function 'assert'
        lib/yang/data.lua:185: in function 'visit'
```

It seems the problem is in the list `operator-state-change`, the data complains it lacks leaf `time` which is part of the key. The leaf should be included in the node via an uses clause. Here's the relevant ietf-alarms.yang part:

```yang
list operator-state-change {
   if-feature operator-actions;
   key time;
   description
      "This list is used by operators to indicate
      the state of human intervention on an alarm.
      For example, if an operator has seen an alarm,
          the operator can add a new item to this list indicating
             that the alarm is acknowledged.";
   uses operator-parameters;
}
```

After debugging the issue I found out the problem is that when iterating an `alarm` node it includes all the properties defined within the node, including `operator-state-change`. However, during the loop the `operator-state-change` property is skipped so it `uses` attribute is not expanded, thus the `time` leaf is not included in the operator-state-change body.

At first I fixed this issue by renaming `operator-state-change` to another name (there's another `operator-state-change` defined in the document). In this patch what I did was copying the node keys to a new array and iterating over them. The loop modifies the node contents, like it removes some of the node keys and values and insert new ones. I think that affects the iteration of the elements (like in Java where you cannot add or remove elements to a collection while iterating over it). This patch fixes the issue, although I do not completely understand why and I haven't managed to isolate the bug in a simpler case.