### PR TITLE
Remove backpressure from IPv4 ping responder

### DIFF
--- a/src/apps/lwaftr/ipv4_apps.lua
+++ b/src/apps/lwaftr/ipv4_apps.lua
@@ -55,7 +55,7 @@ function Reassembler:push ()
    local input, output = self.input.input, self.output.output
    local errors = self.output.errors
 
-   for _ = 1, math.min(link.nreadable(input), link.nwritable(output)) do
+   for _ = 1, link.nreadable(input) do
       local pkt = receive(input)
       if is_ipv4_fragment(pkt) then
          counter.add(self.counters["in-ipv4-frag-needs-reassembly"])


### PR DESCRIPTION
This PR optimizes packet flow a bit in the lwAFTR, bypassing the ping responder function on the way out, and removing backpressure in the ping responders.  Waiting on perf results until snabb1 gets wired in the expected way :/