### PR TITLE
[YANG] Empty data type binary compilation

### DIFF
--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -246,8 +246,8 @@ local function data_emitter(production)
          end
       elseif primitive_type == 'empty' then
          return function (data, stream)
-            stream:write_stringref('stringref')
-            stream:write_stringref('')
+            stream:write_stringref('flag')
+            stream:write_uint32(data and 1 or 0)
          end
       elseif type.ctype then
          local ctype = type.ctype
@@ -418,6 +418,10 @@ local function read_compiled_data(stream, strtab)
    function readers.cdata()
       local ctype = scalar_type(read_string())
       return stream:read_ptr(ctype)[0]
+   end
+   function readers.flag()
+      if stream:read_uint32() ~= 0 then return true end
+      return nil
    end
    return read1()
 end

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -244,6 +244,11 @@ local function data_emitter(production)
             stream:write_stringref('stringref')
             stream:write_stringref(data)
          end
+      elseif primitive_type == 'empty' then
+         return function (data, stream)
+            stream:write_stringref('stringref')
+            stream:write_stringref('')
+         end
       elseif type.ctype then
          local ctype = type.ctype
          local emit_value = value_emitter(ctype)
@@ -500,6 +505,12 @@ function selftest()
             }
          }
       }
+
+      container foo {
+         leaf enable-qos {
+            type empty;
+         }
+      }
    }]])
    local data = data.load_data_for_schema(test_schema, [[
       is-active true;
@@ -516,6 +527,9 @@ function selftest()
       }
       next-hop {
          ipv4 5.6.7.8;
+      }
+      foo {
+         enable-qos;
       }
    ]])
 


### PR DESCRIPTION
The YANG `empty` data type was partially implemented in https://github.com/Igalia/snabb/pull/823, but it missed the binary compilation part.

In ietf-alarms.yang this data type is used to define the leaf `shelves-active`:

```yang
leaf shelves-active {
   if-feature alarm-shelving;
   type empty;
   description
      "This is a hint to the operator that there are active
      alarm shelves.  This leaf MUST exist if the
      alarms/shelved-alarms/number-of-shelved-alarms is > 0.";
}
```

Empty data-type reference: https://tools.ietf.org/html/rfc6020#page-131