### PR TITLE
Place counters into a counters container

### DIFF
--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -548,7 +548,7 @@ function Leader:rpc_get_state (args)
       local printer = path_printer_for_schema_by_name(self.schema_name, args.path, args)
       local s = {}
       for _, follower in pairs(self.followers) do
-         for k,v in pairs(state.show_state(self.schema_name, follower.pid, args.path)) do
+         for k,v in pairs(state.show_state(self.schema_name, follower.pid)) do
             s[k] = v
          end
       end

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -355,367 +355,369 @@ module snabb-softwire-v2 {
     description "State data about lwaftr.";
     config false;
 
-    leaf drop-all-ipv4-iface-bytes {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv4 interfaces,
-         whether or not they actually IPv4 (they only include data about
-         packets that go in/out over the wires, excluding internally generated
-         ICMP packets).";
-    }
-    leaf drop-all-ipv4-iface-packets {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv4 interfaces,
-         whether or not they actually IPv4 (they only include data about
-         packets that go in/out over the wires, excluding internally generated
-         ICMP packets).";
-    }
-    leaf drop-all-ipv6-iface-bytes {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv6 interfaces,
-         whether or not they actually IPv6 (they only include data about packets
-         that go in/out over the wires, excluding internally generated ICMP
-         packets).";
-    }
-    leaf drop-all-ipv6-iface-packets {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv6 interfaces,
-         whether or not they actually IPv6 (they only include data about packets
-         that go in/out over the wires, excluding internally generated ICMP
-         packets).";
-    }
-    leaf drop-bad-checksum-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description "ICMPv4 packets dropped because of a bad checksum.";
-    }
-    leaf drop-bad-checksum-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description "ICMPv4 packets dropped because of a bad checksum.";
-    }
-    leaf drop-in-by-policy-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv4 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-policy-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv4 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-policy-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv6 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-policy-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv6 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-rfc7596-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
-    }
-    leaf drop-in-by-rfc7596-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
-    }
-    leaf drop-ipv4-frag-disabled {
-      type yang:zero-based-counter64;
-      description
-        "If fragmentation is disabled, the only potentially non-zero IPv4
-         fragmentation counter is drop-ipv4-frag-disabled. If fragmentation is
-         enabled, it will always be zero.";
-    }
-    leaf drop-ipv4-frag-invalid-reassembly {
-      type yang:zero-based-counter64;
-      description
-        "Two or more IPv4 fragments were received, and reassembly was started,
-         but was invalid and dropped. Causes include multiple fragments claiming
-         they are the last fragment, overlapping fragment offsets, or the packet
-         was being reassembled from too many fragments (the setting is
-         max_fragments_per_reassembly_packet, and the default is that no packet
-         should be reassembled from more than 40).";
-    }
-    leaf drop-ipv4-frag-random-evicted {
-      type yang:zero-based-counter64;
-      description
-        "Reassembling an IPv4 packet from fragments was in progress, but the
-         configured amount of packets to reassemble at once was exceeded, so one
-         was dropped at random. Consider increasing the setting
-         max_ipv4_reassembly_packets.";
-    }
-    leaf drop-ipv6-frag-disabled {
-      type yang:zero-based-counter64;
-      description
-        "If fragmentation is disabled, the only potentially non-zero IPv6
-         fragmentation counter is drop-ipv6-frag-disabled. If fragmentation is
-         enabled, it will always be zero.";
-    }
-    leaf drop-ipv6-frag-invalid-reassembly {
-      type yang:zero-based-counter64;
-      description
-        "Two or more IPv6 fragments were received, and reassembly was started,
-         but was invalid and dropped. Causes include multiple fragments claiming
-         they are the last fragment, overlapping fragment offsets, or the packet
-         was being reassembled from too many fragments (the setting is
-         max_fragments_per_reassembly_packet, and the default is that no packet
-         should be reassembled from more than 40).";
-    }
-    leaf drop-ipv6-frag-random-evicted {
-      type yang:zero-based-counter64;
-      description
-        "Reassembling an IPv6 packet from fragments was in progress, but the
-        configured amount of packets to reassemble at once was exceeded, so one
-        was dropped at random. Consider increasing the setting
-        max_ipv6_reassembly_packets.";
-    }
-    leaf drop-misplaced-not-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "Non-IPv4 packets incoming on the IPv4 link.";
-    }
-    leaf drop-misplaced-not-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "Non-IPv4 packets incoming on the IPv4 link.";
-    }
-    leaf drop-misplaced-not-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "Non-IPv6 packets incoming on IPv6 link.";
-    }
-    leaf drop-misplaced-not-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "Non-IPv6 packets incoming on IPv6 link.";
-    }
-    leaf drop-no-dest-softwire-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description
-        "No matching destination softwire in the binding table; incremented
-         whether or not the reason was RFC7596.";
-    }
-    leaf drop-no-dest-softwire-ipv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "No matching destination softwire in the binding table; incremented
-         whether or not the reason was RFC7596.";
-    }
-    leaf drop-no-source-softwire-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "No matching source softwire in the binding table; incremented whether
-         or not the reason was RFC7596.";
-    }
-    leaf drop-no-source-softwire-ipv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "No matching source softwire in the binding table; incremented whether
-         or not the reason was RFC7596.";
-    }
-    leaf drop-out-by-policy-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "Internally generated ICMPv4 error packets dropped because of current
-         policy.";
-    }
-    leaf drop-out-by-policy-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Internally generated ICMPv6 packets dropped because of current
-         policy.";
-    }
-    leaf drop-over-mtu-but-dont-fragment-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description
-        "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
-         flag was set.";
-    }
-    leaf drop-over-mtu-but-dont-fragment-ipv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
-         flag was set.";
-    }
-    leaf drop-over-rate-limit-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
-    }
-    leaf drop-over-rate-limit-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
-    }
-    leaf drop-over-time-but-not-hop-limit-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Packet's time limit was exceeded, but the hop limit was not.";
-    }
-    leaf drop-over-time-but-not-hop-limit-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Packet's time limit was exceeded, but the hop limit was not.";
-    }
-    leaf drop-too-big-type-but-not-code-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
-         acceptable one for this type.";
-    }
-    leaf drop-too-big-type-but-not-code-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
-         acceptable one for this type.";
-    }
-    leaf drop-ttl-zero-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "IPv4 packets dropped because their TTL was zero.";
-    }
-    leaf drop-ttl-zero-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "IPv4 packets dropped because their TTL was zero.";
-    }
-    leaf drop-unknown-protocol-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown ICMPv6 protocol.";
-    }
-    leaf drop-unknown-protocol-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown ICMPv6 protocol.";
-    }
-    leaf drop-unknown-protocol-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown IPv6 protocol.";
-    }
-    leaf drop-unknown-protocol-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown IPv6 protocol.";
-    }
-    leaf hairpin-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "IPv4 packets going to a known b4 (hairpinned).";
-    }
-    leaf hairpin-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "IPv4 packets going to a known b4 (hairpinned).";
-    }
-    leaf in-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf in-ipv4-frag-needs-reassembly {
-      type yang:zero-based-counter64;
-      description "An IPv4 fragment was received.";
-    }
-    leaf in-ipv4-frag-reassembled {
-      type yang:zero-based-counter64;
-      description "A packet was successfully reassembled from IPv4 fragments.";
-    }
-    leaf in-ipv4-frag-reassembly-unneeded {
-      type yang:zero-based-counter64;
-      description
-        "An IPv4 packet which was not a fragment was received - consequently,
-         it did not need to be reassembled. This should be the usual case.";
-    }
-    leaf in-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf in-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf in-ipv6-frag-needs-reassembly {
-      type yang:zero-based-counter64;
-      description "An IPv6 fragment was received.";
-    }
-    leaf in-ipv6-frag-reassembled {
-      type yang:zero-based-counter64;
-      description "A packet was successfully reassembled from IPv6 fragments.";
-    }
-    leaf in-ipv6-frag-reassembly-unneeded {
-      type yang:zero-based-counter64;
-      description
-        "An IPv6 packet which was not a fragment was received - consequently, it
-         did not need to be reassembled. This should be the usual case.";
-    }
-    leaf in-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf ingress-packet-drops {
-      type yang:zero-based-counter64;
-      description "Packets dropped due to ingress filters.";
-    }
-    leaf memuse-ipv4-frag-reassembly-buffer {
-      type yang:zero-based-counter64;
-      description
-        "The amount of memory being used by the statically sized data structure
-         for reassembling IPv4 fragments. This is directly proportional to the
-        setting max_ipv4_reassembly_packets.";
-    }
-    leaf memuse-ipv6-frag-reassembly-buffer {
-      type yang:zero-based-counter64;
-      description
-        "The amount of memory being used by the statically sized data structure
-         for reassembling IPv6 fragments. This is directly proportional to the
-         setting max_ipv6_reassembly_packets.";
-    }
-    leaf out-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description "Internally generated ICMPv4 packets.";
-    }
-    leaf out-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description "Internally generated ICMPv4 packets.";
-    }
-    leaf out-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description "Internally generted ICMPv6 error packets.";
-    }
-    leaf out-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description "Internally generted ICMPv6 error packets.";
-    }
-    leaf out-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "Valid outgoing IPv4 packets.";
-    }
-    leaf out-ipv4-frag {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet exceeded the configured IPv4 MTU, so needed to be
-         fragmented. This may happen, but should be unusual.";
-    }
-    leaf out-ipv4-frag-not {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet was small enough to pass through unfragmented - this
-         should be the usual case.";
-    }
-    leaf out-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "Valid outgoing IPv4 packets.";
-    }
-    leaf out-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv6 packets.";
-    }
-    leaf out-ipv6-frag {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet exceeded the configured IPv6 MTU, so needed to be
-        fragmented. This may happen, but should be unusual.";
-    }
-    leaf out-ipv6-frag-not {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet was small enough to pass through unfragmented - this
-         should be the usual case.";
-    }
-    leaf out-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv6 packets.";
+    container counters {
+      leaf drop-all-ipv4-iface-bytes {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv4 interfaces,
+           whether or not they actually IPv4 (they only include data about
+           packets that go in/out over the wires, excluding internally generated
+           ICMP packets).";
+      }
+      leaf drop-all-ipv4-iface-packets {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv4 interfaces,
+           whether or not they actually IPv4 (they only include data about
+           packets that go in/out over the wires, excluding internally generated
+           ICMP packets).";
+      }
+      leaf drop-all-ipv6-iface-bytes {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv6 interfaces,
+           whether or not they actually IPv6 (they only include data about packets
+           that go in/out over the wires, excluding internally generated ICMP
+           packets).";
+      }
+      leaf drop-all-ipv6-iface-packets {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv6 interfaces,
+           whether or not they actually IPv6 (they only include data about packets
+           that go in/out over the wires, excluding internally generated ICMP
+           packets).";
+      }
+      leaf drop-bad-checksum-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description "ICMPv4 packets dropped because of a bad checksum.";
+      }
+      leaf drop-bad-checksum-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description "ICMPv4 packets dropped because of a bad checksum.";
+      }
+      leaf drop-in-by-policy-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv4 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-policy-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv4 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-policy-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv6 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-policy-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv6 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-rfc7596-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
+      }
+      leaf drop-in-by-rfc7596-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
+      }
+      leaf drop-ipv4-frag-disabled {
+        type yang:zero-based-counter64;
+        description
+          "If fragmentation is disabled, the only potentially non-zero IPv4
+           fragmentation counter is drop-ipv4-frag-disabled. If fragmentation is
+           enabled, it will always be zero.";
+      }
+      leaf drop-ipv4-frag-invalid-reassembly {
+        type yang:zero-based-counter64;
+        description
+          "Two or more IPv4 fragments were received, and reassembly was started,
+           but was invalid and dropped. Causes include multiple fragments claiming
+           they are the last fragment, overlapping fragment offsets, or the packet
+           was being reassembled from too many fragments (the setting is
+           max_fragments_per_reassembly_packet, and the default is that no packet
+           should be reassembled from more than 40).";
+      }
+      leaf drop-ipv4-frag-random-evicted {
+        type yang:zero-based-counter64;
+        description
+          "Reassembling an IPv4 packet from fragments was in progress, but the
+           configured amount of packets to reassemble at once was exceeded, so one
+           was dropped at random. Consider increasing the setting
+           max_ipv4_reassembly_packets.";
+      }
+      leaf drop-ipv6-frag-disabled {
+        type yang:zero-based-counter64;
+        description
+          "If fragmentation is disabled, the only potentially non-zero IPv6
+           fragmentation counter is drop-ipv6-frag-disabled. If fragmentation is
+           enabled, it will always be zero.";
+      }
+      leaf drop-ipv6-frag-invalid-reassembly {
+        type yang:zero-based-counter64;
+        description
+          "Two or more IPv6 fragments were received, and reassembly was started,
+           but was invalid and dropped. Causes include multiple fragments claiming
+           they are the last fragment, overlapping fragment offsets, or the packet
+           was being reassembled from too many fragments (the setting is
+           max_fragments_per_reassembly_packet, and the default is that no packet
+           should be reassembled from more than 40).";
+      }
+      leaf drop-ipv6-frag-random-evicted {
+        type yang:zero-based-counter64;
+        description
+          "Reassembling an IPv6 packet from fragments was in progress, but the
+          configured amount of packets to reassemble at once was exceeded, so one
+          was dropped at random. Consider increasing the setting
+          max_ipv6_reassembly_packets.";
+      }
+      leaf drop-misplaced-not-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "Non-IPv4 packets incoming on the IPv4 link.";
+      }
+      leaf drop-misplaced-not-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "Non-IPv4 packets incoming on the IPv4 link.";
+      }
+      leaf drop-misplaced-not-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "Non-IPv6 packets incoming on IPv6 link.";
+      }
+      leaf drop-misplaced-not-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "Non-IPv6 packets incoming on IPv6 link.";
+      }
+      leaf drop-no-dest-softwire-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description
+          "No matching destination softwire in the binding table; incremented
+           whether or not the reason was RFC7596.";
+      }
+      leaf drop-no-dest-softwire-ipv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "No matching destination softwire in the binding table; incremented
+           whether or not the reason was RFC7596.";
+      }
+      leaf drop-no-source-softwire-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "No matching source softwire in the binding table; incremented whether
+           or not the reason was RFC7596.";
+      }
+      leaf drop-no-source-softwire-ipv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "No matching source softwire in the binding table; incremented whether
+           or not the reason was RFC7596.";
+      }
+      leaf drop-out-by-policy-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "Internally generated ICMPv4 error packets dropped because of current
+           policy.";
+      }
+      leaf drop-out-by-policy-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Internally generated ICMPv6 packets dropped because of current
+           policy.";
+      }
+      leaf drop-over-mtu-but-dont-fragment-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description
+          "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
+           flag was set.";
+      }
+      leaf drop-over-mtu-but-dont-fragment-ipv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
+           flag was set.";
+      }
+      leaf drop-over-rate-limit-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
+      }
+      leaf drop-over-rate-limit-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
+      }
+      leaf drop-over-time-but-not-hop-limit-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Packet's time limit was exceeded, but the hop limit was not.";
+      }
+      leaf drop-over-time-but-not-hop-limit-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Packet's time limit was exceeded, but the hop limit was not.";
+      }
+      leaf drop-too-big-type-but-not-code-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
+           acceptable one for this type.";
+      }
+      leaf drop-too-big-type-but-not-code-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
+           acceptable one for this type.";
+      }
+      leaf drop-ttl-zero-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "IPv4 packets dropped because their TTL was zero.";
+      }
+      leaf drop-ttl-zero-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "IPv4 packets dropped because their TTL was zero.";
+      }
+      leaf drop-unknown-protocol-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown ICMPv6 protocol.";
+      }
+      leaf drop-unknown-protocol-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown ICMPv6 protocol.";
+      }
+      leaf drop-unknown-protocol-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown IPv6 protocol.";
+      }
+      leaf drop-unknown-protocol-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown IPv6 protocol.";
+      }
+      leaf hairpin-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "IPv4 packets going to a known b4 (hairpinned).";
+      }
+      leaf hairpin-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "IPv4 packets going to a known b4 (hairpinned).";
+      }
+      leaf in-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf in-ipv4-frag-needs-reassembly {
+        type yang:zero-based-counter64;
+        description "An IPv4 fragment was received.";
+      }
+      leaf in-ipv4-frag-reassembled {
+        type yang:zero-based-counter64;
+        description "A packet was successfully reassembled from IPv4 fragments.";
+      }
+      leaf in-ipv4-frag-reassembly-unneeded {
+        type yang:zero-based-counter64;
+        description
+          "An IPv4 packet which was not a fragment was received - consequently,
+           it did not need to be reassembled. This should be the usual case.";
+      }
+      leaf in-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf in-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf in-ipv6-frag-needs-reassembly {
+        type yang:zero-based-counter64;
+        description "An IPv6 fragment was received.";
+      }
+      leaf in-ipv6-frag-reassembled {
+        type yang:zero-based-counter64;
+        description "A packet was successfully reassembled from IPv6 fragments.";
+      }
+      leaf in-ipv6-frag-reassembly-unneeded {
+        type yang:zero-based-counter64;
+        description
+          "An IPv6 packet which was not a fragment was received - consequently, it
+           did not need to be reassembled. This should be the usual case.";
+      }
+      leaf in-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf ingress-packet-drops {
+        type yang:zero-based-counter64;
+        description "Packets dropped due to ingress filters.";
+      }
+      leaf memuse-ipv4-frag-reassembly-buffer {
+        type yang:zero-based-counter64;
+        description
+          "The amount of memory being used by the statically sized data structure
+           for reassembling IPv4 fragments. This is directly proportional to the
+          setting max_ipv4_reassembly_packets.";
+      }
+      leaf memuse-ipv6-frag-reassembly-buffer {
+        type yang:zero-based-counter64;
+        description
+          "The amount of memory being used by the statically sized data structure
+           for reassembling IPv6 fragments. This is directly proportional to the
+           setting max_ipv6_reassembly_packets.";
+      }
+      leaf out-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description "Internally generated ICMPv4 packets.";
+      }
+      leaf out-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description "Internally generated ICMPv4 packets.";
+      }
+      leaf out-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description "Internally generted ICMPv6 error packets.";
+      }
+      leaf out-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description "Internally generted ICMPv6 error packets.";
+      }
+      leaf out-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "Valid outgoing IPv4 packets.";
+      }
+      leaf out-ipv4-frag {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet exceeded the configured IPv4 MTU, so needed to be
+           fragmented. This may happen, but should be unusual.";
+      }
+      leaf out-ipv4-frag-not {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet was small enough to pass through unfragmented - this
+           should be the usual case.";
+      }
+      leaf out-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "Valid outgoing IPv4 packets.";
+      }
+      leaf out-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv6 packets.";
+      }
+      leaf out-ipv6-frag {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet exceeded the configured IPv6 MTU, so needed to be
+          fragmented. This may happen, but should be unusual.";
+      }
+      leaf out-ipv6-frag-not {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet was small enough to pass through unfragmented - this
+           should be the usual case.";
+      }
+      leaf out-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv6 packets.";
+      }
     }
   }
 }

--- a/src/lib/yang/state.lua
+++ b/src/lib/yang/state.lua
@@ -5,7 +5,6 @@ local lib = require("core.lib")
 local shm = require("core.shm")
 local yang = require("lib.yang.yang")
 local yang_data = require("lib.yang.data")
-local counter = require("core.counter")
 
 local counter_directory = "/apps"
 
@@ -22,7 +21,7 @@ local function flatten(val)
    return rtn
 end
 
-function find_counters(pid)
+local function find_counters(pid)
    local path = shm.root.."/"..pid..counter_directory
    local apps = {}
    for _, c in pairs(lib.files_in_directory(path)) do
@@ -38,7 +37,7 @@ function find_counters(pid)
    return apps
 end
 
-function collect_state_leaves(schema)
+local function collect_state_leaves(schema)
    -- Iterate over schema looking fo state leaves at a specific path into the
    -- schema. This should return a dictionary of leaf to lua path.
    local function collection(scm, path)

--- a/src/lib/yang/state.lua
+++ b/src/lib/yang/state.lua
@@ -3,7 +3,6 @@ module(..., package.seeall)
 
 local lib = require("core.lib")
 local shm = require("core.shm")
-local xpath = require("lib.yang.path")
 local yang = require("lib.yang.yang")
 local yang_data = require("lib.yang.data")
 local counter = require("core.counter")
@@ -90,11 +89,9 @@ local function set_data_value(data, path, value)
    set_data_value(data[head], path, value)
 end
 
-function show_state(scm, pid, raw_path)
+function show_state(scm, pid)
    local schema = yang.load_schema_by_name(scm)
-   local grammar = yang_data.data_grammar_from_schema(schema)
    local counters = find_counters(pid)
-   local path = xpath.convert_path(grammar, raw_path)
 
    -- Lookup the specific schema element that's being addressed by the path
    local leaves = collect_state_leaves(schema)()

--- a/src/lib/yang/state.lua
+++ b/src/lib/yang/state.lua
@@ -11,102 +11,102 @@ local counter = require("core.counter")
 local counter_directory = "/apps"
 
 local function flatten(val)
-    local rtn = {}
-    for k, v in pairs(val) do
-        if type(v) == "table" then
-            v = flatten(v)
-            for k1, v1 in pairs(v) do rtn[k1] = v1 end
-        else
-            rtn[k] = v
-        end
-    end
-    return rtn
+   local rtn = {}
+   for k, v in pairs(val) do
+      if type(v) == "table" then
+         v = flatten(v)
+         for k1, v1 in pairs(v) do rtn[k1] = v1 end
+      else
+         rtn[k] = v
+      end
+   end
+   return rtn
 end
 
 function find_counters(pid)
-    local path = shm.root.."/"..pid..counter_directory
-    local apps = {}
-    for _, c in pairs(lib.files_in_directory(path)) do
-        local counters = {}
-        local counterdir = "/"..pid..counter_directory.."/"..c
-        for k,v in pairs(shm.open_frame(counterdir)) do
-            if type(v) == "cdata" then
-                counters[k] = v.c
-            end
-        end
-        apps[c] = counters
-    end
-    return apps
+   local path = shm.root.."/"..pid..counter_directory
+   local apps = {}
+   for _, c in pairs(lib.files_in_directory(path)) do
+      local counters = {}
+      local counterdir = "/"..pid..counter_directory.."/"..c
+      for k,v in pairs(shm.open_frame(counterdir)) do
+         if type(v) == "cdata" then
+            counters[k] = v.c
+         end
+      end
+      apps[c] = counters
+   end
+   return apps
 end
 
 function collect_state_leaves(schema)
-    -- Iterate over schema looking fo state leaves at a specific path into the
-    -- schema. This should return a dictionary of leaf to lua path.
-    local function collection(scm, path)
-        local function newpath(oldpath)
-            return lib.deepcopy(oldpath)
-        end
-        if path == nil then path = {} end
-        table.insert(path, scm.id)
+   -- Iterate over schema looking fo state leaves at a specific path into the
+   -- schema. This should return a dictionary of leaf to lua path.
+   local function collection(scm, path)
+      local function newpath(oldpath)
+         return lib.deepcopy(oldpath)
+      end
+      if path == nil then path = {} end
+      table.insert(path, scm.id)
 
-        if scm.kind == "container" then
-            -- Iterate over the body and recursively call self on all children.
+      if scm.kind == "container" then
+         -- Iterate over the body and recursively call self on all children.
+         local rtn = {}
+         for _, child in pairs(scm.body) do
+            local leaves = collection(child, newpath(path))
+            table.insert(rtn, leaves)
+         end
+         return rtn
+      elseif scm.kind == "leaf" then
+         if scm.config == false then
             local rtn = {}
-            for _, child in pairs(scm.body) do
-                local leaves = collection(child, newpath(path))
-                table.insert(rtn, leaves)
-            end
+            rtn[path] = scm.id
             return rtn
-        elseif scm.kind == "leaf" then
-            if scm.config == false then
-                local rtn = {}
-                rtn[path] = scm.id
-                return rtn
-            end
-        elseif scm.kind == "module" then
-            local rtn = {}
-            for _, v in pairs(scm.body) do
-                -- We deliberately don't want to include the module in the path.
-                table.insert(rtn, collection(v, {}))
-            end
-            return rtn
-        end
-        return {}
-    end
+         end
+      elseif scm.kind == "module" then
+         local rtn = {}
+         for _, v in pairs(scm.body) do
+            -- We deliberately don't want to include the module in the path.
+            table.insert(rtn, collection(v, {}))
+         end
+         return rtn
+      end
+      return {}
+   end
 
-    local leaves = collection(schema)
-    if leaves == nil then return {} end
-    leaves = flatten(leaves)
-    return function () return leaves end
+   local leaves = collection(schema)
+   if leaves == nil then return {} end
+   leaves = flatten(leaves)
+   return function () return leaves end
 end
 
 local function set_data_value(data, path, value)
-    local head = yang_data.normalize_id(table.remove(path, 1))
-    if #path == 0 then
-        data[head] = value
-        return
-    end
-    if data[head] == nil then data[head] = {} end
-    set_data_value(data[head], path, value)
+   local head = yang_data.normalize_id(table.remove(path, 1))
+   if #path == 0 then
+      data[head] = value
+      return
+   end
+   if data[head] == nil then data[head] = {} end
+   set_data_value(data[head], path, value)
 end
 
 function show_state(scm, pid, raw_path)
-    local schema = yang.load_schema_by_name(scm)
-    local grammar = yang_data.data_grammar_from_schema(schema)
-    local counters = find_counters(pid)
-    local path = xpath.convert_path(grammar, raw_path)
+   local schema = yang.load_schema_by_name(scm)
+   local grammar = yang_data.data_grammar_from_schema(schema)
+   local counters = find_counters(pid)
+   local path = xpath.convert_path(grammar, raw_path)
 
-    -- Lookup the specific schema element that's being addressed by the path
-    local leaves = collect_state_leaves(schema)()
-    local data = {}
-    for leaf_path, leaf in pairs(leaves) do
-        for _, counter in pairs(counters) do
-            if counter[leaf] then
-                set_data_value(data, leaf_path, counter[leaf])
-            end
-        end
-    end
-    return data
+   -- Lookup the specific schema element that's being addressed by the path
+   local leaves = collect_state_leaves(schema)()
+   local data = {}
+   for leaf_path, leaf in pairs(leaves) do
+      for _, counter in pairs(counters) do
+         if counter[leaf] then
+            set_data_value(data, leaf_path, counter[leaf])
+         end
+      end
+   end
+   return data
 end
 
 function selftest ()

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -155,8 +155,8 @@ class TestConfigMisc(BaseTestCase):
         get_state_args = self.get_cmd_args('get-state')
         # Select a few at random which should have non-zero results.
         for query in (
-                '/softwire-state/in-ipv4-bytes',
-                '/softwire-state/out-ipv4-bytes',
+                '/softwire-state/counters/in-ipv4-bytes',
+                '/softwire-state/counters/out-ipv4-bytes',
             ):
             cmd_args = list(get_state_args)
             cmd_args.append(query)


### PR DESCRIPTION
Right now counters are stored as leaves inside `softwire-state`. Since I will need to put alarm state information in `softwire-state` too, I want to move the counters leaves inside their own container (`softwire-state/counters`).

The PR contains some clean ups too:

* lib/yang/state.lua: 
   - The file contained a mix of 4-space indents and 3-space indents. Set all as 3-space indents.
   - Function 'get_state' was not using parameter 'path'. Removed.
   - Remove other unused variables and localize functions where possible. 