### PR TITLE
Add option to print out default values in 'config get' and 'config get-state'

### DIFF
--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -701,7 +701,7 @@ local function value_serializer(typ)
    return serializer
 end
 
-function data_printer_from_grammar(production)
+function data_printer_from_grammar(production, print_default)
    local handlers = {}
    local translators = {}
    local function printer(keyword, production, printers)
@@ -834,7 +834,7 @@ function data_printer_from_grammar(production)
       local serialize = value_serializer(production.argument_type)
       return function(data, file, indent)
          local str = serialize(data)
-         if str ~= production.default then
+         if print_default or str ~= production.default then
             print_keyword(keyword, file, indent)
             file:write(str)
             file:write(';\n')

--- a/src/lib/yang/snabb-config-leader-v1.yang
+++ b/src/lib/yang/snabb-config-leader-v1.yang
@@ -38,6 +38,7 @@ module snabb-config-leader-v1 {
       leaf schema { type string; mandatory true; }
       leaf revision { type string; }
       leaf path { type string; default "/"; }
+      leaf print-default { type boolean; }
     }
     output {
       uses error-reporting;
@@ -85,6 +86,7 @@ module snabb-config-leader-v1 {
       leaf schema { type string; mandatory true; }
       leaf revision { type string; }
       leaf path { type string; default "/"; }
+      leaf print-default { type boolean; }
     }
     output {
       uses error-reporting;

--- a/src/program/config/README.md
+++ b/src/program/config/README.md
@@ -106,6 +106,35 @@ and the YANG schema quoting rules for strings apply.
 So indeed, `snabb config get ID /` might print out just the output given
 above.
 
+By default, `snabb config get` does not print out attributes which
+value is the default value.  To print out all attributes, including those
+which value is the default, use the knob `--print-default`.  This
+knob is also available in `snabb config get-state`.  Example:
+
+```
+$ snabb config get --print-default ID /softwire-config/external-interace
+allow-incoming-icmp false;
+error-rate-limiting {
+  packets 600000;
+  period 2;
+}
+generate-icmp-errors true;
+ip 10.10.10.10;
+mac 12:12:12:12:12:12;
+mtu 1460;
+next-hop {
+  mac 68:68:68:68:68:68;
+}
+reassembly {
+  max-fragments-per-packet 40;
+  max-packets 20000;
+}
+```
+
+In the example above, attributes sucha as `period` and `mtu` take their
+default values.  They wouldn't be printed out unless `--print-default`
+was used.
+
 Users can limit their query to a particular subtree via passing a
 different `PATH`.  For example, with the same configuration, we can
 query just the `active` value:

--- a/src/program/config/common.lua
+++ b/src/program/config/common.lua
@@ -51,15 +51,21 @@ end
 function parse_command_line(args, opts)
    opts = lib.parse(opts, parse_command_line_opts)
    local function err(msg) show_usage(opts.command, 1, msg) end
-   local ret = {}
+   local ret = {
+      print_default = false,
+   }
    local handlers = {}
    function handlers.h() show_usage(opts.command, 0) end
    function handlers.s(arg) ret.schema_name = arg end
    function handlers.r(arg) ret.revision_date = arg end
    function handlers.c(arg) ret.socket = arg end
+   handlers['print-default'] = function ()
+      ret.print_default = true
+   end
    args = lib.dogetopt(args, handlers, "hs:r:c:",
                        {help="h", ['schema-name']="s", schema="s",
-                        ['revision-date']="r", revision="r", socket="c"})
+                        ['revision-date']="r", revision="r", socket="c",
+                        ['print-default']=0})
    if #args == 0 then err() end
    ret.instance_id = table.remove(args, 1)
    local descr = call_leader(ret.instance_id, 'describe', {})

--- a/src/program/config/get/README
+++ b/src/program/config/get/README
@@ -4,6 +4,7 @@ Get the configuration for a Snabb network function.
 Available options:
   -s, --schema SCHEMA        YANG data interface to request.
   -r, --revision REVISION    Require a specific revision of the YANG module.
+      --print-default        Forces print out of default values.
   -h, --help                 Display this message.
 
 If the --schema argument is not provided, "snabb config" will ask the

--- a/src/program/config/get/get.lua
+++ b/src/program/config/get/get.lua
@@ -8,6 +8,6 @@ function run(args)
    local response = common.call_leader(
       args.instance_id, 'get-config',
       { schema = args.schema_name, revision = args.revision_date,
-        path = args.path })
+        path = args.path, print_default = args.print_default })
    common.print_and_exit(response, "config")
 end

--- a/src/program/config/get_state/README
+++ b/src/program/config/get_state/README
@@ -4,6 +4,7 @@ Get the state for a Snabb network function.
 Available options:
   -s, --schema SCHEMA        YANG data interface to request.
   -r, --revision REVISION    Require a specific revision of the YANG module.
+      --print-default        Forces print out of default values.
   -h, --help                 Displays this message.
 
 Given an instance identifier and a schema path, display the current counter

--- a/src/program/config/get_state/get_state.lua
+++ b/src/program/config/get_state/get_state.lua
@@ -8,6 +8,6 @@ function run(args)
 	local response = common.call_leader(
    	args.instance_id, 'get-state',
       { schema = args.schema_name, revision = args.revision_date,
-        path = args.path })
+        path = args.path, print_default = args.print_default })
 	common.print_and_exit(response, "state")
 end


### PR DESCRIPTION
I split #843 and pushed in this PR only the changes relative to printing out default values for `config get` and `config get-statep`. The comments from #843 relative to this default values are already tackled in this PR.