### PR TITLE
Print out schema name in leader processes

### DIFF
--- a/src/program/ps/ps.lua
+++ b/src/program/ps/ps.lua
@@ -3,9 +3,10 @@
 module(..., package.seeall)
 
 local S = require("syscall")
+local app = require("core.app")
+local common = require("program.config.common")
 local lib = require("core.lib")
 local shm = require("core.shm")
-local app = require("core.app")
 
 local basename, dirname = lib.basename, lib.dirname
 
@@ -68,6 +69,8 @@ local function compute_snabb_instances()
          end
          if is_addressable(p) then
             instance.addressable = true
+            local descr = common.call_leader(p, 'describe', {})
+            instance.schema = descr.native_schema
          end
          table.insert(pids, instance)
       end
@@ -93,6 +96,9 @@ function run (args)
       end
       if instance.addressable then
          io.write(" *")
+      end
+      if instance.schema then
+         io.write(" [schema: "..instance.schema.."]")
       end
       io.write("\n")
    end


### PR DESCRIPTION
Fixes #836.

Instead of adding a knob to `snabb ps` to filter by schema name, when I did instead is to print out schema name in leader processes. Using standard linux grep would possible to filter out by schema name. Another advantage of printing out schema name always, it's to figure out what the correct schema name.

Example of use:

```bash
$ sudo ./snabb ps | grep -A 1 snabb-softwire-v2
9777 * [schema: snabb-softwire-v2]
  \- 9779   worker for 9777
```
