### PR TITLE
Avoid the most repetitive output in tests

### DIFF
--- a/src/apps/socket/unix.lua
+++ b/src/apps/socket/unix.lua
@@ -154,7 +154,6 @@ function selftest ()
             if l == nil then return end
             while not link.empty(l) do
                local p = link.receive(l)
-               print(name..': ', p.length, ffi.string(p.data, p.length))
                packet.free(p)
             end
          end

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -733,8 +733,6 @@ end
 function randomseed (seed)
    seed = tonumber(seed)
    if seed then
-      local msg = 'Using deterministic random numbers, SNABB_RANDOM_SEED=%d.\n'
-      io.stderr:write(msg:format(seed))
       math.randomseed(seed)
       -- When setting a seed, use deterministic random bytes.
       random_bytes = random_bytes_from_math_random


### PR DESCRIPTION
The CI output has become extremely long and repetitive when there are errors, so much so that Github truncates the report ([example](https://gist.github.com/lwaftr-igalia/52ef86d3ab93dd8859d0726a180f486e)). This PR removes the two most egregious offenders, responsible of many hundreds of output lines each.