### PR TITLE
Alarms basic support

### DIFF
--- a/src/apps/config/action_codec.lua
+++ b/src/apps/config/action_codec.lua
@@ -2,12 +2,8 @@
 
 module(...,package.seeall)
 
-local S = require("syscall")
-local lib = require("core.lib")
-local ffi = require("ffi")
-local yang = require("lib.yang.yang")
-local binary = require("lib.yang.binary")
-local shm = require("core.shm")
+local codec = require("apps.config.codec")
+local encoder, decoder = codec.encoder, codec.decoder
 
 local action_names = { 'unlink_output', 'unlink_input', 'free_link',
                        'new_link', 'link_output', 'link_input', 'stop_app',
@@ -74,126 +70,11 @@ function actions.commit (codec)
    return codec:finish()
 end
 
-local public_names = {}
-local function find_public_name(obj)
-   if public_names[obj] then return unpack(public_names[obj]) end
-   for modname, mod in pairs(package.loaded) do
-      if type(mod) == 'table' then
-         for name, val in pairs(mod) do
-            if val == obj then
-               if type(val) == 'table' and type(val.new) == 'function' then
-                  public_names[obj] = { modname, name }
-                  return modname, name
-               end
-            end
-         end
-      end
-   end
-   error('could not determine public name for object: '..tostring(obj))
-end
-
-local lower_case = "abcdefghijklmnopqrstuvwxyz"
-local upper_case = lower_case:upper()
-local extra = "0123456789_-"
-local alphabet = table.concat({lower_case, upper_case, extra})
-assert(#alphabet == 64)
-local function random_file_name()
-   -- 22 bytes, but we only use 2^6=64 bits from each byte, so total of
-   -- 132 bits of entropy.
-   local bytes = lib.random_data(22)
-   local out = {}
-   for i=1,#bytes do
-      table.insert(out, alphabet:byte(bytes:byte(i) % 64 + 1))
-   end
-   local basename = string.char(unpack(out))
-   return shm.root..'/'..tostring(S.getpid())..'/app-conf-'..basename
-end
-
-local function encoder()
-   local encoder = { out = {} }
-   function encoder:uint32(len)
-      table.insert(self.out, ffi.new('uint32_t[1]', len))
-   end
-   function encoder:string(str)
-      self:uint32(#str)
-      local buf = ffi.new('uint8_t[?]', #str)
-      ffi.copy(buf, str, #str)
-      table.insert(self.out, buf)
-   end
-   function encoder:blob(blob)
-      self:uint32(ffi.sizeof(blob))
-      table.insert(self.out, blob)
-   end
-   function encoder:class(class)
-      local require_path, name = find_public_name(class)
-      self:string(require_path)
-      self:string(name)
-   end
-   function encoder:config(class, arg)
-      local file_name = random_file_name()
-      if class.yang_schema then
-         yang.compile_data_for_schema_by_name(class.yang_schema, arg,
-                                              file_name)
-      else
-         if arg == nil then arg = {} end
-         binary.compile_ad_hoc_lua_data_to_file(file_name, arg)
-      end
-      self:string(file_name)
-   end
-   function encoder:finish()
-      local size = 0
-      for _,src in ipairs(self.out) do size = size + ffi.sizeof(src) end
-      local dst = ffi.new('uint8_t[?]', size)
-      local pos = 0
-      for _,src in ipairs(self.out) do
-         ffi.copy(dst + pos, src, ffi.sizeof(src))
-         pos = pos + ffi.sizeof(src)
-      end
-      return dst, size
-   end
-   return encoder
-end
-
 function encode(action)
    local name, args = unpack(action)
    local codec = encoder()
    codec:uint32(assert(action_codes[name], name))
    return assert(actions[name], name)(codec, unpack(args))
-end
-
-local uint32_ptr_t = ffi.typeof('uint32_t*')
-local function decoder(buf, len)
-   local decoder = { buf=buf, len=len, pos=0 }
-   function decoder:read(count)
-      local ret = self.buf + self.pos
-      self.pos = self.pos + count
-      assert(self.pos <= self.len)
-      return ret
-   end
-   function decoder:uint32()
-      return ffi.cast(uint32_ptr_t, self:read(4))[0]
-   end
-   function decoder:string()
-      local len = self:uint32()
-      return ffi.string(self:read(len), len)
-   end
-   function decoder:blob()
-      local len = self:uint32()
-      local blob = ffi.new('uint8_t[?]', len)
-      ffi.copy(blob, self:read(len), len)
-      return blob
-   end
-   function decoder:class()
-      local require_path, name = self:string(), self:string()
-      return assert(require(require_path)[name])
-   end
-   function decoder:config()
-      return binary.load_compiled_data_file(self:string()).data
-   end
-   function decoder:finish(...)
-      return { ... }
-   end
-   return decoder
 end
 
 function decode(buf, len)
@@ -204,20 +85,8 @@ end
 
 function selftest ()
    print('selftest: apps.config.action_codec')
-   local function serialize(data)
-      local tmp = random_file_name()
-      print('serializing to:', tmp)
-      binary.compile_ad_hoc_lua_data_to_file(tmp, data)
-      local loaded = binary.load_compiled_data_file(tmp)
-      assert(loaded.schema_name == '')
-      assert(lib.equal(data, loaded.data))
-      os.remove(tmp)
-   end
-   serialize('foo')
-   serialize({foo='bar'})
-   serialize({foo={qux='baz'}})
-   serialize(1)
-   serialize(1LL)
+   local lib = require("core.lib")
+   local ffi = require("ffi")
    local function test_action(action)
       local encoded, len = encode(action)
       local decoded = decode(encoded, len)

--- a/src/apps/config/alarm_codec.lua
+++ b/src/apps/config/alarm_codec.lua
@@ -1,0 +1,88 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+module(...,package.seeall)
+
+local S = require("syscall")
+local channel = require("apps.config.channel")
+local codec = require("apps.config.codec")
+
+local alarm_names = { 'raise_alarm', 'clear_alarm' }
+local alarm_codes = {}
+for i, name in ipairs(alarm_names) do alarm_codes[name] = i end
+
+local alarms_channel
+
+local alarms = {}
+
+function alarms.raise_alarm (codec, key, args)
+   key = codec:table(key)
+   args = codec:table(args)
+   return codec:finish(key, args)
+end
+function alarms.clear_alarm (codec, key, args)
+   key = codec:table(key)
+   args = codec:table(args)
+   return codec:finish(key, args)
+end
+
+function encode (alarm)
+   local name, args = unpack(alarm)
+   local encoder = codec.encoder()
+   encoder:uint32(assert(alarm_codes[name], name))
+   return assert(alarms[name], name)(encoder, unpack(args))
+end
+
+function decode (buf, len)
+   local codec = codec.decoder(buf, len)
+   local name = assert(alarm_names[codec:uint32()])
+   return { name, assert(alarms[name], name)(codec) }
+end
+
+local function get_channel ()
+   if alarms_channel then return alarms_channel end
+   local name = '/'..S.getpid()..'/alarms-follower-channel'
+   local success, value = pcall(channel.open, name)
+   if success then
+      alarms_channel = value
+   end
+   return alarms_channel
+end
+
+-- To be called by the data-plane to signal an alarm was raised.
+-- XXX: Limiting mechanism to avoid sending messages too often.
+function raise_alarm (key, args)
+   local channel = get_channel()
+   if channel then
+      args = args or {}
+      args.is_cleared = false
+      local buf, len = encode({'raise_alarm', {key, args}})
+      channel:put_message(buf, len)
+   end
+end
+-- To be called by the data-plane to signal an alarm was cleared.
+-- XXX: Limiting mechanism to avoid sending messages too often.
+function clear_alarm (key, args)
+   local channel = get_channel()
+   if channel then
+      args = args or {}
+      args.is_cleared = true
+      local buf, len = encode({'clear_alarm', {key, args}})
+      channel:put_message(buf, len)
+   end
+end
+
+function selftest ()
+   print('selftest: apps.config.alarm_codec')
+   local lib = require("core.lib")
+   local ffi = require("ffi")
+   local function test_alarm(alarm)
+      local encoded, len = encode(alarm)
+      local decoded = decode(encoded, len)
+      assert(lib.equal(alarm, decoded))
+   end
+   local key = {resource='resource', alarm_type_id='alarm_type_id',
+                alarm_type_qualifier='alarm_type_qualifier'}
+   local args = {}
+   test_alarm({'raise_alarm', {key, args}})
+   test_alarm({'clear_alarm', {key, args}})
+   print('selftest: ok')
+end

--- a/src/apps/config/codec.lua
+++ b/src/apps/config/codec.lua
@@ -135,10 +135,28 @@ function selftest ()
       assert(lib.equal(data, loaded.data))
       os.remove(tmp)
    end
+   local function encode_decode (data)
+      local buf, len
+      local encode = encoder()
+      if type(data) == 'number' then
+         encode:uint32(data)
+         local decode = decoder(encode:finish())
+         assert(data == decode:uint32())
+      elseif type(data) == 'string' then
+         encode:string(data)
+         local decode = decoder(encode:finish())
+         assert(data == decode:string())
+      end
+   end
+
    serialize('foo')
    serialize({foo='bar'})
    serialize({foo={qux='baz'}})
    serialize(1)
    serialize(1LL)
+
+   encode_decode('foo')
+   encode_decode(1)
+
    print('selftest: ok')
 end

--- a/src/apps/config/codec.lua
+++ b/src/apps/config/codec.lua
@@ -1,0 +1,144 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(...,package.seeall)
+
+local S = require("syscall")
+local lib = require("core.lib")
+local ffi = require("ffi")
+local yang = require("lib.yang.yang")
+local binary = require("lib.yang.binary")
+local shm = require("core.shm")
+
+local public_names = {}
+local function find_public_name(obj)
+   if public_names[obj] then return unpack(public_names[obj]) end
+   for modname, mod in pairs(package.loaded) do
+      if type(mod) == 'table' then
+         for name, val in pairs(mod) do
+            if val == obj then
+               if type(val) == 'table' and type(val.new) == 'function' then
+                  public_names[obj] = { modname, name }
+                  return modname, name
+               end
+            end
+         end
+      end
+   end
+   error('could not determine public name for object: '..tostring(obj))
+end
+
+local lower_case = "abcdefghijklmnopqrstuvwxyz"
+local upper_case = lower_case:upper()
+local extra = "0123456789_-"
+local alphabet = table.concat({lower_case, upper_case, extra})
+assert(#alphabet == 64)
+local function random_file_name()
+   -- 22 bytes, but we only use 2^6=64 bits from each byte, so total of
+   -- 132 bits of entropy.
+   local bytes = lib.random_data(22)
+   local out = {}
+   for i=1,#bytes do
+      table.insert(out, alphabet:byte(bytes:byte(i) % 64 + 1))
+   end
+   local basename = string.char(unpack(out))
+   return shm.root..'/'..tostring(S.getpid())..'/app-conf-'..basename
+end
+
+function encoder()
+   local encoder = { out = {} }
+   function encoder:uint32(len)
+      table.insert(self.out, ffi.new('uint32_t[1]', len))
+   end
+   function encoder:string(str)
+      self:uint32(#str)
+      local buf = ffi.new('uint8_t[?]', #str)
+      ffi.copy(buf, str, #str)
+      table.insert(self.out, buf)
+   end
+   function encoder:blob(blob)
+      self:uint32(ffi.sizeof(blob))
+      table.insert(self.out, blob)
+   end
+   function encoder:class(class)
+      local require_path, name = find_public_name(class)
+      self:string(require_path)
+      self:string(name)
+   end
+   function encoder:config(class, arg)
+      local file_name = random_file_name()
+      if class.yang_schema then
+         yang.compile_data_for_schema_by_name(class.yang_schema, arg,
+                                              file_name)
+      else
+         if arg == nil then arg = {} end
+         binary.compile_ad_hoc_lua_data_to_file(file_name, arg)
+      end
+      self:string(file_name)
+   end
+   function encoder:finish()
+      local size = 0
+      for _,src in ipairs(self.out) do size = size + ffi.sizeof(src) end
+      local dst = ffi.new('uint8_t[?]', size)
+      local pos = 0
+      for _,src in ipairs(self.out) do
+         ffi.copy(dst + pos, src, ffi.sizeof(src))
+         pos = pos + ffi.sizeof(src)
+      end
+      return dst, size
+   end
+   return encoder
+end
+
+local uint32_ptr_t = ffi.typeof('uint32_t*')
+function decoder(buf, len)
+   local decoder = { buf=buf, len=len, pos=0 }
+   function decoder:read(count)
+      local ret = self.buf + self.pos
+      self.pos = self.pos + count
+      assert(self.pos <= self.len)
+      return ret
+   end
+   function decoder:uint32()
+      return ffi.cast(uint32_ptr_t, self:read(4))[0]
+   end
+   function decoder:string()
+      local len = self:uint32()
+      return ffi.string(self:read(len), len)
+   end
+   function decoder:blob()
+      local len = self:uint32()
+      local blob = ffi.new('uint8_t[?]', len)
+      ffi.copy(blob, self:read(len), len)
+      return blob
+   end
+   function decoder:class()
+      local require_path, name = self:string(), self:string()
+      return assert(require(require_path)[name])
+   end
+   function decoder:config()
+      return binary.load_compiled_data_file(self:string()).data
+   end
+   function decoder:finish(...)
+      return { ... }
+   end
+   return decoder
+end
+
+function selftest ()
+   print('selftest: apps.config.codec')
+   local function serialize(data)
+      local tmp = random_file_name()
+      print('serializing to:', tmp)
+      binary.compile_ad_hoc_lua_data_to_file(tmp, data)
+      local loaded = binary.load_compiled_data_file(tmp)
+      assert(loaded.schema_name == '')
+      assert(lib.equal(data, loaded.data))
+      os.remove(tmp)
+   end
+   serialize('foo')
+   serialize({foo='bar'})
+   serialize({foo={qux='baz'}})
+   serialize(1)
+   serialize(1LL)
+   print('selftest: ok')
+end

--- a/src/apps/config/codec.lua
+++ b/src/apps/config/codec.lua
@@ -66,7 +66,7 @@ function encoder()
    end
    function encoder:config(class, arg)
       local file_name = random_file_name()
-      if class.yang_schema then
+      if class and class.yang_schema then
          yang.compile_data_for_schema_by_name(class.yang_schema, arg,
                                               file_name)
       else
@@ -146,6 +146,10 @@ function selftest ()
          encode:string(data)
          local decode = decoder(encode:finish())
          assert(data == decode:string())
+      elseif type(data) == 'table' then
+         encode:config(nil, data)
+         local decode = decoder(encode:finish())
+         assert(lib.equal(data, decode:config()))
       end
    end
 
@@ -156,6 +160,8 @@ function selftest ()
    serialize(1LL)
 
    encode_decode('foo')
+   encode_decode({foo='bar'})
+   encode_decode({foo={qux='baz'}})
    encode_decode(1)
 
    print('selftest: ok')

--- a/src/apps/config/follower.lua
+++ b/src/apps/config/follower.lua
@@ -23,6 +23,7 @@ function Follower:new (conf)
    ret.period = 1/conf.Hz
    ret.next_time = app.now()
    ret.channel = channel.create('config-follower-channel', 1e6)
+   ret.alarms_channel = channel.create('alarms-follower-channel', 1e6)
    ret.pending_actions = {}
    return ret
 end

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -19,6 +19,8 @@ local app_graph = require("core.config")
 local action_codec = require("apps.config.action_codec")
 local support = require("apps.config.support")
 local channel = require("apps.config.channel")
+local alarms = require("lib.yang.alarms")
+local alarm_codec = require("apps.config.alarm_codec")
 
 Leader = {
    config = {
@@ -701,11 +703,45 @@ function Leader:send_messages_to_followers()
    end
 end
 
+function Leader:receive_alarms_from_followers ()
+   for _,follower in ipairs(self.followers) do
+      self:receive_alarms_from_follower(follower)
+   end
+end
+
+function Leader:receive_alarms_from_follower (follower)
+   if not follower.alarms_channel then
+      local name = '/'..tostring(follower.pid)..'/alarms-follower-channel'
+      local success, channel = pcall(channel.open, name)
+      if not success then return end
+      follower.alarms_channel = channel
+   end
+   local channel = follower.alarms_channel
+   while true do
+      local buf, len = channel:peek_message()
+      if not buf then break end
+      local alarm = alarm_codec.decode(buf, len)
+      self:handle_alarm(follower, alarm)
+      channel:discard_message(len)
+   end
+end
+
+function Leader:handle_alarm (follower, alarm)
+   local fn, args = unpack(alarm)
+   if fn == 'raise_alarm' then
+      alarms.raise_alarm(unpack(args))
+   end
+   if fn == 'clear_alarm' then
+      alarms.clear_alarm(unpack(args))
+   end
+end
+
 function Leader:pull ()
    if app.now() < self.next_time then return end
    self.next_time = app.now() + self.period
    self:handle_calls_from_peers()
    self:send_messages_to_followers()
+   self:receive_alarms_from_followers()
 end
 
 function Leader:stop ()

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -548,7 +548,7 @@ function Leader:rpc_get_state (args)
       local printer = path_printer_for_schema_by_name(self.schema_name, args.path, args)
       local s = {}
       for _, follower in pairs(self.followers) do
-         for k,v in pairs(state.show_state(self.schema_name, follower.pid, args.path)) do
+         for k,v in pairs(state.show_state(self.schema_name, follower.pid)) do
             s[k] = v
          end
       end

--- a/src/apps/lwaftr/ipv4_apps.lua
+++ b/src/apps/lwaftr/ipv4_apps.lua
@@ -16,6 +16,7 @@ local lib = require("core.lib")
 local counter = require("core.counter")
 local link = require("core.link")
 local engine = require("core.app")
+local alarm_codec = require("apps.config.alarm_codec")
 
 local receive, transmit = link.receive, link.transmit
 local wr16, rd32, wr32 = lwutil.wr16, lwutil.rd32, lwutil.wr32
@@ -137,6 +138,8 @@ function ARP:maybe_send_arp_request (output)
    self.next_arp_request_time = self.next_arp_request_time or engine.now()
    if self.next_arp_request_time <= engine.now() then
       print(("ARP: Resolving '%s'"):format(ipv4:ntop(self.conf.dst_ipv4)))
+      local key = {resource='external-interface', alarm_type_id='arp-resolution'}
+      alarm_codec.raise_alarm(key)
       self:send_arp_request(output)
       self.next_arp_request_time = engine.now() + self.arp_request_interval
    end

--- a/src/lib/yang/alarm_list.csv
+++ b/src/lib/yang/alarm_list.csv
@@ -1,0 +1,3 @@
+resource          |alarm_type_id |alarm_type_qualifier|perceived_severity|alarm_text
+external-interface|arp-resolution|                    |critical          |Make sure you can resolved external-inteface.next-hop.ip from the lwAFTR.  If cannot resolve it, consider using the MAC address of the next-hop directly.  To do it so, set external-interface.next-hop.mac to the value of the MAC address.
+internal-interface|ndp-resolution|                    |critical          |Make sure you can resolved internal-inteface.next-hop.ip from the lwAFTR.  If cannot resolve it, consider using the MAC address of the next-hop directly.  To do it so, set internal-interface.next-hop.mac to the value of the MAC address.

--- a/src/lib/yang/alarm_type.csv
+++ b/src/lib/yang/alarm_type.csv
@@ -1,0 +1,3 @@
+alarm_type_id |alarm_type_qualifier|resource           |has_clear|description
+arp-resolution|                    |external-interface#|true     |
+ndp-resolution|                    |internal-interface#|true     |

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -48,6 +48,18 @@ end
 
 state.alarm_inventory.alarm_type = load_alarm_type()
 
+function raise_alarm (key, args)
+   assert(key)
+   assert(args and not args.is_cleared)
+   print('raise alarm')
+end
+
+function clean_alarm (key, args)
+   assert(key)
+   assert(args and args.is_cleared)
+   print('clear alarm')
+end
+
 function selftest ()
    print("selftest: alarms")
    local function table_size (t)

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -3,9 +3,14 @@ module(..., package.seeall)
 local util = require("lib.yang.util")
 
 local csv_to_table = util.csv_to_table
+local iso_8601 = util.iso_8601
 
 local state = {
    alarm_inventory = {},
+   alarm_list = {
+      alarm = {},
+      number_of_alarms = 0,
+   },
 }
 
 function get_state ()
@@ -14,7 +19,7 @@ function get_state ()
    }
 end
 
--- Single point access to alarm type keys.
+-- Single point to access alarm type keys.
 alarm_type_keys = {}
 
 function alarm_type_keys:fetch (...)
@@ -48,16 +53,166 @@ end
 
 state.alarm_inventory.alarm_type = load_alarm_type()
 
-function raise_alarm (key, args)
-   assert(key)
-   assert(args and not args.is_cleared)
-   print('raise alarm')
+-- Single point to access alarm keys.
+alarm_keys = {}
+
+function alarm_keys:fetch (...)
+   self.cache = self.cache or {}
+   local function lookup (resource, alarm_type_id, alarm_type_qualifier)
+      if not self.cache[resource] then
+         self.cache[resource] = {}
+      end
+      if not self.cache[resource][alarm_type_id] then
+         self.cache[resource][alarm_type_id] = {}
+      end
+      return self.cache[resource][alarm_type_id][alarm_type_qualifier]
+   end
+   local resource, alarm_type_id, alarm_type_qualifier = unpack({...})
+   assert(resource and alarm_type_id)
+   alarm_type_qualifier = alarm_type_qualifier or ''
+   local key = lookup(resource, alarm_type_id, alarm_type_qualifier)
+   if not key then
+      key = {resource=resource, alarm_type_id=alarm_type_id,
+             alarm_type_qualifier=alarm_type_qualifier}
+      self.cache[resource][alarm_type_id][alarm_type_qualifier] = key
+   end
+   return key
+end
+function alarm_keys:normalize (key)
+   local resource = assert(key.resource)
+   local alarm_type_id = assert(key.alarm_type_id)
+   local alarm_type_qualifier = key.alarm_type_qualifier or ''
+   return self:fetch(resource, alarm_type_id, alarm_type_qualifier)
 end
 
-function clean_alarm (key, args)
+-- Keeps a list indexed by alarm key of predefined alarms.
+local alarm_db
+
+local function load_alarm_db (filename)
+   filename = filename or 'lib/yang/alarm_list.csv'
+   local ret = {}
+   for _, row in ipairs(csv_to_table(filename, {sep='|'})) do
+      local key_str = alarm_keys:normalize(row)
+      ret[key_str] = row
+   end
+   return ret
+end
+
+local function retrieve_alarm_from_db (key, args)
+   local function lookup (key)
+      alarm_db = alarm_db or load_alarm_db()
+      return alarm_db[key]
+   end
+   local function copy (src, args)
+      local ret = {}
+      for k,v in pairs(src) do ret[k] = args[k] or v end
+      return ret
+   end
+   local alarm = lookup(key)
+   if alarm then
+      return copy(alarm, args or {})
+   end
+end
+
+-- The entry with latest time-stamp in this list MUST correspond to the leafs
+-- 'is-cleared', 'perceived-severity' and 'alarm-text' for the alarm.
+-- The time-stamp for that entry MUST be equal to the 'last-changed' leaf.
+local function add_status_change (alarm, status)
+   alarm.status_change = alarm.status_change or {}
+   alarm.perceived_severity = status.perceived_severity
+   alarm.alarm_text = status.alarm_text
+   alarm.last_changed = status.time
+   state.alarm_list.last_changed = status.time
+   table.insert(alarm.status_change, status)
+end
+
+-- Creates a new alarm.
+--
+-- The alarm is retrieved from the db of predefined alarms. Default values got
+-- overridden by args. Additional fields are initialized too and an initial
+-- status change is added to the alarm.
+local function create_alarm (key, args)
+   local ret = assert(retrieve_alarm_from_db(key, args), 'Not supported alarm')
+   local status = {
+      time = iso_8601(),
+      perceived_severity = args.perceived_severity or ret.perceived_severity,
+      alarm_text = args.alarm_text or ret.alarm_text,
+   }
+   add_status_change(ret, status)
+   ret.last_changed = assert(status.time)
+   ret.time_created = assert(ret.last_changed)
+   ret.is_cleared = args.is_cleared
+   ret.operator_state_change = {}
+   state.alarm_list.number_of_alarms = state.alarm_list.number_of_alarms + 1
+   return ret
+end
+
+-- Adds alarm to state.alarm_list.
+local function add_alarm (key, args)
+   local alarm = assert(create_alarm(key, args))
+   state.alarm_list.alarm[key] = alarm
+end
+
+-- The following state changes creates a new status change:
+--   - changed severity (warning, minor, major, critical).
+--   - clearance status, this also updates the 'is-cleared' leaf.
+--   - alarm text update.
+local function needs_status_change (alarm, args)
+   if alarm.is_cleared ~= args.is_cleared then
+      return true
+   elseif args.perceived_severity and
+          alarm.perceived_severity ~= args.perceived_severity then
+      return true
+   elseif args.alarm_text and alarm.alarm_text ~= args.alarm_text then
+      return true
+   end
+   return false
+end
+
+-- An alarm gets updated if it needs a status change.  A status change implies
+-- to add a new status change to the alarm and update the alarm 'is_cleared'
+-- flag.
+local function update_alarm (alarm, args)
+   if needs_status_change(alarm, args) then
+      local status = {
+         time = assert(iso_8601()),
+         perceived_severity = assert(args.perceived_severity or alarm.perceived_severity),
+         alarm_text = assert(args.alarm_text or alarm.alarm_text),
+      }
+      add_status_change(alarm, status)
+      alarm.is_cleared = args.is_cleared
+   end
+end
+
+-- Check up if the alarm already exists in state.alarm_list.
+local function lookup_alarm (key)
+   return state.alarm_list.alarm[key]
+end
+
+function raise_alarm (key, args)
    assert(key)
-   assert(args and args.is_cleared)
-   print('clear alarm')
+   args = args or {}
+   args.is_cleared = false
+   key = alarm_keys:normalize(key)
+   local alarm = lookup_alarm(key)
+   if not alarm then
+      add_alarm(key, args)
+   else
+      update_alarm(alarm, args)
+   end
+end
+
+function clear_alarm (key, args)
+   assert(key)
+   args = args or {}
+   args.is_cleared = true
+   key = alarm_keys:normalize(key)
+   local alarm = lookup_alarm(key)
+   if not alarm then
+      add_alarm(key, args)
+   else
+      update_alarm(alarm, args)
+   end
 end
 
 function selftest ()
@@ -67,11 +222,87 @@ function selftest ()
       for _ in pairs(t) do size = size + 1 end
       return size
    end
-   local state = {
-      alarm_inventory = {
-         alarm_type = load_alarm_type(),
-      }
-   }
+   local function sleep (seconds)
+      os.execute("sleep "..tonumber(seconds))
+   end
+   local function check_status_change (alarm)
+      local status_change = alarm.status_change
+      for k, v in pairs(status_change) do
+         assert(v.perceived_severity)
+         assert(v.time)
+         assert(v.alarm_text)
+      end
+   end
+
+   -- Check alarm inventory has been loaded.
    assert(table_size(state.alarm_inventory.alarm_type) == 2)
+
+   -- Check number of alarms is zero.
+   assert(state.alarm_list.number_of_alarms == 0)
+
+   -- Raising an alarm when alarms is empty, creates an alarm.
+   local key = alarm_keys:fetch('external-interface', 'arp-resolution')
+   raise_alarm(key)
+   local alarm = assert(state.alarm_list.alarm[key])
+   assert(table_size(alarm.status_change) == 1)
+   assert(state.alarm_list.number_of_alarms == 1)
+
+   -- Raise same alarm again. Since there are not changes, everything remains the same.
+   local alarm = state.alarm_list.alarm[key]
+   local last_changed = alarm.last_changed
+   local number_of_status_change = table_size(alarm.status_change)
+   local number_of_alarms = state.alarm_list.number_of_alarms
+   sleep(1)
+   raise_alarm(key)
+   assert(state.alarm_list.alarm[key].last_changed == last_changed)
+   assert(table_size(alarm.status_change) == number_of_status_change)
+   assert(state.alarm_list.number_of_alarms == number_of_alarms)
+
+   -- Raise alarm again but changing severity.
+   local alarm = state.alarm_list.alarm[key]
+   local last_changed = alarm.last_changed
+   local number_of_status_change = table_size(alarm.status_change)
+   raise_alarm(key, {perceived_severity='minor'})
+   assert(alarm.perceived_severity == 'minor')
+   assert(last_changed ~= alarm.last_changed)
+   assert(table_size(alarm.status_change) == number_of_status_change + 1)
+   check_status_change(alarm)
+
+   -- Raise alarm again with same severity. Should not produce changes.
+   local alarm = state.alarm_list.alarm[key]
+   local last_changed = alarm.last_changed
+   local number_of_status_change = table_size(alarm.status_change)
+   raise_alarm(key, {perceived_severity='minor'})
+   assert(alarm.perceived_severity == 'minor')
+   assert(last_changed == alarm.last_changed)
+   assert(table_size(alarm.status_change) == number_of_status_change)
+
+   -- Raise alarm again but changing alarm_text. A new status change is added.
+   local alarm = state.alarm_list.alarm[key]
+   local number_of_status_change = table_size(alarm.status_change)
+   raise_alarm(key, {alarm_text='new text'})
+   assert(table_size(alarm.status_change) == number_of_status_change + 1)
+   assert(alarm.alarm_text == 'new text')
+
+   -- Clear alarm. Should clear alarm and create a new status change in the alarm.
+   local alarm = state.alarm_list.alarm[key]
+   local number_of_status_change = table_size(alarm.status_change)
+   assert(not alarm.is_cleared)
+   sleep(1)
+   clear_alarm(key)
+   assert(alarm.is_cleared)
+   assert(table_size(alarm.status_change) == number_of_status_change + 1)
+
+   -- Clear alarm again. Nothing should change.
+   local alarm = state.alarm_list.alarm[key]
+   local last_changed = alarm.last_changed
+   local number_of_status_change = table_size(alarm.status_change)
+   assert(alarm.is_cleared)
+   clear_alarm(key)
+   assert(alarm.is_cleared)
+   assert(table_size(alarm.status_change) == number_of_status_change,
+          table_size(alarm.status_change).." == "..number_of_status_change)
+   assert(alarm.last_changed == last_changed)
+
    print("ok")
 end

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -60,8 +60,17 @@ function alarm_type_keys:fetch (...)
    return key
 end
 
+local function snabb_src ()
+   local pwd = lib.getenv("PWD")
+   if pwd then
+      local pos = pwd:match(".*/src()")
+      return pos and pwd:sub(1, pos)..'/'
+   end
+   return ""
+end
+
 function load_alarm_type (filename)
-   filename = filename or 'lib/yang/alarm_type.csv'
+   filename = filename or snabb_src()..'lib/yang/alarm_type.csv'
    local ret = {}
    for _, row in ipairs(csv_to_table(filename, {sep='|'})) do
       local key = alarm_type_keys:fetch(row.alarm_type_id, row.alarm_type_qualifier)
@@ -108,7 +117,7 @@ end
 local alarm_db
 
 local function load_alarm_db (filename)
-   filename = filename or 'lib/yang/alarm_list.csv'
+   filename = filename or snabb_src()..'lib/yang/alarm_list.csv'
    local ret = {}
    for _, row in ipairs(csv_to_table(filename, {sep='|'})) do
       local key_str = alarm_keys:normalize(row)

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -1,0 +1,65 @@
+module(..., package.seeall)
+
+local util = require("lib.yang.util")
+
+local csv_to_table = util.csv_to_table
+
+local state = {
+   alarm_inventory = {},
+}
+
+function get_state ()
+   return {
+      alarm_inventory = state.alarm_inventory,
+   }
+end
+
+-- Single point access to alarm type keys.
+alarm_type_keys = {}
+
+function alarm_type_keys:fetch (...)
+   self.cache = self.cache or {}
+   local function lookup (alarm_type_id, alarm_type_qualifier)
+      if not self.cache[alarm_type_id] then
+         self.cache[alarm_type_id] = {}
+      end
+      return self.cache[alarm_type_id][alarm_type_qualifier]
+   end
+   local alarm_type_id, alarm_type_qualifier = unpack({...})
+   assert(alarm_type_id)
+   alarm_type_qualifier = alarm_type_qualifier or ''
+   local key = lookup(alarm_type_id, alarm_type_qualifier)
+   if not key then
+      key = {alarm_type_id=alarm_type_id, alarm_type_qualifier=alarm_type_qualifier}
+      self.cache[alarm_type_id][alarm_type_qualifier] = key
+   end
+   return key
+end
+
+function load_alarm_type (filename)
+   filename = filename or 'lib/yang/alarm_type.csv'
+   local ret = {}
+   for _, row in ipairs(csv_to_table(filename, {sep='|'})) do
+      local key = alarm_type_keys:fetch(row.alarm_type_id, row.alarm_type_qualifier)
+      ret[key] = row
+   end
+   return ret
+end
+
+state.alarm_inventory.alarm_type = load_alarm_type()
+
+function selftest ()
+   print("selftest: alarms")
+   local function table_size (t)
+      local size = 0
+      for _ in pairs(t) do size = size + 1 end
+      return size
+   end
+   local state = {
+      alarm_inventory = {
+         alarm_type = load_alarm_type(),
+      }
+   }
+   assert(table_size(state.alarm_inventory.alarm_type) == 2)
+   print("ok")
+end

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -234,6 +234,7 @@ local function data_emitter(production)
       end
    end
    local native_types = {
+      ['instance-identifier'] = true,
       enumeration = true,
       identityref = true,
       string = true,

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -233,13 +233,13 @@ local function data_emitter(production)
          end
       end
    end
-   local native_types = {
-      ['instance-identifier'] = true,
-      leafref = true,
-      enumeration = true,
-      identityref = true,
-      string = true,
-   }
+   local function set (t)
+      local ret = {}
+      for _, k in ipairs(t) do ret[k] = true end
+      return ret
+   end
+   local native_types = set({'enumeration', 'identityref', 'instance-identifier',
+                             'leafref', 'string'})
    function handlers.scalar(production)
       local primitive_type = production.argument_type.primitive_type
       local type = assert(value.types[primitive_type], "unsupported type: "..primitive_type)

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -235,6 +235,7 @@ local function data_emitter(production)
    end
    local native_types = {
       ['instance-identifier'] = true,
+      leafref = true,
       enumeration = true,
       identityref = true,
       string = true,

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -247,6 +247,11 @@ local function data_emitter(production)
             stream:write_stringref('stringref')
             stream:write_stringref(data)
          end
+      elseif primitive_type == 'empty' then
+         return function (data, stream)
+            stream:write_stringref('stringref')
+            stream:write_stringref('')
+         end
       elseif type.ctype then
          local ctype = type.ctype
          local emit_value = value_emitter(ctype)
@@ -503,6 +508,12 @@ function selftest()
             }
          }
       }
+
+      container foo {
+         leaf enable-qos {
+            type empty;
+         }
+      }
    }]])
    local data = data.load_data_for_schema(test_schema, [[
       is-active true;
@@ -519,6 +530,9 @@ function selftest()
       }
       next-hop {
          ipv4 5.6.7.8;
+      }
+      foo {
+         enable-qos;
       }
    ]])
 

--- a/src/lib/yang/ietf-alarms.yang
+++ b/src/lib/yang/ietf-alarms.yang
@@ -152,11 +152,11 @@ module ietf-alarms {
 
     typedef resource {
         type union {
+            type string;
             type instance-identifier {
                 require-instance false;
             }
             type yang:object-identifier;
-            type string;
         }
         description
             "This is an identification of the alarming resource, such as an
@@ -305,9 +305,13 @@ module ietf-alarms {
     /* Alarm type */
 
     typedef alarm-type-id {
+        /* FIXME: identityref is not supported, temporarily replace for string. */
+        /*
         type identityref {
             base alarm-identity;
         }
+        */
+        type string;
         description
             "Identifies an alarm type.  The description of the alarm type
             id MUST indicate if the alarm type is abstract or not.  An

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -355,367 +355,369 @@ module snabb-softwire-v2 {
     description "State data about lwaftr.";
     config false;
 
-    leaf drop-all-ipv4-iface-bytes {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv4 interfaces,
-         whether or not they actually IPv4 (they only include data about
-         packets that go in/out over the wires, excluding internally generated
-         ICMP packets).";
-    }
-    leaf drop-all-ipv4-iface-packets {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv4 interfaces,
-         whether or not they actually IPv4 (they only include data about
-         packets that go in/out over the wires, excluding internally generated
-         ICMP packets).";
-    }
-    leaf drop-all-ipv6-iface-bytes {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv6 interfaces,
-         whether or not they actually IPv6 (they only include data about packets
-         that go in/out over the wires, excluding internally generated ICMP
-         packets).";
-    }
-    leaf drop-all-ipv6-iface-packets {
-      type yang:zero-based-counter64;
-      description
-        "All dropped packets and bytes that came in over IPv6 interfaces,
-         whether or not they actually IPv6 (they only include data about packets
-         that go in/out over the wires, excluding internally generated ICMP
-         packets).";
-    }
-    leaf drop-bad-checksum-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description "ICMPv4 packets dropped because of a bad checksum.";
-    }
-    leaf drop-bad-checksum-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description "ICMPv4 packets dropped because of a bad checksum.";
-    }
-    leaf drop-in-by-policy-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv4 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-policy-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv4 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-policy-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv6 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-policy-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description "Incoming ICMPv6 packets dropped because of current policy.";
-    }
-    leaf drop-in-by-rfc7596-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
-    }
-    leaf drop-in-by-rfc7596-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
-    }
-    leaf drop-ipv4-frag-disabled {
-      type yang:zero-based-counter64;
-      description
-        "If fragmentation is disabled, the only potentially non-zero IPv4
-         fragmentation counter is drop-ipv4-frag-disabled. If fragmentation is
-         enabled, it will always be zero.";
-    }
-    leaf drop-ipv4-frag-invalid-reassembly {
-      type yang:zero-based-counter64;
-      description
-        "Two or more IPv4 fragments were received, and reassembly was started,
-         but was invalid and dropped. Causes include multiple fragments claiming
-         they are the last fragment, overlapping fragment offsets, or the packet
-         was being reassembled from too many fragments (the setting is
-         max_fragments_per_reassembly_packet, and the default is that no packet
-         should be reassembled from more than 40).";
-    }
-    leaf drop-ipv4-frag-random-evicted {
-      type yang:zero-based-counter64;
-      description
-        "Reassembling an IPv4 packet from fragments was in progress, but the
-         configured amount of packets to reassemble at once was exceeded, so one
-         was dropped at random. Consider increasing the setting
-         max_ipv4_reassembly_packets.";
-    }
-    leaf drop-ipv6-frag-disabled {
-      type yang:zero-based-counter64;
-      description
-        "If fragmentation is disabled, the only potentially non-zero IPv6
-         fragmentation counter is drop-ipv6-frag-disabled. If fragmentation is
-         enabled, it will always be zero.";
-    }
-    leaf drop-ipv6-frag-invalid-reassembly {
-      type yang:zero-based-counter64;
-      description
-        "Two or more IPv6 fragments were received, and reassembly was started,
-         but was invalid and dropped. Causes include multiple fragments claiming
-         they are the last fragment, overlapping fragment offsets, or the packet
-         was being reassembled from too many fragments (the setting is
-         max_fragments_per_reassembly_packet, and the default is that no packet
-         should be reassembled from more than 40).";
-    }
-    leaf drop-ipv6-frag-random-evicted {
-      type yang:zero-based-counter64;
-      description
-        "Reassembling an IPv6 packet from fragments was in progress, but the
-        configured amount of packets to reassemble at once was exceeded, so one
-        was dropped at random. Consider increasing the setting
-        max_ipv6_reassembly_packets.";
-    }
-    leaf drop-misplaced-not-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "Non-IPv4 packets incoming on the IPv4 link.";
-    }
-    leaf drop-misplaced-not-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "Non-IPv4 packets incoming on the IPv4 link.";
-    }
-    leaf drop-misplaced-not-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "Non-IPv6 packets incoming on IPv6 link.";
-    }
-    leaf drop-misplaced-not-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "Non-IPv6 packets incoming on IPv6 link.";
-    }
-    leaf drop-no-dest-softwire-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description
-        "No matching destination softwire in the binding table; incremented
-         whether or not the reason was RFC7596.";
-    }
-    leaf drop-no-dest-softwire-ipv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "No matching destination softwire in the binding table; incremented
-         whether or not the reason was RFC7596.";
-    }
-    leaf drop-no-source-softwire-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "No matching source softwire in the binding table; incremented whether
-         or not the reason was RFC7596.";
-    }
-    leaf drop-no-source-softwire-ipv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "No matching source softwire in the binding table; incremented whether
-         or not the reason was RFC7596.";
-    }
-    leaf drop-out-by-policy-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "Internally generated ICMPv4 error packets dropped because of current
-         policy.";
-    }
-    leaf drop-out-by-policy-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Internally generated ICMPv6 packets dropped because of current
-         policy.";
-    }
-    leaf drop-over-mtu-but-dont-fragment-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description
-        "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
-         flag was set.";
-    }
-    leaf drop-over-mtu-but-dont-fragment-ipv4-packets {
-      type yang:zero-based-counter64;
-      description
-        "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
-         flag was set.";
-    }
-    leaf drop-over-rate-limit-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
-    }
-    leaf drop-over-rate-limit-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
-    }
-    leaf drop-over-time-but-not-hop-limit-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Packet's time limit was exceeded, but the hop limit was not.";
-    }
-    leaf drop-over-time-but-not-hop-limit-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Packet's time limit was exceeded, but the hop limit was not.";
-    }
-    leaf drop-too-big-type-but-not-code-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description
-        "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
-         acceptable one for this type.";
-    }
-    leaf drop-too-big-type-but-not-code-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description
-        "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
-         acceptable one for this type.";
-    }
-    leaf drop-ttl-zero-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "IPv4 packets dropped because their TTL was zero.";
-    }
-    leaf drop-ttl-zero-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "IPv4 packets dropped because their TTL was zero.";
-    }
-    leaf drop-unknown-protocol-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown ICMPv6 protocol.";
-    }
-    leaf drop-unknown-protocol-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown ICMPv6 protocol.";
-    }
-    leaf drop-unknown-protocol-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown IPv6 protocol.";
-    }
-    leaf drop-unknown-protocol-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "Packets with an unknown IPv6 protocol.";
-    }
-    leaf hairpin-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "IPv4 packets going to a known b4 (hairpinned).";
-    }
-    leaf hairpin-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "IPv4 packets going to a known b4 (hairpinned).";
-    }
-    leaf in-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf in-ipv4-frag-needs-reassembly {
-      type yang:zero-based-counter64;
-      description "An IPv4 fragment was received.";
-    }
-    leaf in-ipv4-frag-reassembled {
-      type yang:zero-based-counter64;
-      description "A packet was successfully reassembled from IPv4 fragments.";
-    }
-    leaf in-ipv4-frag-reassembly-unneeded {
-      type yang:zero-based-counter64;
-      description
-        "An IPv4 packet which was not a fragment was received - consequently,
-         it did not need to be reassembled. This should be the usual case.";
-    }
-    leaf in-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf in-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf in-ipv6-frag-needs-reassembly {
-      type yang:zero-based-counter64;
-      description "An IPv6 fragment was received.";
-    }
-    leaf in-ipv6-frag-reassembled {
-      type yang:zero-based-counter64;
-      description "A packet was successfully reassembled from IPv6 fragments.";
-    }
-    leaf in-ipv6-frag-reassembly-unneeded {
-      type yang:zero-based-counter64;
-      description
-        "An IPv6 packet which was not a fragment was received - consequently, it
-         did not need to be reassembled. This should be the usual case.";
-    }
-    leaf in-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv4 packets.";
-    }
-    leaf ingress-packet-drops {
-      type yang:zero-based-counter64;
-      description "Packets dropped due to ingress filters.";
-    }
-    leaf memuse-ipv4-frag-reassembly-buffer {
-      type yang:zero-based-counter64;
-      description
-        "The amount of memory being used by the statically sized data structure
-         for reassembling IPv4 fragments. This is directly proportional to the
-        setting max_ipv4_reassembly_packets.";
-    }
-    leaf memuse-ipv6-frag-reassembly-buffer {
-      type yang:zero-based-counter64;
-      description
-        "The amount of memory being used by the statically sized data structure
-         for reassembling IPv6 fragments. This is directly proportional to the
-         setting max_ipv6_reassembly_packets.";
-    }
-    leaf out-icmpv4-bytes {
-      type yang:zero-based-counter64;
-      description "Internally generated ICMPv4 packets.";
-    }
-    leaf out-icmpv4-packets {
-      type yang:zero-based-counter64;
-      description "Internally generated ICMPv4 packets.";
-    }
-    leaf out-icmpv6-bytes {
-      type yang:zero-based-counter64;
-      description "Internally generted ICMPv6 error packets.";
-    }
-    leaf out-icmpv6-packets {
-      type yang:zero-based-counter64;
-      description "Internally generted ICMPv6 error packets.";
-    }
-    leaf out-ipv4-bytes {
-      type yang:zero-based-counter64;
-      description "Valid outgoing IPv4 packets.";
-    }
-    leaf out-ipv4-frag {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet exceeded the configured IPv4 MTU, so needed to be
-         fragmented. This may happen, but should be unusual.";
-    }
-    leaf out-ipv4-frag-not {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet was small enough to pass through unfragmented - this
-         should be the usual case.";
-    }
-    leaf out-ipv4-packets {
-      type yang:zero-based-counter64;
-      description "Valid outgoing IPv4 packets.";
-    }
-    leaf out-ipv6-bytes {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv6 packets.";
-    }
-    leaf out-ipv6-frag {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet exceeded the configured IPv6 MTU, so needed to be
-        fragmented. This may happen, but should be unusual.";
-    }
-    leaf out-ipv6-frag-not {
-      type yang:zero-based-counter64;
-      description
-        "An outgoing packet was small enough to pass through unfragmented - this
-         should be the usual case.";
-    }
-    leaf out-ipv6-packets {
-      type yang:zero-based-counter64;
-      description "All valid outgoing IPv6 packets.";
+    container counters {
+      leaf drop-all-ipv4-iface-bytes {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv4 interfaces,
+           whether or not they actually IPv4 (they only include data about
+           packets that go in/out over the wires, excluding internally generated
+           ICMP packets).";
+      }
+      leaf drop-all-ipv4-iface-packets {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv4 interfaces,
+           whether or not they actually IPv4 (they only include data about
+           packets that go in/out over the wires, excluding internally generated
+           ICMP packets).";
+      }
+      leaf drop-all-ipv6-iface-bytes {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv6 interfaces,
+           whether or not they actually IPv6 (they only include data about packets
+           that go in/out over the wires, excluding internally generated ICMP
+           packets).";
+      }
+      leaf drop-all-ipv6-iface-packets {
+        type yang:zero-based-counter64;
+        description
+          "All dropped packets and bytes that came in over IPv6 interfaces,
+           whether or not they actually IPv6 (they only include data about packets
+           that go in/out over the wires, excluding internally generated ICMP
+           packets).";
+      }
+      leaf drop-bad-checksum-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description "ICMPv4 packets dropped because of a bad checksum.";
+      }
+      leaf drop-bad-checksum-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description "ICMPv4 packets dropped because of a bad checksum.";
+      }
+      leaf drop-in-by-policy-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv4 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-policy-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv4 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-policy-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv6 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-policy-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description "Incoming ICMPv6 packets dropped because of current policy.";
+      }
+      leaf drop-in-by-rfc7596-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
+      }
+      leaf drop-in-by-rfc7596-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "Incoming ICMPv4 packets with no destination (RFC 7596 section 8.1).";
+      }
+      leaf drop-ipv4-frag-disabled {
+        type yang:zero-based-counter64;
+        description
+          "If fragmentation is disabled, the only potentially non-zero IPv4
+           fragmentation counter is drop-ipv4-frag-disabled. If fragmentation is
+           enabled, it will always be zero.";
+      }
+      leaf drop-ipv4-frag-invalid-reassembly {
+        type yang:zero-based-counter64;
+        description
+          "Two or more IPv4 fragments were received, and reassembly was started,
+           but was invalid and dropped. Causes include multiple fragments claiming
+           they are the last fragment, overlapping fragment offsets, or the packet
+           was being reassembled from too many fragments (the setting is
+           max_fragments_per_reassembly_packet, and the default is that no packet
+           should be reassembled from more than 40).";
+      }
+      leaf drop-ipv4-frag-random-evicted {
+        type yang:zero-based-counter64;
+        description
+          "Reassembling an IPv4 packet from fragments was in progress, but the
+           configured amount of packets to reassemble at once was exceeded, so one
+           was dropped at random. Consider increasing the setting
+           max_ipv4_reassembly_packets.";
+      }
+      leaf drop-ipv6-frag-disabled {
+        type yang:zero-based-counter64;
+        description
+          "If fragmentation is disabled, the only potentially non-zero IPv6
+           fragmentation counter is drop-ipv6-frag-disabled. If fragmentation is
+           enabled, it will always be zero.";
+      }
+      leaf drop-ipv6-frag-invalid-reassembly {
+        type yang:zero-based-counter64;
+        description
+          "Two or more IPv6 fragments were received, and reassembly was started,
+           but was invalid and dropped. Causes include multiple fragments claiming
+           they are the last fragment, overlapping fragment offsets, or the packet
+           was being reassembled from too many fragments (the setting is
+           max_fragments_per_reassembly_packet, and the default is that no packet
+           should be reassembled from more than 40).";
+      }
+      leaf drop-ipv6-frag-random-evicted {
+        type yang:zero-based-counter64;
+        description
+          "Reassembling an IPv6 packet from fragments was in progress, but the
+          configured amount of packets to reassemble at once was exceeded, so one
+          was dropped at random. Consider increasing the setting
+          max_ipv6_reassembly_packets.";
+      }
+      leaf drop-misplaced-not-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "Non-IPv4 packets incoming on the IPv4 link.";
+      }
+      leaf drop-misplaced-not-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "Non-IPv4 packets incoming on the IPv4 link.";
+      }
+      leaf drop-misplaced-not-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "Non-IPv6 packets incoming on IPv6 link.";
+      }
+      leaf drop-misplaced-not-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "Non-IPv6 packets incoming on IPv6 link.";
+      }
+      leaf drop-no-dest-softwire-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description
+          "No matching destination softwire in the binding table; incremented
+           whether or not the reason was RFC7596.";
+      }
+      leaf drop-no-dest-softwire-ipv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "No matching destination softwire in the binding table; incremented
+           whether or not the reason was RFC7596.";
+      }
+      leaf drop-no-source-softwire-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "No matching source softwire in the binding table; incremented whether
+           or not the reason was RFC7596.";
+      }
+      leaf drop-no-source-softwire-ipv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "No matching source softwire in the binding table; incremented whether
+           or not the reason was RFC7596.";
+      }
+      leaf drop-out-by-policy-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "Internally generated ICMPv4 error packets dropped because of current
+           policy.";
+      }
+      leaf drop-out-by-policy-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Internally generated ICMPv6 packets dropped because of current
+           policy.";
+      }
+      leaf drop-over-mtu-but-dont-fragment-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description
+          "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
+           flag was set.";
+      }
+      leaf drop-over-mtu-but-dont-fragment-ipv4-packets {
+        type yang:zero-based-counter64;
+        description
+          "IPv4 packets whose size exceeded the MTU, but the DF (Don't Fragment)
+           flag was set.";
+      }
+      leaf drop-over-rate-limit-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
+      }
+      leaf drop-over-rate-limit-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Packets dropped because the outgoing ICMPv6 rate limit was reached.";
+      }
+      leaf drop-over-time-but-not-hop-limit-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Packet's time limit was exceeded, but the hop limit was not.";
+      }
+      leaf drop-over-time-but-not-hop-limit-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Packet's time limit was exceeded, but the hop limit was not.";
+      }
+      leaf drop-too-big-type-but-not-code-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description
+          "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
+           acceptable one for this type.";
+      }
+      leaf drop-too-big-type-but-not-code-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description
+          "Packet's ICMP type was 'Packet too big' but its ICMP code was not an
+           acceptable one for this type.";
+      }
+      leaf drop-ttl-zero-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "IPv4 packets dropped because their TTL was zero.";
+      }
+      leaf drop-ttl-zero-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "IPv4 packets dropped because their TTL was zero.";
+      }
+      leaf drop-unknown-protocol-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown ICMPv6 protocol.";
+      }
+      leaf drop-unknown-protocol-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown ICMPv6 protocol.";
+      }
+      leaf drop-unknown-protocol-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown IPv6 protocol.";
+      }
+      leaf drop-unknown-protocol-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "Packets with an unknown IPv6 protocol.";
+      }
+      leaf hairpin-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "IPv4 packets going to a known b4 (hairpinned).";
+      }
+      leaf hairpin-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "IPv4 packets going to a known b4 (hairpinned).";
+      }
+      leaf in-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf in-ipv4-frag-needs-reassembly {
+        type yang:zero-based-counter64;
+        description "An IPv4 fragment was received.";
+      }
+      leaf in-ipv4-frag-reassembled {
+        type yang:zero-based-counter64;
+        description "A packet was successfully reassembled from IPv4 fragments.";
+      }
+      leaf in-ipv4-frag-reassembly-unneeded {
+        type yang:zero-based-counter64;
+        description
+          "An IPv4 packet which was not a fragment was received - consequently,
+           it did not need to be reassembled. This should be the usual case.";
+      }
+      leaf in-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf in-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf in-ipv6-frag-needs-reassembly {
+        type yang:zero-based-counter64;
+        description "An IPv6 fragment was received.";
+      }
+      leaf in-ipv6-frag-reassembled {
+        type yang:zero-based-counter64;
+        description "A packet was successfully reassembled from IPv6 fragments.";
+      }
+      leaf in-ipv6-frag-reassembly-unneeded {
+        type yang:zero-based-counter64;
+        description
+          "An IPv6 packet which was not a fragment was received - consequently, it
+           did not need to be reassembled. This should be the usual case.";
+      }
+      leaf in-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv4 packets.";
+      }
+      leaf ingress-packet-drops {
+        type yang:zero-based-counter64;
+        description "Packets dropped due to ingress filters.";
+      }
+      leaf memuse-ipv4-frag-reassembly-buffer {
+        type yang:zero-based-counter64;
+        description
+          "The amount of memory being used by the statically sized data structure
+           for reassembling IPv4 fragments. This is directly proportional to the
+          setting max_ipv4_reassembly_packets.";
+      }
+      leaf memuse-ipv6-frag-reassembly-buffer {
+        type yang:zero-based-counter64;
+        description
+          "The amount of memory being used by the statically sized data structure
+           for reassembling IPv6 fragments. This is directly proportional to the
+           setting max_ipv6_reassembly_packets.";
+      }
+      leaf out-icmpv4-bytes {
+        type yang:zero-based-counter64;
+        description "Internally generated ICMPv4 packets.";
+      }
+      leaf out-icmpv4-packets {
+        type yang:zero-based-counter64;
+        description "Internally generated ICMPv4 packets.";
+      }
+      leaf out-icmpv6-bytes {
+        type yang:zero-based-counter64;
+        description "Internally generted ICMPv6 error packets.";
+      }
+      leaf out-icmpv6-packets {
+        type yang:zero-based-counter64;
+        description "Internally generted ICMPv6 error packets.";
+      }
+      leaf out-ipv4-bytes {
+        type yang:zero-based-counter64;
+        description "Valid outgoing IPv4 packets.";
+      }
+      leaf out-ipv4-frag {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet exceeded the configured IPv4 MTU, so needed to be
+           fragmented. This may happen, but should be unusual.";
+      }
+      leaf out-ipv4-frag-not {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet was small enough to pass through unfragmented - this
+           should be the usual case.";
+      }
+      leaf out-ipv4-packets {
+        type yang:zero-based-counter64;
+        description "Valid outgoing IPv4 packets.";
+      }
+      leaf out-ipv6-bytes {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv6 packets.";
+      }
+      leaf out-ipv6-frag {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet exceeded the configured IPv6 MTU, so needed to be
+          fragmented. This may happen, but should be unusual.";
+      }
+      leaf out-ipv6-frag-not {
+        type yang:zero-based-counter64;
+        description
+          "An outgoing packet was small enough to pass through unfragmented - this
+           should be the usual case.";
+      }
+      leaf out-ipv6-packets {
+        type yang:zero-based-counter64;
+        description "All valid outgoing IPv6 packets.";
+      }
     }
   }
 }

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -4,6 +4,7 @@ module snabb-softwire-v2 {
 
   import ietf-inet-types { prefix inet; }
   import ietf-yang-types { prefix yang; }
+  import ietf-alarms { prefix al; }
 
   organization "Igalia, S.L.";
   contact "Jessica Tallon <tsyesika@igalia.com>";
@@ -259,7 +260,7 @@ module snabb-softwire-v2 {
           description
            "Public IPv4 address of the softwire.";
         }
-        
+
         leaf padding {
           type uint16;
           default 0;
@@ -345,6 +346,97 @@ module snabb-softwire-v2 {
               ports (for example) from being mapped to customers.  Note
               that psid-length and shift must add up to less than or
               equal to 16.";
+          }
+        }
+      }
+    }
+
+    container alarms {
+      description
+        "The top container for this module";
+
+      container control {
+        description
+          "Configuration to control the alarm behaviour.";
+
+        leaf max-alarm-status-changes {
+          type union {
+            type uint16;
+            type enumeration {
+              enum infinite {
+                description
+                  "The status change entries are accumulated
+                  infinitely.";
+              }
+            }
+          }
+          default 32;
+          description
+            "The status-change entries are kept in a circular list
+            per alarm.  When this number is exceeded, the oldest
+            status change entry is automatically removed.  If the
+            value is 'infinite', the status change entries are
+            accumulated infinitely.";
+        }
+
+        leaf notify-status-changes {
+          type boolean;
+          default false;
+          description
+            "This leaf controls whether notifications are sent on all
+            alarm status updates, e.g., updated perceived-severity or
+            alarm-text.  By default the notifications are only sent
+            when a new alarm is raised, re-raised after being cleared
+            and when an alarm is cleared.";
+        }
+        container alarm-shelving {
+          if-feature al:alarm-shelving;
+          description
+            "This list is used to shelve alarms.  The server will move
+            any alarms corresponding to the shelving criteria from the
+            alarms/alarm-list/alarm list to the
+            alarms/shelved-alarms/shelved-alarm list.  It will also
+            stop sending notifications for the shelved alarms.  The
+            conditions in the shelf criteria are logically ANDed.
+            When the shelving criteria is deleted or changed, the
+            non-matching alarms MUST appear in the
+            alarms/alarm-list/alarm list according to the real state.
+            This means that the instrumentation MUST maintain states
+            for the shelved alarms.  Alarms that match the criteria
+              shall have an operator-state 'shelved'.";
+          list shelf {
+            key shelf-name;
+            leaf shelf-name {
+              type string;
+              description
+                "An arbitrary name for the alarm shelf.";
+            }
+            description
+              "Each entry defines the criteria for shelving alarms.
+              Criterias are ANDed.";
+
+            leaf resource {
+              type al:resource;
+              description
+                "Shelve alarms for this resource.";
+            }
+            leaf alarm-type-id {
+              type al:alarm-type-id;
+              description
+                "Shelve alarms for this alarm type identifier.";
+            }
+            leaf alarm-type-qualifier {
+              type al:alarm-type-qualifier;
+              description
+                "Shelve alarms for this alarm type qualifier.";
+            }
+            leaf description {
+              type string;
+              description
+                "An optional textual description of the shelf.  This
+                description should include the reason for shelving
+                these alarms.";
+            }
           }
         }
       }
@@ -717,6 +809,287 @@ module snabb-softwire-v2 {
       leaf out-ipv6-packets {
         type yang:zero-based-counter64;
         description "All valid outgoing IPv6 packets.";
+      }
+    }
+
+    container alarms {
+      description
+        "The top container for this module";
+
+      container alarm-inventory {
+        config false;
+        description
+          "This list contains all possible alarm types for the system.
+          If the system knows for wich resources a a specific alarm
+          type can appear, this is also identified in the inventory.
+          The list also tells if each alarm type has a corresponding
+          clear state.  The inventory shall only contain concrete
+          alarm types.
+
+          The alarm inventory MUST be updated by the system when new
+          alarms can appear.  This can be the case when installing new
+          software modules or inserting new card types.  A
+          notification 'alarm-inventory-changed' is sent when the
+          inventory is changed.";
+
+        list alarm-type {
+          key "alarm-type-id alarm-type-qualifier";
+          description
+            "An entry in this list defines a possible alarm.";
+          leaf alarm-type-id {
+            type al:alarm-type-id;
+            mandatory true;
+            description
+              "The statically defined alarm type identifier for this
+              possible alarm.";
+          }
+          leaf alarm-type-qualifier {
+            type al:alarm-type-qualifier;
+            description
+              "The optionally dynamically defined alarm type identifier
+              for this possible alarm.";
+          }
+          leaf-list resource {
+            type string;
+            description
+              "Optionally, specifies for which resources the alarm type
+              is valid.  This string is for human consumption but
+              SHOULD refer to paths in the model.";
+          }
+          leaf has-clear {
+            type boolean;
+            mandatory true;
+            description
+              "This leaf tells the operator if the alarm will be
+              cleared when the correct corrective action has been
+              taken.  Implementations SHOULD strive for detecting the
+              cleared state for all alarm types.  If this leaf is
+              true, the operator can monitor the alarm until it
+              becomes cleared after the corrective action has been
+              taken.  If this leaf is false the operator needs to
+              validate that the alarm is not longer active using other
+              mechanisms.  Alarms can lack a corresponding clear due
+              to missing instrumentation or that there is no logical
+              corresponding clear state.";
+          }
+          leaf description {
+            type string;
+            mandatory true;
+            description
+              "A description of the possible alarm.  It SHOULD include
+              information on possible underlying root causes and
+              corrective actions.";
+          }
+        }
+      }
+
+      container summary {
+        config false;
+        description
+          "This container gives a summary of number of alarms
+          and shelved alarms";
+        list alarm-summary {
+          key severity;
+          description
+            "A global summary of all alarms in the system.";
+          leaf severity {
+            type al:severity;
+            description
+              "Alarm summary for this severity level.";
+          }
+          leaf total {
+            type yang:gauge32;
+            description
+              "Total number of alarms of this severity level.";
+          }
+          leaf cleared {
+            type yang:gauge32;
+            description
+              "For this severity level, the number of alarms that are
+              cleared.";
+          }
+          leaf cleared-not-closed {
+            if-feature al:operator-actions;
+            type yang:gauge32;
+            description
+              "For this severity level, the number of alarms that are
+              cleared but not closed.";
+          }
+          leaf cleared-closed {
+            if-feature al:operator-actions;
+            type yang:gauge32;
+            description
+              "For this severity level, the number of alarms that are
+              cleared and closed.";
+          }
+          leaf not-cleared-closed {
+            if-feature al:operator-actions;
+            type yang:gauge32;
+            description
+              "For this severity level, the number of alarms that are
+              not cleared but closed.";
+          }
+          leaf not-cleared-not-closed {
+            if-feature al:operator-actions;
+            type yang:gauge32;
+            description
+              "For this severity level, the number of alarms that are
+              not cleared and not closed.";
+          }
+        }
+        leaf shelves-active {
+          if-feature al:alarm-shelving;
+          type empty;
+          description
+            "This is a hint to the operator that there are active
+            alarm shelves.  This leaf MUST exist if the
+            alarms/shelved-alarms/number-of-shelved-alarms is > 0.";
+        }
+      }
+
+      container alarm-list {
+        config false;
+        description
+          "The alarms in the system.";
+        leaf number-of-alarms {
+          type yang:gauge32;
+          description
+            "This object shows the total number of
+            alarms in the system, i.e., the total number
+            of entries in the alarm list.";
+        }
+
+        leaf last-changed {
+          type yang:date-and-time;
+          description
+            "A timestamp when the alarm list was last
+            changed.  The value can be used by a manager to
+            initiate an alarm resynchronization procedure.";
+        }
+
+        list alarm {
+          key "resource alarm-type-id alarm-type-qualifier";
+
+          description
+            "The list of alarms.  Each entry in the list holds one
+            alarm for a given alarm type and resource.
+            An alarm can be updated from the underlying resource or
+            by the user.  The following leafs are maintained by the
+            resource:  is-cleared, last-change, perceived-severity,
+            and alarm-text.  An operator can change: operator-state
+              and operator-text.
+
+              Entries appear in the alarm list the first time an
+              alarm becomes active for a given alarm-type and resource.
+              Entries do not get deleted when the alarm is cleared, this
+              is a boolean state in the alarm.
+
+              Alarm entries are removed, purged, from the list by an
+              explicit purge action.  For example, delete all alarms
+              that are cleared and in closed operator-state that are
+              older than 24 hours.  Systems may also remove alarms based
+              on locally configured policies which is out of scope for
+              this module.";
+          leaf time-created {
+            type yang:date-and-time;
+            mandatory true;
+            description
+              "The time-stamp when this alarm entry was created. This
+              represents the first time the alarm appeared, it can
+              also represent that the alarm re-appeared after a purge.
+              Further state-changes of the same alarm does not change
+              this leaf, these changes will update the 'last-changed'
+              leaf.";
+          }
+
+          uses al:common-alarm-parameters;
+          uses al:resource-alarm-parameters;
+
+          list operator-state-change {
+            if-feature al:operator-actions;
+            key time;
+            description
+              "This list is used by operators to indicate
+              the state of human intervention on an alarm.
+              For example, if an operator has seen an alarm,
+                the operator can add a new item to this list indicating
+                  that the alarm is acknowledged.";
+            uses al:operator-parameters;
+          }
+
+          action set-operator-state {
+            if-feature al:operator-actions;
+            description
+              "This is a means for the operator to indicate
+              the level of human intervention on an alarm.";
+            input {
+              leaf state {
+                type operator-state;
+                mandatory true;
+                description
+                  "Set this operator state.";
+              }
+              leaf text {
+                type string;
+                description
+                  "Additional optional textual information.";
+              }
+            }
+          }
+        }
+      }
+
+      container shelved-alarms {
+        if-feature al:alarm-shelving;
+        config false;
+        description
+          "The shelved alarms.  Alarms appear here if they match the
+          criterias in /alarms/control/alarm-shelving.  This list does
+          not generate any notifications.  The list represents alarms
+          that are considered not relevant by the operator.  Alarms in
+          this list have an operator-state of 'shelved'.  This can not
+          be changed.";
+        leaf number-of-shelved-alarms {
+          type yang:gauge32;
+          description
+            "This object shows the total number of currently
+            alarms, i.e., the total number of entries
+            in the alarm list.";
+        }
+
+        leaf alarm-shelf-last-changed {
+          type yang:date-and-time;
+          description
+            "A timestamp when the shelved alarm list was last
+            changed.  The value can be used by a manager to
+            initiate an alarm resynchronization procedure.";
+        }
+
+        list shelved-alarm {
+          key "resource alarm-type-id alarm-type-qualifier";
+
+          description
+            "The list of shelved alarms.  Each entry in the list holds
+            one alarm for a given alarm type and resource.  An alarm
+            can be updated from the underlying resource or by the
+            user.  These changes are reflected in different lists
+            below the corresponding alarm.";
+
+          uses al:common-alarm-parameters;
+          uses al:resource-alarm-parameters;
+
+          list operator-state-change {
+            if-feature al:operator-actions;
+            key time;
+            description
+              "This list is used by operators to indicate
+              the state of human intervention on an alarm.
+              For example, if an operator has seen an alarm,
+                the operator can add a new item to this list indicating
+                  that the alarm is acknowledged.";
+            uses al:operator-parameters;
+          }
+        }
       }
     }
   }

--- a/src/lib/yang/state.lua
+++ b/src/lib/yang/state.lua
@@ -5,7 +5,6 @@ local lib = require("core.lib")
 local shm = require("core.shm")
 local yang = require("lib.yang.yang")
 local yang_data = require("lib.yang.data")
-local counter = require("core.counter")
 
 local counter_directory = "/apps"
 
@@ -22,7 +21,7 @@ local function flatten(val)
    return rtn
 end
 
-function find_counters(pid)
+local function find_counters(pid)
    local path = shm.root.."/"..pid..counter_directory
    local apps = {}
    for _, c in pairs(lib.files_in_directory(path)) do
@@ -38,7 +37,7 @@ function find_counters(pid)
    return apps
 end
 
-function collect_state_leaves(schema)
+local function collect_state_leaves(schema)
    -- Iterate over schema looking fo state leaves at a specific path into the
    -- schema. This should return a dictionary of leaf to lua path.
    local function collection(scm, path)

--- a/src/lib/yang/state.lua
+++ b/src/lib/yang/state.lua
@@ -3,7 +3,6 @@ module(..., package.seeall)
 
 local lib = require("core.lib")
 local shm = require("core.shm")
-local xpath = require("lib.yang.path")
 local yang = require("lib.yang.yang")
 local yang_data = require("lib.yang.data")
 local counter = require("core.counter")
@@ -90,11 +89,9 @@ local function set_data_value(data, path, value)
    set_data_value(data[head], path, value)
 end
 
-function show_state(scm, pid, raw_path)
+function show_state(scm, pid)
    local schema = yang.load_schema_by_name(scm)
-   local grammar = yang_data.data_grammar_from_schema(schema)
    local counters = find_counters(pid)
-   local path = xpath.convert_path(grammar, raw_path)
 
    -- Lookup the specific schema element that's being addressed by the path
    local leaves = collect_state_leaves(schema)()

--- a/src/lib/yang/state.lua
+++ b/src/lib/yang/state.lua
@@ -11,102 +11,102 @@ local counter = require("core.counter")
 local counter_directory = "/apps"
 
 local function flatten(val)
-    local rtn = {}
-    for k, v in pairs(val) do
-        if type(v) == "table" then
-            v = flatten(v)
-            for k1, v1 in pairs(v) do rtn[k1] = v1 end
-        else
-            rtn[k] = v
-        end
-    end
-    return rtn
+   local rtn = {}
+   for k, v in pairs(val) do
+      if type(v) == "table" then
+         v = flatten(v)
+         for k1, v1 in pairs(v) do rtn[k1] = v1 end
+      else
+         rtn[k] = v
+      end
+   end
+   return rtn
 end
 
 function find_counters(pid)
-    local path = shm.root.."/"..pid..counter_directory
-    local apps = {}
-    for _, c in pairs(lib.files_in_directory(path)) do
-        local counters = {}
-        local counterdir = "/"..pid..counter_directory.."/"..c
-        for k,v in pairs(shm.open_frame(counterdir)) do
-            if type(v) == "cdata" then
-                counters[k] = v.c
-            end
-        end
-        apps[c] = counters
-    end
-    return apps
+   local path = shm.root.."/"..pid..counter_directory
+   local apps = {}
+   for _, c in pairs(lib.files_in_directory(path)) do
+      local counters = {}
+      local counterdir = "/"..pid..counter_directory.."/"..c
+      for k,v in pairs(shm.open_frame(counterdir)) do
+         if type(v) == "cdata" then
+            counters[k] = v.c
+         end
+      end
+      apps[c] = counters
+   end
+   return apps
 end
 
 function collect_state_leaves(schema)
-    -- Iterate over schema looking fo state leaves at a specific path into the
-    -- schema. This should return a dictionary of leaf to lua path.
-    local function collection(scm, path)
-        local function newpath(oldpath)
-            return lib.deepcopy(oldpath)
-        end
-        if path == nil then path = {} end
-        table.insert(path, scm.id)
+   -- Iterate over schema looking fo state leaves at a specific path into the
+   -- schema. This should return a dictionary of leaf to lua path.
+   local function collection(scm, path)
+      local function newpath(oldpath)
+         return lib.deepcopy(oldpath)
+      end
+      if path == nil then path = {} end
+      table.insert(path, scm.id)
 
-        if scm.kind == "container" then
-            -- Iterate over the body and recursively call self on all children.
+      if scm.kind == "container" then
+         -- Iterate over the body and recursively call self on all children.
+         local rtn = {}
+         for _, child in pairs(scm.body) do
+            local leaves = collection(child, newpath(path))
+            table.insert(rtn, leaves)
+         end
+         return rtn
+      elseif scm.kind == "leaf" then
+         if scm.config == false then
             local rtn = {}
-            for _, child in pairs(scm.body) do
-                local leaves = collection(child, newpath(path))
-                table.insert(rtn, leaves)
-            end
+            rtn[path] = scm.id
             return rtn
-        elseif scm.kind == "leaf" then
-            if scm.config == false then
-                local rtn = {}
-                rtn[path] = scm.id
-                return rtn
-            end
-        elseif scm.kind == "module" then
-            local rtn = {}
-            for _, v in pairs(scm.body) do
-                -- We deliberately don't want to include the module in the path.
-                table.insert(rtn, collection(v, {}))
-            end
-            return rtn
-        end
-        return {}
-    end
+         end
+      elseif scm.kind == "module" then
+         local rtn = {}
+         for _, v in pairs(scm.body) do
+            -- We deliberately don't want to include the module in the path.
+            table.insert(rtn, collection(v, {}))
+         end
+         return rtn
+      end
+      return {}
+   end
 
-    local leaves = collection(schema)
-    if leaves == nil then return {} end
-    leaves = flatten(leaves)
-    return function () return leaves end
+   local leaves = collection(schema)
+   if leaves == nil then return {} end
+   leaves = flatten(leaves)
+   return function () return leaves end
 end
 
 local function set_data_value(data, path, value)
-    local head = yang_data.normalize_id(table.remove(path, 1))
-    if #path == 0 then
-        data[head] = value
-        return
-    end
-    if data[head] == nil then data[head] = {} end
-    set_data_value(data[head], path, value)
+   local head = yang_data.normalize_id(table.remove(path, 1))
+   if #path == 0 then
+      data[head] = value
+      return
+   end
+   if data[head] == nil then data[head] = {} end
+   set_data_value(data[head], path, value)
 end
 
 function show_state(scm, pid, raw_path)
-    local schema = yang.load_schema_by_name(scm)
-    local grammar = yang_data.data_grammar_from_schema(schema)
-    local counters = find_counters(pid)
-    local path = xpath.convert_path(grammar, raw_path)
+   local schema = yang.load_schema_by_name(scm)
+   local grammar = yang_data.data_grammar_from_schema(schema)
+   local counters = find_counters(pid)
+   local path = xpath.convert_path(grammar, raw_path)
 
-    -- Lookup the specific schema element that's being addressed by the path
-    local leaves = collect_state_leaves(schema)()
-    local data = {}
-    for leaf_path, leaf in pairs(leaves) do
-        for _, counter in pairs(counters) do
-            if counter[leaf] then
-                set_data_value(data, leaf_path, counter[leaf])
-            end
-        end
-    end
-    return data
+   -- Lookup the specific schema element that's being addressed by the path
+   local leaves = collect_state_leaves(schema)()
+   local data = {}
+   for leaf_path, leaf in pairs(leaves) do
+      for _, counter in pairs(counters) do
+         if counter[leaf] then
+            set_data_value(data, leaf_path, counter[leaf])
+         end
+      end
+   end
+   return data
 end
 
 function selftest ()

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -194,6 +194,19 @@ function csv_to_table (filename, opts)
    return ret, size
 end
 
+local function gmtime ()
+   local now = os.time()
+   local utcdate = os.date("!*t", now)
+   local localdate = os.date("*t", now)
+   localdate.isdst = false
+   local timediff = os.difftime(os.time(utcdate), os.time(localdate))
+   return now + timediff
+end
+
+function iso_8601 (time)
+   time = time or gmtime()
+   return os.date("%Y-%m-%dT%H:%M:%SZ", time)
+end
 
 function selftest()
    print('selftest: lib.yang.util')

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -128,6 +128,73 @@ function memoize(f, max_occupancy)
    end
 end
 
+-- Converts a csv file to a Lua table.
+--
+-- Columns may contain multivalue data, in that case the values should be
+-- separated by hashes (#). Multivalue columns are converted to simple arrays.
+function csv_to_table (filename, opts)
+   assert(filename, 'Missing filename')
+   opts = opts or {}
+   local sep = opts.sep or ';'
+   local fields = opts.fields
+   local function split (str, sep)
+      sep = sep or ';'
+      local ret = {}
+      local pattern = "([^"..sep.."]+)"
+      for each in str:gmatch(pattern) do
+         table.insert(ret, each)
+      end
+      return ret
+   end
+   local function trim (str)
+      str = str or ''
+      str = str:gsub("^%s+", "")
+      str = str:gsub("%s+$", "")
+      return str
+   end
+   local function parse_line (line)
+      local ret = {}
+      for _, val in ipairs(split(line, sep)) do
+         table.insert(ret, trim(val))
+      end
+      return ret
+   end
+   local function parse_value (value)
+      local type = type(value)
+      if type == 'nil' then
+         return nil
+      elseif type == 'number' then
+         return tonumber(value)
+      elseif type == 'boolean' then
+         return value:upper() == 'TRUE'
+      elseif type == 'string' then
+         return value:match('#') and split(value, '#') or value
+      else
+         error('Not supported type: '..type)
+      end
+   end
+   local ret = {}
+   local lineno = 0
+   for line in io.lines(filename) do
+      lineno = lineno + 1
+      if lineno == 1 then
+         fields = parse_line(line)
+         goto continue
+      end
+      local values = parse_line(line)
+      local row = {}
+      for i=1,#fields do
+         local field, value = fields[i], values[i]
+         row[field] = parse_value(value)
+      end
+      table.insert(ret, row)
+      ::continue::
+   end
+   local size = lineno - 1
+   return ret, size
+end
+
+
 function selftest()
    print('selftest: lib.yang.util')
    assert(tointeger('0') == 0)

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -95,7 +95,14 @@ function types.identityref.tostring(val)
    return val
 end
 
-types['instance-identifier'] = unimplemented('instance-identifier')
+types['instance-identifier'] = {}
+types['instance-identifier'].parse = function (str, what)
+   return assert(str, 'missing value for '..what)
+end
+types['instance-identifier'].tostring = function (val)
+   return val
+end
+
 types.leafref = unimplemented('leafref')
 
 types.string = {}

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -103,7 +103,13 @@ types['instance-identifier'].tostring = function (val)
    return val
 end
 
-types.leafref = unimplemented('leafref')
+types.leafref = {}
+function types.leafref.parse(str, what)
+   return assert(str, 'missing value for '..what)
+end
+function types.leafref.toleafref(val)
+   return val
+end
 
 types.string = {}
 function types.string.parse(str, what)

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -83,7 +83,7 @@ function types.empty.parse (str, what)
    return assert(str == nil, "not empty value for "..what)
 end
 function types.empty.tostring (val)
-   return ""
+   return ''
 end
 
 types.identityref = {}

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -22,7 +22,10 @@ local ipv4_ntop  = require("lib.yang.util").ipv4_ntop
 local S          = require("syscall")
 local engine     = require("core.app")
 
-local capabilities = {['ietf-softwire']={feature={'binding', 'br'}}}
+local capabilities = {
+   ['ietf-softwire']={feature={'binding', 'br'}},
+   ['ietf-alarms']={feature={'operator-actions', 'alarm-shelving', 'alarm-history'}},
+}
 require('lib.yang.schema').set_default_capabilities(capabilities)
 
 local function convert_ipv4(addr)

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -155,8 +155,8 @@ class TestConfigMisc(BaseTestCase):
         get_state_args = self.get_cmd_args('get-state')
         # Select a few at random which should have non-zero results.
         for query in (
-                '/softwire-state/in-ipv4-bytes',
-                '/softwire-state/out-ipv4-bytes',
+                '/softwire-state/counters/in-ipv4-bytes',
+                '/softwire-state/counters/out-ipv4-bytes',
             ):
             cmd_args = list(get_state_args)
             cmd_args.append(query)


### PR DESCRIPTION
Adds the basic skeleton for alarms support which consists of:

- Adapting snabb-softwire-v2.yang schema to support alarms.
- Adding support for a few YANG datatypes which are necessary to parse IETF alarms YANG model (identityref and leafref are not actually implemented only the basics to pass parsing).
- Add a channelling mechanism to communicate the follower (data-plane) and the leader. Alarms are raised or cleared in the follower, which puts a message into a channel of its own. The leader pulls all the followers alarm channels and executes the pending operations (raise, clear, etc). In this manner, alarms are single managed at a central point, the leader, which keeps the alarm status.
- When querying softwire-state, the alarms status is appended to the output.
- Right now the only alarms containers supported are alarm-inventory and alarm-list. Alarm-inventory keeps a list of all the alarms types supported in the system. This list is initially fetched from a .csv file (alarm_inventory.csv). Likewise there's a csv file with all the alarms supported in the system and their default parameters. The alarms state is always cleared for every run.

Example how to use:

```
$ sudo ./snabb lwaftr run --reconfigurable --name lwaftr --conf lwaftr.conf --on-a-stick 83:00.1 
```

```bash
$ sudo ./snabb config get-state lwaftr3 /softwire-state/alarms
alarm-inventory {
  alarm-type {
    alarm-type-id ndp-resolution;
    alarm-type-qualifier ;
    has-clear true;
    resource internal-interface;
  }
  alarm-type {
    alarm-type-id arp-resolution;
    alarm-type-qualifier ;
    has-clear true;
    resource external-interface;
  }
}
alarm-list {
  alarm {
    alarm-type-id arp-resolution;
    alarm-type-qualifier ;
    resource external-interface;
    alarm-text "Make sure you can resolved external-inteface.next-hop.ip from the lwAFTR.  If cannot resolve it, consider using the MAC address of the next-hop directly.  To do it so, set external-interface.next-hop.mac to the value of the MAC address.";
    is-cleared false;
    last-changed 2017-07-25T10:14:01Z;
    perceived-severity critical;
    status-change {
      time 2017-07-25T10:14:01Z;
      alarm-text "Make sure you can resolved external-inteface.next-hop.ip from the lwAFTR.  If cannot resolve it, consider using the MAC address of the next-hop directly.  To do it so, set external-interface.next-hop.mac to the value of the MAC address.";
      perceived-severity critical;
    }
    time-created 2017-07-25T10:14:01Z;
  }
  last-changed 2017-07-25T10:14:01Z;
  number-of-alarms 1;
}
```