### PR TITLE
Refactor action codec

### DIFF
--- a/src/apps/config/action_codec.lua
+++ b/src/apps/config/action_codec.lua
@@ -2,12 +2,8 @@
 
 module(...,package.seeall)
 
-local S = require("syscall")
-local lib = require("core.lib")
-local ffi = require("ffi")
-local yang = require("lib.yang.yang")
-local binary = require("lib.yang.binary")
-local shm = require("core.shm")
+local codec = require("apps.config.codec")
+local encoder, decoder = codec.encoder, codec.decoder
 
 local action_names = { 'unlink_output', 'unlink_input', 'free_link',
                        'new_link', 'link_output', 'link_input', 'stop_app',
@@ -74,126 +70,11 @@ function actions.commit (codec)
    return codec:finish()
 end
 
-local public_names = {}
-local function find_public_name(obj)
-   if public_names[obj] then return unpack(public_names[obj]) end
-   for modname, mod in pairs(package.loaded) do
-      if type(mod) == 'table' then
-         for name, val in pairs(mod) do
-            if val == obj then
-               if type(val) == 'table' and type(val.new) == 'function' then
-                  public_names[obj] = { modname, name }
-                  return modname, name
-               end
-            end
-         end
-      end
-   end
-   error('could not determine public name for object: '..tostring(obj))
-end
-
-local lower_case = "abcdefghijklmnopqrstuvwxyz"
-local upper_case = lower_case:upper()
-local extra = "0123456789_-"
-local alphabet = table.concat({lower_case, upper_case, extra})
-assert(#alphabet == 64)
-local function random_file_name()
-   -- 22 bytes, but we only use 2^6=64 bits from each byte, so total of
-   -- 132 bits of entropy.
-   local bytes = lib.random_data(22)
-   local out = {}
-   for i=1,#bytes do
-      table.insert(out, alphabet:byte(bytes:byte(i) % 64 + 1))
-   end
-   local basename = string.char(unpack(out))
-   return shm.root..'/'..tostring(S.getpid())..'/app-conf-'..basename
-end
-
-local function encoder()
-   local encoder = { out = {} }
-   function encoder:uint32(len)
-      table.insert(self.out, ffi.new('uint32_t[1]', len))
-   end
-   function encoder:string(str)
-      self:uint32(#str)
-      local buf = ffi.new('uint8_t[?]', #str)
-      ffi.copy(buf, str, #str)
-      table.insert(self.out, buf)
-   end
-   function encoder:blob(blob)
-      self:uint32(ffi.sizeof(blob))
-      table.insert(self.out, blob)
-   end
-   function encoder:class(class)
-      local require_path, name = find_public_name(class)
-      self:string(require_path)
-      self:string(name)
-   end
-   function encoder:config(class, arg)
-      local file_name = random_file_name()
-      if class.yang_schema then
-         yang.compile_data_for_schema_by_name(class.yang_schema, arg,
-                                              file_name)
-      else
-         if arg == nil then arg = {} end
-         binary.compile_ad_hoc_lua_data_to_file(file_name, arg)
-      end
-      self:string(file_name)
-   end
-   function encoder:finish()
-      local size = 0
-      for _,src in ipairs(self.out) do size = size + ffi.sizeof(src) end
-      local dst = ffi.new('uint8_t[?]', size)
-      local pos = 0
-      for _,src in ipairs(self.out) do
-         ffi.copy(dst + pos, src, ffi.sizeof(src))
-         pos = pos + ffi.sizeof(src)
-      end
-      return dst, size
-   end
-   return encoder
-end
-
 function encode(action)
    local name, args = unpack(action)
    local codec = encoder()
    codec:uint32(assert(action_codes[name], name))
    return assert(actions[name], name)(codec, unpack(args))
-end
-
-local uint32_ptr_t = ffi.typeof('uint32_t*')
-local function decoder(buf, len)
-   local decoder = { buf=buf, len=len, pos=0 }
-   function decoder:read(count)
-      local ret = self.buf + self.pos
-      self.pos = self.pos + count
-      assert(self.pos <= self.len)
-      return ret
-   end
-   function decoder:uint32()
-      return ffi.cast(uint32_ptr_t, self:read(4))[0]
-   end
-   function decoder:string()
-      local len = self:uint32()
-      return ffi.string(self:read(len), len)
-   end
-   function decoder:blob()
-      local len = self:uint32()
-      local blob = ffi.new('uint8_t[?]', len)
-      ffi.copy(blob, self:read(len), len)
-      return blob
-   end
-   function decoder:class()
-      local require_path, name = self:string(), self:string()
-      return assert(require(require_path)[name])
-   end
-   function decoder:config()
-      return binary.load_compiled_data_file(self:string()).data
-   end
-   function decoder:finish(...)
-      return { ... }
-   end
-   return decoder
 end
 
 function decode(buf, len)
@@ -204,20 +85,8 @@ end
 
 function selftest ()
    print('selftest: apps.config.action_codec')
-   local function serialize(data)
-      local tmp = random_file_name()
-      print('serializing to:', tmp)
-      binary.compile_ad_hoc_lua_data_to_file(tmp, data)
-      local loaded = binary.load_compiled_data_file(tmp)
-      assert(loaded.schema_name == '')
-      assert(lib.equal(data, loaded.data))
-      os.remove(tmp)
-   end
-   serialize('foo')
-   serialize({foo='bar'})
-   serialize({foo={qux='baz'}})
-   serialize(1)
-   serialize(1LL)
+   local lib = require("core.lib")
+   local ffi = require("ffi")
    local function test_action(action)
       local encoded, len = encode(action)
       local decoded = decode(encoded, len)

--- a/src/apps/config/codec.lua
+++ b/src/apps/config/codec.lua
@@ -135,10 +135,28 @@ function selftest ()
       assert(lib.equal(data, loaded.data))
       os.remove(tmp)
    end
+   local function encode_decode (data)
+      local buf, len
+      local encode = encoder()
+      if type(data) == 'number' then
+         encode:uint32(data)
+         local decode = decoder(encode:finish())
+         assert(data == decode:uint32())
+      elseif type(data) == 'string' then
+         encode:string(data)
+         local decode = decoder(encode:finish())
+         assert(data == decode:string())
+      end
+   end
+
    serialize('foo')
    serialize({foo='bar'})
    serialize({foo={qux='baz'}})
    serialize(1)
    serialize(1LL)
+
+   encode_decode('foo')
+   encode_decode(1)
+
    print('selftest: ok')
 end

--- a/src/apps/config/codec.lua
+++ b/src/apps/config/codec.lua
@@ -1,0 +1,144 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(...,package.seeall)
+
+local S = require("syscall")
+local lib = require("core.lib")
+local ffi = require("ffi")
+local yang = require("lib.yang.yang")
+local binary = require("lib.yang.binary")
+local shm = require("core.shm")
+
+local public_names = {}
+local function find_public_name(obj)
+   if public_names[obj] then return unpack(public_names[obj]) end
+   for modname, mod in pairs(package.loaded) do
+      if type(mod) == 'table' then
+         for name, val in pairs(mod) do
+            if val == obj then
+               if type(val) == 'table' and type(val.new) == 'function' then
+                  public_names[obj] = { modname, name }
+                  return modname, name
+               end
+            end
+         end
+      end
+   end
+   error('could not determine public name for object: '..tostring(obj))
+end
+
+local lower_case = "abcdefghijklmnopqrstuvwxyz"
+local upper_case = lower_case:upper()
+local extra = "0123456789_-"
+local alphabet = table.concat({lower_case, upper_case, extra})
+assert(#alphabet == 64)
+local function random_file_name()
+   -- 22 bytes, but we only use 2^6=64 bits from each byte, so total of
+   -- 132 bits of entropy.
+   local bytes = lib.random_data(22)
+   local out = {}
+   for i=1,#bytes do
+      table.insert(out, alphabet:byte(bytes:byte(i) % 64 + 1))
+   end
+   local basename = string.char(unpack(out))
+   return shm.root..'/'..tostring(S.getpid())..'/app-conf-'..basename
+end
+
+function encoder()
+   local encoder = { out = {} }
+   function encoder:uint32(len)
+      table.insert(self.out, ffi.new('uint32_t[1]', len))
+   end
+   function encoder:string(str)
+      self:uint32(#str)
+      local buf = ffi.new('uint8_t[?]', #str)
+      ffi.copy(buf, str, #str)
+      table.insert(self.out, buf)
+   end
+   function encoder:blob(blob)
+      self:uint32(ffi.sizeof(blob))
+      table.insert(self.out, blob)
+   end
+   function encoder:class(class)
+      local require_path, name = find_public_name(class)
+      self:string(require_path)
+      self:string(name)
+   end
+   function encoder:config(class, arg)
+      local file_name = random_file_name()
+      if class.yang_schema then
+         yang.compile_data_for_schema_by_name(class.yang_schema, arg,
+                                              file_name)
+      else
+         if arg == nil then arg = {} end
+         binary.compile_ad_hoc_lua_data_to_file(file_name, arg)
+      end
+      self:string(file_name)
+   end
+   function encoder:finish()
+      local size = 0
+      for _,src in ipairs(self.out) do size = size + ffi.sizeof(src) end
+      local dst = ffi.new('uint8_t[?]', size)
+      local pos = 0
+      for _,src in ipairs(self.out) do
+         ffi.copy(dst + pos, src, ffi.sizeof(src))
+         pos = pos + ffi.sizeof(src)
+      end
+      return dst, size
+   end
+   return encoder
+end
+
+local uint32_ptr_t = ffi.typeof('uint32_t*')
+function decoder(buf, len)
+   local decoder = { buf=buf, len=len, pos=0 }
+   function decoder:read(count)
+      local ret = self.buf + self.pos
+      self.pos = self.pos + count
+      assert(self.pos <= self.len)
+      return ret
+   end
+   function decoder:uint32()
+      return ffi.cast(uint32_ptr_t, self:read(4))[0]
+   end
+   function decoder:string()
+      local len = self:uint32()
+      return ffi.string(self:read(len), len)
+   end
+   function decoder:blob()
+      local len = self:uint32()
+      local blob = ffi.new('uint8_t[?]', len)
+      ffi.copy(blob, self:read(len), len)
+      return blob
+   end
+   function decoder:class()
+      local require_path, name = self:string(), self:string()
+      return assert(require(require_path)[name])
+   end
+   function decoder:config()
+      return binary.load_compiled_data_file(self:string()).data
+   end
+   function decoder:finish(...)
+      return { ... }
+   end
+   return decoder
+end
+
+function selftest ()
+   print('selftest: apps.config.codec')
+   local function serialize(data)
+      local tmp = random_file_name()
+      print('serializing to:', tmp)
+      binary.compile_ad_hoc_lua_data_to_file(tmp, data)
+      local loaded = binary.load_compiled_data_file(tmp)
+      assert(loaded.schema_name == '')
+      assert(lib.equal(data, loaded.data))
+      os.remove(tmp)
+   end
+   serialize('foo')
+   serialize({foo='bar'})
+   serialize({foo={qux='baz'}})
+   serialize(1)
+   serialize(1LL)
+   print('selftest: ok')
+end

--- a/src/apps/config/codec.lua
+++ b/src/apps/config/codec.lua
@@ -66,7 +66,7 @@ function encoder()
    end
    function encoder:config(class, arg)
       local file_name = random_file_name()
-      if class.yang_schema then
+      if class and class.yang_schema then
          yang.compile_data_for_schema_by_name(class.yang_schema, arg,
                                               file_name)
       else
@@ -146,6 +146,10 @@ function selftest ()
          encode:string(data)
          local decode = decoder(encode:finish())
          assert(data == decode:string())
+      elseif type(data) == 'table' then
+         encode:config(nil, data)
+         local decode = decoder(encode:finish())
+         assert(lib.equal(data, decode:config()))
       end
    end
 
@@ -156,6 +160,8 @@ function selftest ()
    serialize(1LL)
 
    encode_decode('foo')
+   encode_decode({foo='bar'})
+   encode_decode({foo={qux='baz'}})
    encode_decode(1)
 
    print('selftest: ok')


### PR DESCRIPTION
This change will be needed to accommodate alarms implementation.

Alarms are emitted from the data-plane (follower) to the leader. The leader manages the state of alarms. A channel to communicate the leader and the follower will be needed, similarly to the config actions mechanism currently implemented.

Thus I'm splitting `action_codec.lua` into `codec.lua` and `action_code.lua`.

`codec.lua` will hand only the encoding/decoding operations of different data types.
`action_codec.lua` defines the verbs and arguments of the action messages.

In addition to the refactoring, the PR fixes an issue in `codec.lua`. It's possible to encode a table using `config`, however the `config` method expects a `config` argument which in the case of a table would be `nil` or an empty table. I think that makes the interface more cumbersome, so I'm defining a 'encode:table' and `decode:table` primitive.