### PR TITLE
Print out snabb config get output in XPath format

### DIFF
--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -138,7 +138,7 @@ end
 function Leader:rpc_get_config (args)
    local function getter()
       if args.schema ~= self.schema_name then
-         return self:foreign_rpc_get_config(args.schema, args.path)
+         return self:foreign_rpc_get_config(args.schema, args.path, args)
       end
       local printer = path_printer_for_schema_by_name(args.schema, args.path, args)
       local config = printer(self.current_configuration, yang.string_output_file())
@@ -445,20 +445,20 @@ function Leader:apply_translated_rpc_updates (updates)
    end
    return {}
 end
-function Leader:foreign_rpc_get_config (schema_name, path, print_default)
+function Leader:foreign_rpc_get_config (schema_name, path, args)
    path = path_mod.normalize_path(path)
    local translate = self:get_translator(schema_name)
    local foreign_config = translate.get_config(self.current_configuration)
-   local printer = path_printer_for_schema_by_name(schema_name, path, print_default)
+   local printer = path_printer_for_schema_by_name(schema_name, path, args)
    local config = printer(foreign_config, yang.string_output_file())
    return { config = config }
 end
-function Leader:foreign_rpc_get_state (schema_name, path, print_default)
+function Leader:foreign_rpc_get_state (schema_name, path, args)
    path = path_mod.normalize_path(path)
    local translate = self:get_translator(schema_name)
    local native_state = state.show_state(self.schema_name, S.getpid(), "/")
    local foreign_state = translate.get_state(native_state)
-   local printer = path_printer_for_schema_by_name(schema_name, path, print_default)
+   local printer = path_printer_for_schema_by_name(schema_name, path, args)
    local config = printer(foreign_state, yang.string_output_file())
    return { state = config }
 end
@@ -543,9 +543,9 @@ end
 function Leader:rpc_get_state (args)
    local function getter()
       if args.schema ~= self.schema_name then
-            return self:foreign_rpc_get_state(args.schema, args.path)
+            return self:foreign_rpc_get_state(args.schema, args.path, args)
       end
-      local printer = path_printer_for_schema_by_name(self.schema_name, args.path, args.print_default)
+      local printer = path_printer_for_schema_by_name(self.schema_name, args.path, args)
       local s = {}
       for _, follower in pairs(self.followers) do
          for k,v in pairs(state.show_state(self.schema_name, follower.pid, args.path)) do

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -117,7 +117,7 @@ end
 local function path_printer_for_grammar(grammar, path, opts)
    local getter, subgrammar = path_mod.resolver(grammar, path)
    local printer
-   if opts.xpath_format then
+   if opts.format == "xpath" then
       printer = data.xpath_printer_from_grammar(subgrammar, opts.print_default, path)
    else
       printer = data.data_printer_from_grammar(subgrammar, opts.print_default)

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -788,8 +788,8 @@ function xpath_printer_from_grammar(production, print_default, root)
    end
    function handlers.struct(keyword, production)
       local print_body = body_printer(production.members)
-      return function(data, file, indent)
-         print_body(data, file, indent)
+      return function(data, file, path)
+         print_body(data, file, path..keyword..'/')
       end
    end
    function handlers.array(keyword, production)

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -762,10 +762,10 @@ function xpath_printer_from_grammar(production, print_default, root)
          local ret = {}
          for i=1,#self.t,2 do
             local key, value = self.t[i], self.t[i+1]
-            table.insert(ret, key.."="..value)
+            table.insert(ret, '['..key.."="..value..']')
          end
          self.t = {}
-         return table.concat(ret, ";")
+         return table.concat(ret, '')
       end
       return function (data, path)
          path = path or ''
@@ -812,7 +812,7 @@ function xpath_printer_from_grammar(production, print_default, root)
          return function(data, file, path)
             for entry in data:iterate() do
                local key = compose_key(entry.key)
-               print_value(entry.value, file, path..'['..key..']/')
+               print_value(entry.value, file, keyword..key..'/')
             end
          end
       elseif production.string_key then
@@ -820,21 +820,21 @@ function xpath_printer_from_grammar(production, print_default, root)
          return function(data, file, path)
             for key, value in pairs(data) do
                local key = compose_key({[id]=key})
-               print_value(value, file, path..'['..key..']/')
+               print_value(value, file, keyword..key..'/')
             end
          end
       elseif production.key_ctype then
          return function(data, file, path)
             for key, value in cltable.pairs(data) do
                local key = compose_key(key)
-               print_value(value, file, path..'['..key..']/')
+               print_value(value, file, keyword..key..'/')
             end
          end
       else
          return function(data, file, path)
             for key, value in pairs(data) do
                print_key(key, file, path..'/')
-               print_value(value, file, path..'['..key..']/')
+               print_value(value, file, keyword..key..'/')
             end
          end
       end

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -892,9 +892,13 @@ function xpath_printer_from_grammar(production, print_default, root)
    function top_printers.array(production)
       local serialize = value_serializer(production.element_type)
       return function(data, file, indent)
+         local count = 1
          for _,v in ipairs(data) do
+            file:write(root.."[position()="..count.."]")
+            file:write(' ')
             file:write(serialize(v))
-            file:write('\n')
+            file:write(';\n')
+            count = count + 1
          end
          return file:flush()
       end
@@ -902,10 +906,14 @@ function xpath_printer_from_grammar(production, print_default, root)
    function top_printers.scalar(production)
       local serialize = value_serializer(production.argument_type)
       return function(data, file)
+         file:write(root)
+         file:write(' ')
          file:write(serialize(data))
+         file:write(';\n')
          return file:flush()
       end
    end
+
    return assert(top_printers[production.type])(production)
 end
 xpath_printer_from_grammar = util.memoize(xpath_printer_from_grammar)

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -906,11 +906,14 @@ function xpath_printer_from_grammar(production, print_default, root)
    function top_printers.scalar(production)
       local serialize = value_serializer(production.argument_type)
       return function(data, file)
-         file:write(root)
-         file:write(' ')
-         file:write(serialize(data))
-         file:write(';\n')
-         return file:flush()
+         local str = serialize(data)
+         if print_default or str ~= production.default then
+            file:write(root)
+            file:write(' ')
+            file:write(str)
+            file:write(';\n')
+            return file:flush()
+         end
       end
    end
 

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -799,7 +799,7 @@ function xpath_printer_from_grammar(production, print_default, root)
          for _,v in ipairs(data) do
             print_keyword(keyword.."[position()="..count.."]", file, '')
             file:write(serialize(v))
-            file:write(';\n')
+            file:write('\n')
             count = count + 1
          end
       end
@@ -856,7 +856,7 @@ function xpath_printer_from_grammar(production, print_default, root)
          if print_default or str ~= production.default then
             print_keyword(keyword, file, path)
             file:write(str)
-            file:write(';\n')
+            file:write('\n')
          end
       end
    end
@@ -897,7 +897,7 @@ function xpath_printer_from_grammar(production, print_default, root)
             file:write(root.."[position()="..count.."]")
             file:write(' ')
             file:write(serialize(v))
-            file:write(';\n')
+            file:write('\n')
             count = count + 1
          end
          return file:flush()
@@ -911,7 +911,7 @@ function xpath_printer_from_grammar(production, print_default, root)
             file:write(root)
             file:write(' ')
             file:write(str)
-            file:write(';\n')
+            file:write('\n')
             return file:flush()
          end
       end

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -795,10 +795,12 @@ function xpath_printer_from_grammar(production, print_default, root)
    function handlers.array(keyword, production)
       local serialize = value_serializer(production.element_type)
       return function(data, file, indent)
+         local count = 1
          for _,v in ipairs(data) do
-            print_keyword(keyword, file, indent)
+            print_keyword(keyword.."[position()="..count.."]", file, '')
             file:write(serialize(v))
             file:write(';\n')
+            count = count + 1
          end
       end
    end

--- a/src/lib/yang/snabb-config-leader-v1.yang
+++ b/src/lib/yang/snabb-config-leader-v1.yang
@@ -39,6 +39,7 @@ module snabb-config-leader-v1 {
       leaf revision { type string; }
       leaf path { type string; default "/"; }
       leaf print-default { type boolean; }
+      leaf xpath-format { type boolean; }
     }
     output {
       uses error-reporting;
@@ -87,6 +88,7 @@ module snabb-config-leader-v1 {
       leaf revision { type string; }
       leaf path { type string; default "/"; }
       leaf print-default { type boolean; }
+      leaf xpath-format { type boolean; }
     }
     output {
       uses error-reporting;

--- a/src/lib/yang/snabb-config-leader-v1.yang
+++ b/src/lib/yang/snabb-config-leader-v1.yang
@@ -39,7 +39,7 @@ module snabb-config-leader-v1 {
       leaf revision { type string; }
       leaf path { type string; default "/"; }
       leaf print-default { type boolean; }
-      leaf xpath-format { type boolean; }
+      leaf format { type string; }
     }
     output {
       uses error-reporting;
@@ -88,7 +88,7 @@ module snabb-config-leader-v1 {
       leaf revision { type string; }
       leaf path { type string; default "/"; }
       leaf print-default { type boolean; }
-      leaf xpath-format { type boolean; }
+      leaf format { type string; }
     }
     output {
       uses error-reporting;

--- a/src/program/config/README.md
+++ b/src/program/config/README.md
@@ -135,11 +135,12 @@ In the example above, attributes sucha as `period` and `mtu` take their
 default values.  They wouldn't be printed out unless `--print-default`
 was used.
 
-In addition, it's possible to print output in XPath format.  When `--xpath-format`
-is selected, every attribute is printed as an absolute path.  Example:
+In addition, it is possible to print output in two different formats:
+Yang or XPath.  By default, output is printed in Yang format.  Here is an
+example for XPath formatted output:
 
 ```
-$ sudo ./snabb config get --xpath-format lwaftr2 /softwire-config/external-interface
+$ sudo ./snabb config get --format=xpath ID /softwire-config/external-interface
 /softwire-config/external-interface/allow-incoming-icmp false;
 /softwire-config/external-interface/error-rate-limiting/packets 600000;
 /softwire-config/external-interface/ip 10.10.10.10;

--- a/src/program/config/README.md
+++ b/src/program/config/README.md
@@ -135,6 +135,19 @@ In the example above, attributes sucha as `period` and `mtu` take their
 default values.  They wouldn't be printed out unless `--print-default`
 was used.
 
+In addition, it's possible to print output in XPath format.  When `--xpath-format`
+is selected, every attribute is printed as an absolute path.  Example:
+
+```
+$ sudo ./snabb config get --xpath-format lwaftr2 /softwire-config/external-interface
+/softwire-config/external-interface/allow-incoming-icmp false;
+/softwire-config/external-interface/error-rate-limiting/packets 600000;
+/softwire-config/external-interface/ip 10.10.10.10;
+/softwire-config/external-interface/mac 12:12:12:12:12:12;
+/softwire-config/external-interface/next-hop/mac 68:68:68:68:68:68;
+/softwire-config/external-interface/reassembly/max-fragments-per-packet 40;
+```
+
 Users can limit their query to a particular subtree via passing a
 different `PATH`.  For example, with the same configuration, we can
 query just the `active` value:

--- a/src/program/config/common.lua
+++ b/src/program/config/common.lua
@@ -53,6 +53,7 @@ function parse_command_line(args, opts)
    local function err(msg) show_usage(opts.command, 1, msg) end
    local ret = {
       print_default = false,
+      xpath_format = false,
    }
    local handlers = {}
    function handlers.h() show_usage(opts.command, 0) end
@@ -62,10 +63,13 @@ function parse_command_line(args, opts)
    handlers['print-default'] = function ()
       ret.print_default = true
    end
+   handlers['xpath-format'] = function ()
+      ret.xpath_format = true
+   end
    args = lib.dogetopt(args, handlers, "hs:r:c:",
                        {help="h", ['schema-name']="s", schema="s",
                         ['revision-date']="r", revision="r", socket="c",
-                        ['print-default']=0})
+                        ['print-default']=0, ['xpath-format']=0})
    if #args == 0 then err() end
    ret.instance_id = table.remove(args, 1)
    local descr = call_leader(ret.instance_id, 'describe', {})

--- a/src/program/config/common.lua
+++ b/src/program/config/common.lua
@@ -53,23 +53,24 @@ function parse_command_line(args, opts)
    local function err(msg) show_usage(opts.command, 1, msg) end
    local ret = {
       print_default = false,
-      xpath_format = false,
+      format = "yang",
    }
    local handlers = {}
    function handlers.h() show_usage(opts.command, 0) end
    function handlers.s(arg) ret.schema_name = arg end
    function handlers.r(arg) ret.revision_date = arg end
    function handlers.c(arg) ret.socket = arg end
+   function handlers.f(arg)
+      assert(arg == "yang" or arg == "xpath", "Not valid output format")
+      ret.format = arg
+   end
    handlers['print-default'] = function ()
       ret.print_default = true
    end
-   handlers['xpath-format'] = function ()
-      ret.xpath_format = true
-   end
-   args = lib.dogetopt(args, handlers, "hs:r:c:",
+   args = lib.dogetopt(args, handlers, "hs:r:c:f:",
                        {help="h", ['schema-name']="s", schema="s",
                         ['revision-date']="r", revision="r", socket="c",
-                        ['print-default']=0, ['xpath-format']=0})
+                        ['print-default']=0, format="f"})
    if #args == 0 then err() end
    ret.instance_id = table.remove(args, 1)
    local descr = call_leader(ret.instance_id, 'describe', {})

--- a/src/program/config/get/README
+++ b/src/program/config/get/README
@@ -4,8 +4,8 @@ Get the configuration for a Snabb network function.
 Available options:
   -s, --schema SCHEMA        YANG data interface to request.
   -r, --revision REVISION    Require a specific revision of the YANG module.
+  -f, --format               Selects output format (yang or xpath). Default: yang.
       --print-default        Forces print out of default values.
-      --xpath-format         Prints output in XPath format.
   -h, --help                 Display this message.
 
 If the --schema argument is not provided, "snabb config" will ask the

--- a/src/program/config/get/README
+++ b/src/program/config/get/README
@@ -5,6 +5,7 @@ Available options:
   -s, --schema SCHEMA        YANG data interface to request.
   -r, --revision REVISION    Require a specific revision of the YANG module.
       --print-default        Forces print out of default values.
+      --xpath-format         Prints output in XPath format.
   -h, --help                 Display this message.
 
 If the --schema argument is not provided, "snabb config" will ask the

--- a/src/program/config/get/get.lua
+++ b/src/program/config/get/get.lua
@@ -8,6 +8,7 @@ function run(args)
    local response = common.call_leader(
       args.instance_id, 'get-config',
       { schema = args.schema_name, revision = args.revision_date,
-        path = args.path, print_default = args.print_default })
+        path = args.path, print_default = args.print_default,
+        xpath_format = args.xpath_format })
    common.print_and_exit(response, "config")
 end

--- a/src/program/config/get/get.lua
+++ b/src/program/config/get/get.lua
@@ -9,6 +9,6 @@ function run(args)
       args.instance_id, 'get-config',
       { schema = args.schema_name, revision = args.revision_date,
         path = args.path, print_default = args.print_default,
-        xpath_format = args.xpath_format })
+        format = args.format })
    common.print_and_exit(response, "config")
 end

--- a/src/program/config/get_state/README
+++ b/src/program/config/get_state/README
@@ -4,8 +4,8 @@ Get the state for a Snabb network function.
 Available options:
   -s, --schema SCHEMA        YANG data interface to request.
   -r, --revision REVISION    Require a specific revision of the YANG module.
+  -f, --format               Selects output format (yang or xpath). Default: yang.
       --print-default        Forces print out of default values.
-      --xpath-format         Prints output in XPath format.
   -h, --help                 Displays this message.
 
 Given an instance identifier and a schema path, display the current counter

--- a/src/program/config/get_state/README
+++ b/src/program/config/get_state/README
@@ -5,6 +5,7 @@ Available options:
   -s, --schema SCHEMA        YANG data interface to request.
   -r, --revision REVISION    Require a specific revision of the YANG module.
       --print-default        Forces print out of default values.
+      --xpath-format         Prints output in XPath format.
   -h, --help                 Displays this message.
 
 Given an instance identifier and a schema path, display the current counter

--- a/src/program/config/get_state/get_state.lua
+++ b/src/program/config/get_state/get_state.lua
@@ -8,6 +8,7 @@ function run(args)
 	local response = common.call_leader(
    	args.instance_id, 'get-state',
       { schema = args.schema_name, revision = args.revision_date,
-        path = args.path, print_default = args.print_default })
+        path = args.path, print_default = args.print_default,
+        xpath_format = args.xpath_format })
 	common.print_and_exit(response, "state")
 end

--- a/src/program/config/get_state/get_state.lua
+++ b/src/program/config/get_state/get_state.lua
@@ -9,6 +9,6 @@ function run(args)
    	args.instance_id, 'get-state',
       { schema = args.schema_name, revision = args.revision_date,
         path = args.path, print_default = args.print_default,
-        xpath_format = args.xpath_format })
+        format = args.format })
 	common.print_and_exit(response, "state")
 end


### PR DESCRIPTION
Fixed #837 . I'm not sure whether this is the best approach. Basically it transforms a standard output to an xpath output. 

The PR doesn't tackle Mislav's suggest to print out default values (this could be a different issue).

Example:

```
$ sudo ./snabb config get 2419 /softwire-config/external-interface
allow-incoming-icmp false;
error-rate-limiting {
  packets 600000;
}
generate-icmp-errors false;
ip 10.0.1.1;
mac 02:aa:aa:aa:aa:aa;
next-hop {
  mac 02:99:99:99:99:99;
}
reassembly {
  max-fragments-per-packet 40;
}
```

```bash
$ sudo ./snabb config get --xpath-format 2419 /softwire-config/external-interface                                                                    
/allow-incoming-icmp false
/error-rate-limiting/packets 600000
/generate-icmp-errors false
/ip 10.0.1.1
/mac 02:aa:aa:aa:aa:aa
/next-hop/mac 02:99:99:99:99:99
/reassembly/max-fragments-per-packet 40
```