### PR TITLE
Stop the lwaftr monitor test from hanging

### DIFF
--- a/src/program/lwaftr/tests/selftest.sh
+++ b/src/program/lwaftr/tests/selftest.sh
@@ -6,18 +6,18 @@
 export TESTS_DIR=`dirname "$0"`
 export PYTHONPATH=${TESTS_DIR}
 
-# Only run tests in the chosen test file (without the _test.py suffix).
+# Only run tests in the passed subdirectory of $TESTS_DIR.
 if [[ -n $1 ]]; then
-    TEST_WHAT=$1
+    START_DIR=${TESTS_DIR}/$1/
 else
-    TEST_WHAT="*"
+    START_DIR=${TESTS_DIR}
 fi
 
-# Start discovery from this script's directory, the root of the "tests" subtree.
-# Look for unittests in all files whose name ends with "_test.py", or just one
-# of them, if its prefix (without _test.py) was passed as first argument.
+# Start discovery from this script's directory, the root of the "tests" subtree,
+# or one of its subdirectories, if passed as first argument to this script.
+# Look for unittests in all files whose name ends with "_test.py".
 # List all executed tests, don't show just dots.
 python3 -m unittest discover \
-    --start-directory "${TESTS_DIR}" \
-    --pattern "${TEST_WHAT}_test.py" \
+    --start-directory "${START_DIR}" \
+    --pattern "*_test.py" \
     --verbose

--- a/src/program/lwaftr/tests/selftest.sh
+++ b/src/program/lwaftr/tests/selftest.sh
@@ -13,9 +13,9 @@ else
     TEST_WHAT="*"
 fi
 
-# Start discovery from this script's directory, the root of the "tests" subtree,
-# or one of its subdirectories, if passed as first argument to this script.
-# Look for unittests in all files whose name ends with "_test.py".
+# Start discovery from this script's directory, the root of the "tests" subtree.
+# Look for unittests in all files whose name ends with "_test.py", or just one
+# of them, if its prefix (without _test.py) was passed as first argument.
 # List all executed tests, don't show just dots.
 python3 -m unittest discover \
     --start-directory "${TESTS_DIR}" \

--- a/src/program/lwaftr/tests/selftest.sh
+++ b/src/program/lwaftr/tests/selftest.sh
@@ -6,11 +6,11 @@
 export TESTS_DIR=`dirname "$0"`
 export PYTHONPATH=${TESTS_DIR}
 
-# Only run tests in the passed subdirectory of $TESTS_DIR.
+# Only run tests in the chosen test file (without the _test.py suffix).
 if [[ -n $1 ]]; then
-    START_DIR=${TESTS_DIR}/$1/
+    TEST_WHAT=$1
 else
-    START_DIR=${TESTS_DIR}
+    TEST_WHAT="*"
 fi
 
 # Start discovery from this script's directory, the root of the "tests" subtree,
@@ -18,6 +18,6 @@ fi
 # Look for unittests in all files whose name ends with "_test.py".
 # List all executed tests, don't show just dots.
 python3 -m unittest discover \
-    --start-directory "${START_DIR}" \
-    --pattern "*_test.py" \
+    --start-directory "${TESTS_DIR}" \
+    --pattern "${TEST_WHAT}_test.py" \
     --verbose

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -12,6 +12,7 @@ import unittest
 from test_env import DATA_DIR, SNABB_CMD, BaseTestCase, nic_names
 
 
+DAEMON_PROC_NAME = 'monitor_test_daemon'
 SNABB_PCI0 = nic_names()[0]
 
 
@@ -20,12 +21,14 @@ class TestMonitor(BaseTestCase):
 
     daemon_args = [
         str(SNABB_CMD), 'lwaftr', 'run',
+        '--name', DAEMON_PROC_NAME,
         '--bench-file', '/dev/null',
         '--conf', str(DATA_DIR / 'icmp_on_fail.conf'),
         '--on-a-stick', SNABB_PCI0,
         '--mirror',  # TAP interface name added in setUpClass.
     ]
-    monitor_args = (str(SNABB_CMD), 'lwaftr', 'monitor', 'all')
+    monitor_args = (
+        str(SNABB_CMD), 'lwaftr', 'monitor', '--name', DAEMON_PROC_NAME, 'all')
 
     # Use setUpClass to only setup the daemon once for all tests.
     @classmethod
@@ -44,9 +47,7 @@ class TestMonitor(BaseTestCase):
             raise
 
     def test_monitor(self):
-        monitor_args = list(self.monitor_args)
-        monitor_args.append(str(self.daemon.pid))
-        output = self.run_cmd(monitor_args)
+        output = self.run_cmd(self.monitor_args)
         self.assertIn(b'Mirror address set', output,
             b'\n'.join((b'OUTPUT', output)))
         self.assertIn(b'255.255.255.255', output,

--- a/src/program/lwaftr/tests/subcommands/monitor_test.py
+++ b/src/program/lwaftr/tests/subcommands/monitor_test.py
@@ -12,7 +12,7 @@ import unittest
 from test_env import DATA_DIR, SNABB_CMD, BaseTestCase, nic_names
 
 
-DAEMON_PROC_NAME = 'monitor_test_daemon'
+DAEMON_PROC_NAME = 'monitor-test-daemon'
 SNABB_PCI0 = nic_names()[0]
 
 

--- a/src/program/lwaftr/tests/test_env.py
+++ b/src/program/lwaftr/tests/test_env.py
@@ -77,8 +77,9 @@ class BaseTestCase(unittest.TestCase):
         try:
             output, errput = proc.communicate(timeout=COMMAND_TIMEOUT)
         except TimeoutExpired:
+            print('\nTimeout running command, trying to kill PID %s' % proc.pid)
             proc.kill()
-            proc.communicate()
+            raise
         if proc.returncode != 0:
             msg_lines = (
                 'Error running command:', str(args),


### PR DESCRIPTION
When the `lwaftr monitor` test fails, it hangs, stopping test execution: make it fail after timeout instead.

Additionally, make the test use the lwaftr process name rather than the PID.

As to why it fails on bare metal and not in a VM, it's still not clear.