### PR TITLE
Add alarms containers to snabb-softwire-v2 schema

### DIFF
--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -247,6 +247,11 @@ local function data_emitter(production)
             stream:write_stringref('stringref')
             stream:write_stringref(data)
          end
+      elseif primitive_type == 'empty' then
+         return function (data, stream)
+            stream:write_stringref('stringref')
+            stream:write_stringref('')
+         end
       elseif type.ctype then
          local ctype = type.ctype
          local emit_value = value_emitter(ctype)
@@ -503,6 +508,12 @@ function selftest()
             }
          }
       }
+
+      container foo {
+         leaf enable-qos {
+            type empty;
+         }
+      }
    }]])
    local data = data.load_data_for_schema(test_schema, [[
       is-active true;
@@ -519,6 +530,9 @@ function selftest()
       }
       next-hop {
          ipv4 5.6.7.8;
+      }
+      foo {
+         enable-qos;
       }
    ]])
 

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -233,7 +233,7 @@ local function data_emitter(production)
          end
       end
    end
-   local native_types = util.set('enumeration', 'identityref', 'string')
+   local native_types = util.set('enumeration', 'identityref', 'instance-identifier', 'string')
    function handlers.scalar(production)
       local primitive_type = production.argument_type.primitive_type
       local type = assert(value.types[primitive_type], "unsupported type: "..primitive_type)

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -233,7 +233,8 @@ local function data_emitter(production)
          end
       end
    end
-   local native_types = util.set('enumeration', 'identityref', 'instance-identifier', 'string')
+   local native_types = util.set('enumeration', 'identityref', 'instance-identifier',
+                                 'leafref', 'string')
    function handlers.scalar(production)
       local primitive_type = production.argument_type.primitive_type
       local type = assert(value.types[primitive_type], "unsupported type: "..primitive_type)

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -233,11 +233,7 @@ local function data_emitter(production)
          end
       end
    end
-   local native_types = {
-      enumeration = true,
-      identityref = true,
-      string = true,
-   }
+   local native_types = util.set('enumeration', 'identityref', 'string')
    function handlers.scalar(production)
       local primitive_type = production.argument_type.primitive_type
       local type = assert(value.types[primitive_type], "unsupported type: "..primitive_type)

--- a/src/lib/yang/ietf-alarms.yang
+++ b/src/lib/yang/ietf-alarms.yang
@@ -152,11 +152,11 @@ module ietf-alarms {
 
     typedef resource {
         type union {
+            type string;
             type instance-identifier {
                 require-instance false;
             }
             type yang:object-identifier;
-            type string;
         }
         description
             "This is an identification of the alarming resource, such as an
@@ -305,9 +305,13 @@ module ietf-alarms {
     /* Alarm type */
 
     typedef alarm-type-id {
+        /* FIXME: identityref is not supported, temporarily replace for string. */
+        /*
         type identityref {
             base alarm-identity;
         }
+        */
+        type string;
         description
             "Identifies an alarm type.  The description of the alarm type
             id MUST indicate if the alarm type is abstract or not.  An

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -583,11 +583,7 @@ local function schema_from_ast(ast)
    return ret
 end
 
-local function set(...)
-   local ret = {}
-   for k, v in pairs({...}) do ret[v] = true end
-   return ret
-end
+local set = util.set
 
 local primitive_types = set(
    'int8', 'int16', 'int32', 'int64', 'uint8', 'uint16', 'uint32', 'uint64',

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -4,6 +4,7 @@ module snabb-softwire-v2 {
 
   import ietf-inet-types { prefix inet; }
   import ietf-yang-types { prefix yang; }
+  import ietf-alarms { prefix al; }
 
   organization "Igalia, S.L.";
   contact "Jessica Tallon <tsyesika@igalia.com>";
@@ -259,7 +260,7 @@ module snabb-softwire-v2 {
           description
            "Public IPv4 address of the softwire.";
         }
-        
+
         leaf padding {
           type uint16;
           default 0;
@@ -345,6 +346,97 @@ module snabb-softwire-v2 {
               ports (for example) from being mapped to customers.  Note
               that psid-length and shift must add up to less than or
               equal to 16.";
+          }
+        }
+      }
+    }
+
+    container alarms {
+      description
+        "The top container for this module";
+
+      container control {
+        description
+          "Configuration to control the alarm behaviour.";
+
+        leaf max-alarm-status-changes {
+          type union {
+            type uint16;
+            type enumeration {
+              enum infinite {
+                description
+                  "The status change entries are accumulated
+                  infinitely.";
+              }
+            }
+          }
+          default 32;
+          description
+            "The status-change entries are kept in a circular list
+            per alarm.  When this number is exceeded, the oldest
+            status change entry is automatically removed.  If the
+            value is 'infinite', the status change entries are
+            accumulated infinitely.";
+        }
+
+        leaf notify-status-changes {
+          type boolean;
+          default false;
+          description
+            "This leaf controls whether notifications are sent on all
+            alarm status updates, e.g., updated perceived-severity or
+            alarm-text.  By default the notifications are only sent
+            when a new alarm is raised, re-raised after being cleared
+            and when an alarm is cleared.";
+        }
+        container alarm-shelving {
+          if-feature al:alarm-shelving;
+          description
+            "This list is used to shelve alarms.  The server will move
+            any alarms corresponding to the shelving criteria from the
+            alarms/alarm-list/alarm list to the
+            alarms/shelved-alarms/shelved-alarm list.  It will also
+            stop sending notifications for the shelved alarms.  The
+            conditions in the shelf criteria are logically ANDed.
+            When the shelving criteria is deleted or changed, the
+            non-matching alarms MUST appear in the
+            alarms/alarm-list/alarm list according to the real state.
+            This means that the instrumentation MUST maintain states
+            for the shelved alarms.  Alarms that match the criteria
+              shall have an operator-state 'shelved'.";
+          list shelf {
+            key shelf-name;
+            leaf shelf-name {
+              type string;
+              description
+                "An arbitrary name for the alarm shelf.";
+            }
+            description
+              "Each entry defines the criteria for shelving alarms.
+              Criterias are ANDed.";
+
+            leaf resource {
+              type al:resource;
+              description
+                "Shelve alarms for this resource.";
+            }
+            leaf alarm-type-id {
+              type al:alarm-type-id;
+              description
+                "Shelve alarms for this alarm type identifier.";
+            }
+            leaf alarm-type-qualifier {
+              type al:alarm-type-qualifier;
+              description
+                "Shelve alarms for this alarm type qualifier.";
+            }
+            leaf description {
+              type string;
+              description
+                "An optional textual description of the shelf.  This
+                description should include the reason for shelving
+                these alarms.";
+            }
           }
         }
       }
@@ -716,6 +808,287 @@ module snabb-softwire-v2 {
     leaf out-ipv6-packets {
       type yang:zero-based-counter64;
       description "All valid outgoing IPv6 packets.";
+    }
+
+    container alarms {
+      description
+        "The top container for this module";
+
+      container alarm-inventory {
+        config false;
+        description
+          "This list contains all possible alarm types for the system.
+          If the system knows for wich resources a a specific alarm
+          type can appear, this is also identified in the inventory.
+          The list also tells if each alarm type has a corresponding
+          clear state.  The inventory shall only contain concrete
+          alarm types.
+
+          The alarm inventory MUST be updated by the system when new
+          alarms can appear.  This can be the case when installing new
+          software modules or inserting new card types.  A
+          notification 'alarm-inventory-changed' is sent when the
+          inventory is changed.";
+
+        list alarm-type {
+          key "alarm-type-id alarm-type-qualifier";
+          description
+            "An entry in this list defines a possible alarm.";
+          leaf alarm-type-id {
+            type al:alarm-type-id;
+            mandatory true;
+            description
+              "The statically defined alarm type identifier for this
+              possible alarm.";
+          }
+          leaf alarm-type-qualifier {
+            type al:alarm-type-qualifier;
+            description
+              "The optionally dynamically defined alarm type identifier
+              for this possible alarm.";
+          }
+          leaf-list resource {
+            type string;
+            description
+              "Optionally, specifies for which resources the alarm type
+              is valid.  This string is for human consumption but
+              SHOULD refer to paths in the model.";
+          }
+          leaf has-clear {
+            type boolean;
+            mandatory true;
+            description
+              "This leaf tells the operator if the alarm will be
+              cleared when the correct corrective action has been
+              taken.  Implementations SHOULD strive for detecting the
+              cleared state for all alarm types.  If this leaf is
+              true, the operator can monitor the alarm until it
+              becomes cleared after the corrective action has been
+              taken.  If this leaf is false the operator needs to
+              validate that the alarm is not longer active using other
+              mechanisms.  Alarms can lack a corresponding clear due
+              to missing instrumentation or that there is no logical
+              corresponding clear state.";
+          }
+          leaf description {
+            type string;
+            mandatory true;
+            description
+              "A description of the possible alarm.  It SHOULD include
+              information on possible underlying root causes and
+              corrective actions.";
+          }
+        }
+      }
+
+      container summary {
+        config false;
+        description
+          "This container gives a summary of number of alarms
+          and shelved alarms";
+        list alarm-summary {
+          key severity;
+          description
+            "A global summary of all alarms in the system.";
+          leaf severity {
+            type al:severity;
+            description
+              "Alarm summary for this severity level.";
+          }
+          leaf total {
+            type yang:gauge32;
+            description
+              "Total number of alarms of this severity level.";
+          }
+          leaf cleared {
+            type yang:gauge32;
+            description
+              "For this severity level, the number of alarms that are
+              cleared.";
+          }
+          leaf cleared-not-closed {
+            if-feature al:operator-actions;
+            type yang:gauge32;
+            description
+              "For this severity level, the number of alarms that are
+              cleared but not closed.";
+          }
+          leaf cleared-closed {
+            if-feature al:operator-actions;
+            type yang:gauge32;
+            description
+              "For this severity level, the number of alarms that are
+              cleared and closed.";
+          }
+          leaf not-cleared-closed {
+            if-feature al:operator-actions;
+            type yang:gauge32;
+            description
+              "For this severity level, the number of alarms that are
+              not cleared but closed.";
+          }
+          leaf not-cleared-not-closed {
+            if-feature al:operator-actions;
+            type yang:gauge32;
+            description
+              "For this severity level, the number of alarms that are
+              not cleared and not closed.";
+          }
+        }
+        leaf shelves-active {
+          if-feature al:alarm-shelving;
+          type empty;
+          description
+            "This is a hint to the operator that there are active
+            alarm shelves.  This leaf MUST exist if the
+            alarms/shelved-alarms/number-of-shelved-alarms is > 0.";
+        }
+      }
+
+      container alarm-list {
+        config false;
+        description
+          "The alarms in the system.";
+        leaf number-of-alarms {
+          type yang:gauge32;
+          description
+            "This object shows the total number of
+            alarms in the system, i.e., the total number
+            of entries in the alarm list.";
+        }
+
+        leaf last-changed {
+          type yang:date-and-time;
+          description
+            "A timestamp when the alarm list was last
+            changed.  The value can be used by a manager to
+            initiate an alarm resynchronization procedure.";
+        }
+
+        list alarm {
+          key "resource alarm-type-id alarm-type-qualifier";
+
+          description
+            "The list of alarms.  Each entry in the list holds one
+            alarm for a given alarm type and resource.
+            An alarm can be updated from the underlying resource or
+            by the user.  The following leafs are maintained by the
+            resource:  is-cleared, last-change, perceived-severity,
+            and alarm-text.  An operator can change: operator-state
+              and operator-text.
+
+              Entries appear in the alarm list the first time an
+              alarm becomes active for a given alarm-type and resource.
+              Entries do not get deleted when the alarm is cleared, this
+              is a boolean state in the alarm.
+
+              Alarm entries are removed, purged, from the list by an
+              explicit purge action.  For example, delete all alarms
+              that are cleared and in closed operator-state that are
+              older than 24 hours.  Systems may also remove alarms based
+              on locally configured policies which is out of scope for
+              this module.";
+          leaf time-created {
+            type yang:date-and-time;
+            mandatory true;
+            description
+              "The time-stamp when this alarm entry was created. This
+              represents the first time the alarm appeared, it can
+              also represent that the alarm re-appeared after a purge.
+              Further state-changes of the same alarm does not change
+              this leaf, these changes will update the 'last-changed'
+              leaf.";
+          }
+
+          uses al:common-alarm-parameters;
+          uses al:resource-alarm-parameters;
+
+          list operator-state-change {
+            if-feature al:operator-actions;
+            key time;
+            description
+              "This list is used by operators to indicate
+              the state of human intervention on an alarm.
+              For example, if an operator has seen an alarm,
+                the operator can add a new item to this list indicating
+                  that the alarm is acknowledged.";
+            uses al:operator-parameters;
+          }
+
+          action set-operator-state {
+            if-feature al:operator-actions;
+            description
+              "This is a means for the operator to indicate
+              the level of human intervention on an alarm.";
+            input {
+              leaf state {
+                type operator-state;
+                mandatory true;
+                description
+                  "Set this operator state.";
+              }
+              leaf text {
+                type string;
+                description
+                  "Additional optional textual information.";
+              }
+            }
+          }
+        }
+      }
+
+      container shelved-alarms {
+        if-feature al:alarm-shelving;
+        config false;
+        description
+          "The shelved alarms.  Alarms appear here if they match the
+          criterias in /alarms/control/alarm-shelving.  This list does
+          not generate any notifications.  The list represents alarms
+          that are considered not relevant by the operator.  Alarms in
+          this list have an operator-state of 'shelved'.  This can not
+          be changed.";
+        leaf number-of-shelved-alarms {
+          type yang:gauge32;
+          description
+            "This object shows the total number of currently
+            alarms, i.e., the total number of entries
+            in the alarm list.";
+        }
+
+        leaf alarm-shelf-last-changed {
+          type yang:date-and-time;
+          description
+            "A timestamp when the shelved alarm list was last
+            changed.  The value can be used by a manager to
+            initiate an alarm resynchronization procedure.";
+        }
+
+        list shelved-alarm {
+          key "resource alarm-type-id alarm-type-qualifier";
+
+          description
+            "The list of shelved alarms.  Each entry in the list holds
+            one alarm for a given alarm type and resource.  An alarm
+            can be updated from the underlying resource or by the
+            user.  These changes are reflected in different lists
+            below the corresponding alarm.";
+
+          uses al:common-alarm-parameters;
+          uses al:resource-alarm-parameters;
+
+          list operator-state-change {
+            if-feature al:operator-actions;
+            key time;
+            description
+              "This list is used by operators to indicate
+              the state of human intervention on an alarm.
+              For example, if an operator has seen an alarm,
+                the operator can add a new item to this list indicating
+                  that the alarm is acknowledged.";
+            uses al:operator-parameters;
+          }
+        }
+      }
     }
   }
 }

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -128,6 +128,13 @@ function memoize(f, max_occupancy)
    end
 end
 
+-- XXX: lib/ctable.lua also defines set. Consider moving this function to core/lib.lua.
+function set(...)
+   local ret = {}
+   for k, v in pairs({...}) do ret[v] = true end
+   return ret
+end
+
 function selftest()
    print('selftest: lib.yang.util')
    assert(tointeger('0') == 0)

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -95,7 +95,14 @@ function types.identityref.tostring(val)
    return val
 end
 
-types['instance-identifier'] = unimplemented('instance-identifier')
+types['instance-identifier'] = {}
+types['instance-identifier'].parse = function (str, what)
+   return assert(str, 'missing value for '..what)
+end
+types['instance-identifier'].tostring = function (val)
+   return val
+end
+
 types.leafref = unimplemented('leafref')
 
 types.string = {}

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -103,7 +103,13 @@ types['instance-identifier'].tostring = function (val)
    return val
 end
 
-types.leafref = unimplemented('leafref')
+types.leafref = {}
+function types.leafref.parse(str, what)
+   return assert(str, 'missing value for '..what)
+end
+function types.leafref.toleafref(val)
+   return val
+end
 
 types.string = {}
 function types.string.parse(str, what)

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -26,7 +26,10 @@ local engine     = require("core.app")
 
 local alarm_notification = false
 
-local capabilities = {['ietf-softwire']={feature={'binding', 'br'}}}
+local capabilities = {
+   ['ietf-softwire']={feature={'binding', 'br'}},
+   ['ietf-alarms']={feature={'operator-actions', 'alarm-shelving', 'alarm-history'}},
+}
 require('lib.yang.schema').set_default_capabilities(capabilities)
 
 local function convert_ipv4(addr)


### PR DESCRIPTION
The PR adds alarms containers to snabb-softwire-v2 schema. The structure is the following:

```yang
softwire-config {
   containter alarms {
     container control {
        ...
     }
   }
}
```

`alarms.control` has configuration information, thus I placed in softwire-config.

```yang
softwire-state {
   container alarms {
      container alarm-inventory {
         ...
      }
      container summary {
         ...
      }
      container alarm-list {
         ...
      }
      container shelved-alarms {
         ...
      }
   }
}
```

All these other containers represent state information.

In order to read the alarms schema as it's defined in IETF schema I needed to add support for types for not currently supported types: `empty`, `identy-ref` and `leafref`. I tried to implement `empty` before, I'm not sure if this implementation is correct. As for `identity-ref` and `leafref` they are not actually implemented, but I need to defined them so schema instances can be parsed.

Lastly I defined several capabilities for the ietf-alarms schema so every alarms if-feature definition is enabled.