### PR TITLE
Implement alarm inventory

### DIFF
--- a/src/apps/config/alarm_codec.lua
+++ b/src/apps/config/alarm_codec.lua
@@ -133,14 +133,15 @@ end
 
 -- To be used by the leader to group args into key and args.
 function parse_args (args)
+   local resource, alarm_type_id, alarm_type_qualifier, perceived_severity, alarm_text = unpack(args)
    local key = {
-      resource = args.resource,
-      alarm_type_id = args.alarm_type_id,
-      alarm_type_qualifier = args.alarm_type_qualifier,
+      resource = resource,
+      alarm_type_id = alarm_type_id,
+      alarm_type_qualifier = alarm_type_qualifier,
    }
    local args = {
-      perceived_severity = args.perceived_severity,
-      alarm_text = args.alarm_text,
+      perceived_severity = perceived_severity,
+      alarm_text = alarm_text,
    }
    return key, args
 end

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -550,7 +550,7 @@ function Leader:rpc_get_state (args)
       local printer = path_printer_for_schema_by_name(self.schema_name, args.path, args)
       local s = {}
       for _, follower in pairs(self.followers) do
-         for k,v in pairs(state.show_state(self.schema_name, follower.pid, args.path)) do
+         for k,v in pairs(state.show_state(self.schema_name, follower.pid)) do
             s[k] = v
          end
       end

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -1,5 +1,54 @@
 module(..., package.seeall)
 
+local data = require('lib.yang.data')
+local util = require('lib.yang.util')
+
+local state = {
+   alarm_inventory = {},
+}
+
+function get_state ()
+   return {
+      alarm_inventory = state.alarm_inventory,
+   }
+end
+
+-- Single point to access alarm type keys.
+alarm_type_keys = {}
+
+function alarm_type_keys:fetch (...)
+   self.cache = self.cache or {}
+   local function lookup (alarm_type_id, alarm_type_qualifier)
+      if not self.cache[alarm_type_id] then
+         self.cache[alarm_type_id] = {}
+      end
+      return self.cache[alarm_type_id][alarm_type_qualifier]
+   end
+   local alarm_type_id, alarm_type_qualifier = unpack({...})
+   assert(alarm_type_id)
+   alarm_type_qualifier = alarm_type_qualifier or ''
+   local key = lookup(alarm_type_id, alarm_type_qualifier)
+   if not key then
+      key = {alarm_type_id=alarm_type_id, alarm_type_qualifier=alarm_type_qualifier}
+      self.cache[alarm_type_id][alarm_type_qualifier] = key
+   end
+   return key
+end
+
+local function load_default_configuration (filename)
+   filename = filename or "lib/yang/lwaftr-default-alarms.conf"
+   local content = util.readfile(filename)
+   local conf = assert(data.load_data_for_schema_by_name('ietf-alarms', content))
+   return conf.alarms
+end
+
+function init ()
+   local default = load_default_configuration()
+   state.alarm_inventory = default.alarm_inventory
+end
+
+---
+
 function raise_alarm (key, args)
    print('raise_alarm')
    assert(type(key) == 'table')
@@ -9,4 +58,20 @@ end
 function clear_alarm (key)
    print('clear alarm')
    assert(type(key) == 'table')
+end
+
+---
+
+function selftest ()
+   print("selftest: alarms")
+   local function table_size (t)
+      local size = 0
+      for _ in pairs(t) do size = size + 1 end
+      return size
+   end
+
+   init()
+   assert(table_size(state.alarm_inventory.alarm_type) > 0)
+
+   print("ok")
 end

--- a/src/lib/yang/lwaftr-default-alarms.conf
+++ b/src/lib/yang/lwaftr-default-alarms.conf
@@ -1,0 +1,18 @@
+alarms {
+   alarm-inventory {
+       alarm-type {
+           alarm-type-id arp-resolution;
+           alarm-type-qualifier "";
+           has-clear true;
+           resource external-interface;
+           description "";
+       }
+       alarm-type {
+           alarm-type-id ndp-resolution;
+           alarm-type-qualifier "";
+           resource internal-interface;
+           has-clear true;
+           description "";
+       }
+   }
+}

--- a/src/lib/yang/state.lua
+++ b/src/lib/yang/state.lua
@@ -5,7 +5,6 @@ local lib = require("core.lib")
 local shm = require("core.shm")
 local yang = require("lib.yang.yang")
 local yang_data = require("lib.yang.data")
-local counter = require("core.counter")
 
 local counter_directory = "/apps"
 
@@ -22,7 +21,7 @@ local function flatten(val)
    return rtn
 end
 
-function find_counters(pid)
+local function find_counters(pid)
    local path = shm.root.."/"..pid..counter_directory
    local apps = {}
    for _, c in pairs(lib.files_in_directory(path)) do
@@ -38,7 +37,7 @@ function find_counters(pid)
    return apps
 end
 
-function collect_state_leaves(schema)
+local function collect_state_leaves(schema)
    -- Iterate over schema looking fo state leaves at a specific path into the
    -- schema. This should return a dictionary of leaf to lua path.
    local function collection(scm, path)

--- a/src/lib/yang/state.lua
+++ b/src/lib/yang/state.lua
@@ -3,7 +3,6 @@ module(..., package.seeall)
 
 local lib = require("core.lib")
 local shm = require("core.shm")
-local xpath = require("lib.yang.path")
 local yang = require("lib.yang.yang")
 local yang_data = require("lib.yang.data")
 local counter = require("core.counter")
@@ -90,11 +89,9 @@ local function set_data_value(data, path, value)
    set_data_value(data[head], path, value)
 end
 
-function show_state(scm, pid, raw_path)
+function show_state(scm, pid)
    local schema = yang.load_schema_by_name(scm)
-   local grammar = yang_data.data_grammar_from_schema(schema)
    local counters = find_counters(pid)
-   local path = xpath.convert_path(grammar, raw_path)
 
    -- Lookup the specific schema element that's being addressed by the path
    local leaves = collect_state_leaves(schema)()

--- a/src/lib/yang/state.lua
+++ b/src/lib/yang/state.lua
@@ -11,102 +11,102 @@ local counter = require("core.counter")
 local counter_directory = "/apps"
 
 local function flatten(val)
-    local rtn = {}
-    for k, v in pairs(val) do
-        if type(v) == "table" then
-            v = flatten(v)
-            for k1, v1 in pairs(v) do rtn[k1] = v1 end
-        else
-            rtn[k] = v
-        end
-    end
-    return rtn
+   local rtn = {}
+   for k, v in pairs(val) do
+      if type(v) == "table" then
+         v = flatten(v)
+         for k1, v1 in pairs(v) do rtn[k1] = v1 end
+      else
+         rtn[k] = v
+      end
+   end
+   return rtn
 end
 
 function find_counters(pid)
-    local path = shm.root.."/"..pid..counter_directory
-    local apps = {}
-    for _, c in pairs(lib.files_in_directory(path)) do
-        local counters = {}
-        local counterdir = "/"..pid..counter_directory.."/"..c
-        for k,v in pairs(shm.open_frame(counterdir)) do
-            if type(v) == "cdata" then
-                counters[k] = v.c
-            end
-        end
-        apps[c] = counters
-    end
-    return apps
+   local path = shm.root.."/"..pid..counter_directory
+   local apps = {}
+   for _, c in pairs(lib.files_in_directory(path)) do
+      local counters = {}
+      local counterdir = "/"..pid..counter_directory.."/"..c
+      for k,v in pairs(shm.open_frame(counterdir)) do
+         if type(v) == "cdata" then
+            counters[k] = v.c
+         end
+      end
+      apps[c] = counters
+   end
+   return apps
 end
 
 function collect_state_leaves(schema)
-    -- Iterate over schema looking fo state leaves at a specific path into the
-    -- schema. This should return a dictionary of leaf to lua path.
-    local function collection(scm, path)
-        local function newpath(oldpath)
-            return lib.deepcopy(oldpath)
-        end
-        if path == nil then path = {} end
-        table.insert(path, scm.id)
+   -- Iterate over schema looking fo state leaves at a specific path into the
+   -- schema. This should return a dictionary of leaf to lua path.
+   local function collection(scm, path)
+      local function newpath(oldpath)
+         return lib.deepcopy(oldpath)
+      end
+      if path == nil then path = {} end
+      table.insert(path, scm.id)
 
-        if scm.kind == "container" then
-            -- Iterate over the body and recursively call self on all children.
+      if scm.kind == "container" then
+         -- Iterate over the body and recursively call self on all children.
+         local rtn = {}
+         for _, child in pairs(scm.body) do
+            local leaves = collection(child, newpath(path))
+            table.insert(rtn, leaves)
+         end
+         return rtn
+      elseif scm.kind == "leaf" then
+         if scm.config == false then
             local rtn = {}
-            for _, child in pairs(scm.body) do
-                local leaves = collection(child, newpath(path))
-                table.insert(rtn, leaves)
-            end
+            rtn[path] = scm.id
             return rtn
-        elseif scm.kind == "leaf" then
-            if scm.config == false then
-                local rtn = {}
-                rtn[path] = scm.id
-                return rtn
-            end
-        elseif scm.kind == "module" then
-            local rtn = {}
-            for _, v in pairs(scm.body) do
-                -- We deliberately don't want to include the module in the path.
-                table.insert(rtn, collection(v, {}))
-            end
-            return rtn
-        end
-        return {}
-    end
+         end
+      elseif scm.kind == "module" then
+         local rtn = {}
+         for _, v in pairs(scm.body) do
+            -- We deliberately don't want to include the module in the path.
+            table.insert(rtn, collection(v, {}))
+         end
+         return rtn
+      end
+      return {}
+   end
 
-    local leaves = collection(schema)
-    if leaves == nil then return {} end
-    leaves = flatten(leaves)
-    return function () return leaves end
+   local leaves = collection(schema)
+   if leaves == nil then return {} end
+   leaves = flatten(leaves)
+   return function () return leaves end
 end
 
 local function set_data_value(data, path, value)
-    local head = yang_data.normalize_id(table.remove(path, 1))
-    if #path == 0 then
-        data[head] = value
-        return
-    end
-    if data[head] == nil then data[head] = {} end
-    set_data_value(data[head], path, value)
+   local head = yang_data.normalize_id(table.remove(path, 1))
+   if #path == 0 then
+      data[head] = value
+      return
+   end
+   if data[head] == nil then data[head] = {} end
+   set_data_value(data[head], path, value)
 end
 
 function show_state(scm, pid, raw_path)
-    local schema = yang.load_schema_by_name(scm)
-    local grammar = yang_data.data_grammar_from_schema(schema)
-    local counters = find_counters(pid)
-    local path = xpath.convert_path(grammar, raw_path)
+   local schema = yang.load_schema_by_name(scm)
+   local grammar = yang_data.data_grammar_from_schema(schema)
+   local counters = find_counters(pid)
+   local path = xpath.convert_path(grammar, raw_path)
 
-    -- Lookup the specific schema element that's being addressed by the path
-    local leaves = collect_state_leaves(schema)()
-    local data = {}
-    for leaf_path, leaf in pairs(leaves) do
-        for _, counter in pairs(counters) do
-            if counter[leaf] then
-                set_data_value(data, leaf_path, counter[leaf])
-            end
-        end
-    end
-    return data
+   -- Lookup the specific schema element that's being addressed by the path
+   local leaves = collect_state_leaves(schema)()
+   local data = {}
+   for leaf_path, leaf in pairs(leaves) do
+      for _, counter in pairs(counters) do
+         if counter[leaf] then
+            set_data_value(data, leaf_path, counter[leaf])
+         end
+      end
+   end
+   return data
 end
 
 function selftest ()

--- a/src/lib/yang/state.lua
+++ b/src/lib/yang/state.lua
@@ -1,6 +1,7 @@
 -- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 module(..., package.seeall)
 
+local alarms = require("lib.yang.alarms")
 local lib = require("core.lib")
 local shm = require("core.shm")
 local yang = require("lib.yang.yang")
@@ -88,6 +89,11 @@ local function set_data_value(data, path, value)
    set_data_value(data[head], path, value)
 end
 
+local function collect_alarms_state (data)
+   data.softwire_state = data.softwire_state or {}
+   data.softwire_state.alarms = alarms.get_state() or {}
+end
+
 function show_state(scm, pid)
    local schema = yang.load_schema_by_name(scm)
    local counters = find_counters(pid)
@@ -102,11 +108,23 @@ function show_state(scm, pid)
          end
       end
    end
+
+   collect_alarms_state(data)
+
    return data
 end
 
 function selftest ()
    print("selftest: lib.yang.state")
+   alarms.init()
+   local t = alarms.get_state()
+   local function table_size (t)
+      local size = 0
+      for _ in pairs(t) do size = size + 1 end
+      return size
+   end
+   assert(table_size(t.alarm_inventory.alarm_type) > 0)
+
    local simple_router_schema_src = [[module snabb-simple-router {
       namespace snabb:simple-router;
       prefix simple-router;

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -128,6 +128,14 @@ function memoize(f, max_occupancy)
    end
 end
 
+function readfile (filename)
+   local fd, errno = io.open(filename, "rt")
+   if not fd then error(errno) end
+   local ret = fd:read("*a")
+   fd:close()
+   return ret
+end
+
 function selftest()
    print('selftest: lib.yang.util')
    assert(tointeger('0') == 0)


### PR DESCRIPTION
This PR implements alarm-inventory.

Alarm-inventory keeps a list of all the possible alarm-types in a system. According to https://datatracker.ietf.org/doc/draft-vallin-netmod-alarm-module/, a system could define its own alarm-types in a configuration file by using the identity keyword (See Section Appendix A.  Enterprise-specific Alarm-Types Example). Example:

```
identity xyz-alarms {
       base al:alarm-identity;
}
```

This doesn't make sense to us, as the lwAFTR will handle a finite set of alarms which types should be known beforehand. In addition, we don't want users to define alarm types in a configuration file. All the alarms state information will be empty in configuration files.

So the the alarm-inventory (the list of alarm types) is predefined in a YANG instance file which contains the default settings for alarms (so far, it only contains alarm-inventory).

The PR also modifies the get-state command to print out the alarm inventory. Example:

```bash
$ sudo ./snabb lwaftr run --conf lwaftr.conf --name lwaftr --on-a-stick 83:00.1
```

```bash
$ sudo ./snabb config get-state lwaftr /softwire-state/alarms
alarm-inventory {
  alarm-type {
    alarm-type-id arp-resolution;
    alarm-type-qualifier ;
    has-clear true;
    resource external-interface;
  }
  alarm-type {
    alarm-type-id ndp-resolution;
    alarm-type-qualifier ;
    has-clear true;
    resource internal-interface;
  }
}
```

