### PR TITLE
Improve the generate-binding-table test

### DIFF
--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -14,7 +14,7 @@ import unittest
 from test_env import BENCHDATA_DIR, DATA_DIR, ENC, SNABB_CMD, BaseTestCase
 
 
-DAEMON_PROC_NAME = 'config_test_daemon'
+DAEMON_PROC_NAME = 'config-test-daemon'
 DAEMON_ARGS = (
     str(SNABB_CMD), 'lwaftr', 'bench', '--reconfigurable',
     '--bench-file', '/dev/null',

--- a/src/program/lwaftr/tests/subcommands/generate_binding_table_test.py
+++ b/src/program/lwaftr/tests/subcommands/generate_binding_table_test.py
@@ -4,52 +4,45 @@ need NICs as it doesn't use any network functionality. The command is
 just to produce a binding table config result.
 """
 
-from subprocess import Popen, PIPE
+from test_env import ENC, SNABB_CMD, BaseTestCase
 
-from test_env import SNABB_CMD, BaseTestCase
+NUM_SOFTWIRES = 10
+
 
 class TestGenerateBindingTable(BaseTestCase):
 
-    generation_args = (str(SNABB_CMD), "lwaftr", "generate-binding-table")
-
+    generation_args = (
+        str(SNABB_CMD), 'lwaftr', 'generate-binding-table', '193.5.1.100',
+        str(NUM_SOFTWIRES), 'fc00::100', 'fc00:1:2:3:4:5:0:7e', '1')
 
     def test_binding_table_generation(self):
         """
         This runs the generate-binding-table subcommand and verifies that
-        it gets the number of softwires it expects back.
+        it gets back the number of softwires it expects.
 
-        Usage can be found in the README however, it's:
+        Usage can be found in the README; however, it's:
 
         <ipv4> <num_ipv4s> <br_address> <b4> <psid_len> <shift>
         """
-        # Build the generate-binding-table command.
-        cmd = list(self.generation_args)
-        num = 10
-        cmd.extend(
-            ("193.5.1.100", str(num), "fc00::100", "fc00:1:2:3:4:5:0:7e", "1")
-        )
+        # Get generate-binding-table command output.
+        output = self.run_cmd(self.generation_args)
 
-        # Execute the command.
-        generation_proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+        # Split it into lines.
+        config = str(output, ENC).split('\n')[:-1]
 
-        # Wait until it's finished.
-        generation_proc.wait()
+        # The output should be "binding-table {" followed by NUM_SOFTWIRES
+        # softwires, then "}".
+        self.assertIn('binding-table {', config[0],
+            'Start line: %s' % config[0])
 
-        # Check the status code is okay.
-        self.assertEqual(generation_proc.returncode, 0)
+        for idx, softwire in enumerate(config[1:-1]):
+            line_msg = 'Line #%d: %s' % (idx + 2, softwire)
+            self.assertTrue(softwire.startswith('  softwire {'), line_msg)
+            self.assertTrue(softwire.endswith('}'), line_msg)
 
-        # Finally get the stdout value which should be the config.
-        config = [l.decode("utf-8") for l in generation_proc.stdout.readlines()]
+        self.assertIn(config[-1], '}',
+            'End line: %s' % config[0])
 
-        # The output should be "binding-table {" followed by 10 softwires then "}"
-        self.assertEqual("binding-table {\n", config[0])
-
-        for softwire in config[1:-1]:
-            self.assertTrue(softwire.startswith("  softwire {"))
-            self.assertTrue(softwire.endswith("}\n"))
-
-        self.assertEqual(config[-1], "}\n")
-
-        # Check the count is 12 (10 softwires + start and end block)
-        self.assertEqual(len(config), num+2)
-
+        # Check that the number of lines is the number of softwires
+        # plus the start and end lines.
+        self.assertEqual(len(config), NUM_SOFTWIRES + 2, len(config))

--- a/src/program/lwaftr/tests/subcommands/query_test.py
+++ b/src/program/lwaftr/tests/subcommands/query_test.py
@@ -9,7 +9,7 @@ import unittest
 from test_env import DATA_DIR, ENC, SNABB_CMD, BaseTestCase, nic_names
 
 
-DAEMON_PROC_NAME = 'query_test_daemon'
+DAEMON_PROC_NAME = 'query-test-daemon'
 SNABB_PCI0, SNABB_PCI1 = nic_names()
 RUN_DIR = Path('/var/run/snabb')
 

--- a/src/program/lwaftr/tests/subcommands/quickcheck_test.py
+++ b/src/program/lwaftr/tests/subcommands/quickcheck_test.py
@@ -4,19 +4,17 @@ Test the "snabb lwaftr quickcheck" subcommand.
 
 import unittest
 
-from test_env import SNABB_CMD, BaseTestCase
+from test_env import ENC, SNABB_CMD, BaseTestCase
 
 
 class TestQuickcheck(BaseTestCase):
 
-    cmd_args = [
-        str(SNABB_CMD), 'lwaftr', 'quickcheck', '-h'
-    ]
+    cmd_args = (str(SNABB_CMD), 'lwaftr', 'quickcheck', '-h')
 
-    def test_run_nohw(self):
-        output = self.run_cmd(self.cmd_args)
-        self.assertIn(b'Usage: quickcheck', output,
-            b'\n'.join((b'OUTPUT', output)))
+    def test_quickcheck(self):
+        output = str(self.run_cmd(self.cmd_args), ENC)
+        self.assertIn('Usage: quickcheck', output,
+            '\n'.join(('OUTPUT', output)))
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/test_env.py
+++ b/src/program/lwaftr/tests/test_env.py
@@ -77,6 +77,8 @@ class BaseTestCase(unittest.TestCase):
         try:
             output, errput = proc.communicate(timeout=COMMAND_TIMEOUT)
         except TimeoutExpired:
+            proc.stdout.close()
+            proc.stderr.close()
             print('\nTimeout running command, trying to kill PID %s' % proc.pid)
             proc.kill()
             raise


### PR DESCRIPTION
The `generate-binding-table` leaks file descriptors:

```
577: ResourceWarning: unclosed file <_io.BufferedReader name=3>
ResourceWarning: unclosed file <_io.BufferedReader name=5>
```

It also doesn't use some of the facilities available in `test_env.py`, making it longer that needed.

Some improvements to the `quickcheck` test are also included, and some others too.