### PR TITLE
Move function set to core/lib.lua

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -953,6 +953,19 @@ lib.parse({foo=42, bar=43}, {foo={required=true}, bar={}, baz={default=44}})
   => {foo=42, bar=43, baz=44}
 ```
 
+- Function **lib.set** *vargs*
+
+Reads a variable number of arguments and returns a table representing a set.
+The returned value can be used to query whether an element belongs or not to
+the set.
+
+Example:
+
+```
+local t = set('foo', 'bar')
+t['foo']  -- yields true.
+t['quax'] -- yields false.
+```
 
 ## Multiprocess operation (core.worker)
 

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -780,6 +780,12 @@ function parse (arg, config)
    return ret
 end
 
+function set(...)
+   local ret = {}
+   for k, v in pairs({...}) do ret[v] = true end
+   return ret
+end
+
 function selftest ()
    print("selftest: lib")
    print("Testing equal")

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -97,12 +97,6 @@ local function make_equal_fn(key_type)
    end
 end
 
-local function set(...)
-   local ret = {}
-   for k, v in pairs({...}) do ret[v] = true end
-   return ret
-end
-
 local function parse_params(params, required, optional)
    local ret = {}
    for k, _ in pairs(required) do
@@ -123,7 +117,7 @@ end
 -- FIXME: For now the value_type option is required, but in the future
 -- we should allow for a nil value type to create a set instead of a
 -- map.
-local required_params = set('key_type', 'value_type')
+local required_params = lib.set('key_type', 'value_type')
 local optional_params = {
    hash_seed = false,
    initial_size = 8,

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -10,6 +10,7 @@ local stream = require("lib.yang.stream")
 local data = require('lib.yang.data')
 local ctable = require('lib.ctable')
 local cltable = require('lib.cltable')
+local lib = require("core.lib")
 
 local MAGIC = "yangconf"
 local VERSION = 0x00005000
@@ -233,11 +234,7 @@ local function data_emitter(production)
          end
       end
    end
-   local native_types = {
-      enumeration = true,
-      identityref = true,
-      string = true,
-   }
+   local native_types = lib.set('enumeration', 'identityref', 'string')
    function handlers.scalar(production)
       local primitive_type = production.argument_type.primitive_type
       local type = assert(value.types[primitive_type], "unsupported type: "..primitive_type)

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -1,6 +1,7 @@
 -- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 module(..., package.seeall)
 
+local lib = require("core.lib")
 local parser = require("lib.yang.parser")
 local util = require("lib.yang.util")
 
@@ -583,13 +584,7 @@ local function schema_from_ast(ast)
    return ret
 end
 
-local function set(...)
-   local ret = {}
-   for k, v in pairs({...}) do ret[v] = true end
-   return ret
-end
-
-local primitive_types = set(
+local primitive_types = lib.set(
    'int8', 'int16', 'int32', 'int64', 'uint8', 'uint16', 'uint32', 'uint64',
    'binary', 'bits', 'boolean', 'decimal64', 'empty', 'enumeration',
    'identityref', 'instance-identifier', 'leafref', 'string', 'union')
@@ -895,9 +890,9 @@ function resolve(schema, features)
 end
 
 local primitive_types = {
-   ['ietf-inet-types']=set('ipv4-address', 'ipv6-address',
+   ['ietf-inet-types']=lib.set('ipv4-address', 'ipv6-address',
                            'ipv4-prefix', 'ipv6-prefix'),
-   ['ietf-yang-types']=set('mac-address')
+   ['ietf-yang-types']=lib.set('mac-address')
 }
 
 -- NB: mutates schema in place!


### PR DESCRIPTION
The function `set` is defined at several locations. Make it part of core/lib.lua.