### PR TITLE
Use ctable in snabbwall

### DIFF
--- a/src/apps/wall/scanner.lua
+++ b/src/apps/wall/scanner.lua
@@ -35,7 +35,7 @@ local TCP_DST_PORT_OFFSET   = const.TCP_DST_PORT_OFFSET
 local UDP_SRC_PORT_OFFSET   = const.UDP_SRC_PORT_OFFSET
 local UDP_DST_PORT_OFFSET   = const.UDP_DST_PORT_OFFSET
 
-local swall_flow_key_ipv4_t = ffi.typeof([[
+swall_flow_key_ipv4_t = ffi.typeof([[
    struct {
       uint16_t vlan_id;
       uint8_t  __pad;
@@ -44,10 +44,11 @@ local swall_flow_key_ipv4_t = ffi.typeof([[
       uint8_t  hi_addr[4];
       uint16_t lo_port;
       uint16_t hi_port;
+      uint16_t eth_type;
    } __attribute__((packed))
 ]])
 
-local swall_flow_key_ipv6_t = ffi.typeof([[
+swall_flow_key_ipv6_t = ffi.typeof([[
    struct {
       uint16_t vlan_id;
       uint8_t  __pad;
@@ -56,6 +57,7 @@ local swall_flow_key_ipv6_t = ffi.typeof([[
       uint8_t  hi_addr[16];
       uint16_t lo_port;
       uint16_t hi_port;
+      uint16_t eth_type;
    } __attribute__((packed))
 ]])
 
@@ -164,6 +166,7 @@ function Scanner:extract_packet_info(p)
          src_port = rd16(p.data + ip_payload_offset + UDP_SRC_PORT_OFFSET)
          dst_port = rd16(p.data + ip_payload_offset + UDP_DST_PORT_OFFSET)
       end
+      key.eth_type = ETH_TYPE_IPv4
    elseif eth_type == ETH_TYPE_IPv6 then
       key = the_flow_key_ipv6
       src_addr = p.data + ip_offset + IPv6_SRC_ADDR_OFFSET
@@ -185,6 +188,7 @@ function Scanner:extract_packet_info(p)
          src_port = rd16(proto_header_ptr + UDP_SRC_PORT_OFFSET)
          dst_port = rd16(proto_header_ptr + UDP_DST_PORT_OFFSET)
       end
+      key.eth_type = ETH_TYPE_IPv6
    else
       return nil
    end

--- a/src/program/wall/spy/spy.lua
+++ b/src/program/wall/spy/spy.lua
@@ -29,7 +29,7 @@ local function key (flow)
 end
 
 local function report_flow(scanner, flow, key)
-   local lo_addr, hi_addr = "<unkeynown>", "<unkeynown>"
+   local lo_addr, hi_addr = "<unknown>", "<unknown>"
    local eth_type = key.eth_type
    if eth_type == const.ETH_TYPE_IPv4 then
       lo_addr = ipv4:ntop(key.lo_addr)
@@ -39,7 +39,7 @@ local function report_flow(scanner, flow, key)
       hi_addr = ipv6:ntop(key.hi_addr)
    end
 
-   if flow.proto_master ~= proto.PROTOCOL_UNkeyNOWN then
+   if flow.proto_master ~= proto.PROTOCOL_UNKNOWN then
       printf("%4dp %15s:%-5d - %15s:%-5d  %s:%s\n",
          flow.packets,
          lo_addr, ntohs(key.lo_port),

--- a/src/program/wall/tests/spy-pcaps.test
+++ b/src/program/wall/tests/spy-pcaps.test
@@ -12,8 +12,8 @@ spy-pcap () {
 filter-output () {
 	local -a line
 	while read -r -a line ; do
-		if [[ ${line[0]} = 0x* ]] ; then
-			echo "${line[5]}"
+		if [[ ${line[0]} = +([[:digit:]])p ]] ; then
+			echo "${line[4]}"
 		fi
 	done | sort -u
 }


### PR DESCRIPTION
Fixes https://github.com/snabbco/snabb/issues/1165. I worked on this fix as a means to learn more about ctable.

The patch needs more testing. Snabbwall's test modules pass: 

```
TEST      apps.wall.scanner
TEST      apps.wall.l7fw
```

However Snabbwall's shell selftest is skipped (due to libndpi.so not present):

```
TEST      program/wall/tests/selftest.sh
SKIPPED   testlog/program.wall.tests.selftest.sh
```

Ideally the PR should be benchmarked too.