### PR TITLE
[YANG] Parsing and binary compilation support of 'leafref' and 'instance-identifier'

### DIFF
--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -234,7 +234,8 @@ local function data_emitter(production)
          end
       end
    end
-   local native_types = lib.set('enumeration', 'identityref', 'instance-identifier', 'string')
+   local native_types = lib.set('enumeration', 'identityref', 'instance-identifier',
+                                'leafref', 'string')
    function handlers.scalar(production)
       local primitive_type = production.argument_type.primitive_type
       local type = assert(value.types[primitive_type], "unsupported type: "..primitive_type)

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -234,7 +234,7 @@ local function data_emitter(production)
          end
       end
    end
-   local native_types = lib.set('enumeration', 'identityref', 'string')
+   local native_types = lib.set('enumeration', 'identityref', 'instance-identifier', 'string')
    function handlers.scalar(production)
       local primitive_type = production.argument_type.primitive_type
       local type = assert(value.types[primitive_type], "unsupported type: "..primitive_type)

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -95,7 +95,14 @@ function types.identityref.tostring(val)
    return val
 end
 
-types['instance-identifier'] = unimplemented('instance-identifier')
+types['instance-identifier'] = {}
+types['instance-identifier'].parse = function (str, what)
+   return assert(str, 'missing value for '..what)
+end
+types['instance-identifier'].tostring = function (val)
+   error("NYI: instance-identifier")
+end
+
 types.leafref = unimplemented('leafref')
 
 types.string = {}

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -103,7 +103,13 @@ types['instance-identifier'].tostring = function (val)
    error("NYI: instance-identifier")
 end
 
-types.leafref = unimplemented('leafref')
+types.leafref = {}
+function types.leafref.parse(str, what)
+   return assert(str, 'missing value for '..what)
+end
+function types.leafref.tostring(val)
+   error("NYI: leafref")
+end
 
 types.string = {}
 function types.string.parse(str, what)


### PR DESCRIPTION
Allows schema instances that contain references to data types `leafref` and `instance-identifier` to be parsed and compiled. However, if `snabb config` prints out a leaf that belongs to one of those data types, an error is emitted.