### PR TITLE
Add Snabbwall copyright notice

### DIFF
--- a/src/program/wall/COPYRIGHT.md
+++ b/src/program/wall/COPYRIGHT.md
@@ -1,0 +1,4 @@
+Copyright: 2017, Igalia and the Snabb project.
+License: See COPYING.
+
+Snabbwall development has been kindly funded by NLnet Foundation (https://nlnet.nl/).


### PR DESCRIPTION
NLnet foundation asked us to include copyright notices in Snabbwall source code. As per-file copyright notices are forbidden in Snabb (See CONTRIBUTING.md) a COPYRIGHT.md file has been included in Snabbwall module (src/program/wall). After online discussion in Slack with Luke Gorrie, we agreed on using COPYRIGHT.md to additionally give credit to Nlnet as the initial sponsors of Snabbwall.