### PR TITLE
Comment not supported data types

### DIFF
--- a/src/lib/yang/ietf-alarms.yang
+++ b/src/lib/yang/ietf-alarms.yang
@@ -372,6 +372,9 @@ module ietf-alarms {
                 3GPP Distinguished names for example.";
         }
 
+
+        /*
+         * XXX: Temporarily replace leafref datatype for string as leafref is not supported.
         list related-alarm {
             key "resource alarm-type-id alarm-type-qualifier";
 
@@ -409,6 +412,31 @@ module ietf-alarms {
                     "The alarm qualifier for the related alarm.";
             }
         }
+        */
+        list related-alarm {
+            key "resource alarm-type-id alarm-type-qualifier";
+
+            description
+                "References to related alarms.  Note that the related alarm
+                might have been removed from the alarm list.";
+
+            leaf resource {
+                type string;
+                description
+                    "The alarming resource for the related alarm.";
+            }
+            leaf alarm-type-id {
+                type string;
+                description
+                    "The alarm type identifier for the related alarm.";
+            }
+            leaf alarm-type-qualifier {
+                type string;
+                description
+                    "The alarm qualifier for the related alarm.";
+            }
+        }
+
         leaf-list impacted-resource {
             type resource;
             description
@@ -959,6 +987,8 @@ module ietf-alarms {
             alarms.  Conditions in the input are logically ANDed.  If no
             input condition is given, all alarms are compressed.";
         input {
+            /*
+             * XXX: Temporarily replace leafref datatype for string as leafref is not supported.
             leaf resource {
                 type leafref {
                     path "/alarms/alarm-list/alarm/resource";
@@ -978,6 +1008,22 @@ module ietf-alarms {
                 type leafref {
                     path "/alarms/alarm-list/alarm/alarm-type-qualifier";
                 }
+                description
+                    "Compress the alarms with this alarm-type-qualifier.";
+            }
+            */
+            leaf resource {
+                type string;
+                description
+                    "Compress the alarms with this resource.";
+            }
+            leaf alarm-type-id {
+                type string;
+                description
+                    "Compress alarms with this alarm-type-id.";
+            }
+            leaf alarm-type-qualifier {
+                type string;
                 description
                     "Compress the alarms with this alarm-type-qualifier.";
             }
@@ -1148,6 +1194,8 @@ module ietf-alarms {
             "This notification is used to report that an operator
             acted upon an alarm.";
 
+        /*
+         * XXX: Temporarily replace leafref datatype for string as leafref is not supported.
         leaf resource {
             type leafref {
                 path "/alarms/alarm-list/alarm/resource";
@@ -1174,6 +1222,22 @@ module ietf-alarms {
                     + "/alarm-type-qualifier";
                 require-instance false;
             }
+            description
+                "The alarm qualifier for the alarm.";
+        }
+        */
+        leaf resource {
+            type string;
+            description
+                "The alarming resource.";
+        }
+        leaf alarm-type-id {
+            type string;
+            description
+                "The alarm type identifier for the alarm.";
+        }
+        leaf alarm-type-qualifier {
+            type string;
             description
                 "The alarm qualifier for the alarm.";
         }

--- a/src/lib/yang/ietf-alarms.yang
+++ b/src/lib/yang/ietf-alarms.yang
@@ -152,11 +152,14 @@ module ietf-alarms {
 
     typedef resource {
         type union {
+            type string;
+            /*
+             * Comment use of instance-identifier as it's not currently supported.
             type instance-identifier {
                 require-instance false;
             }
+            */
             type yang:object-identifier;
-            type string;
         }
         description
             "This is an identification of the alarming resource, such as an


### PR DESCRIPTION
Data types `leafref` and `instance-identifier` are used in `ietf-alarms` YANG schema. However these types are not currently supported by the yang library. The patch replaces uses of `leafref` for `string` and comments the single use of `instance-identifier`. This use happens inside an union, which as it's implemented now by the yang library it simply picks the first type in the union (which happens to be a string).