### PR TITLE
Deprecate reconfigurable flag

### DIFF
--- a/src/program/lwaftr/bench/README
+++ b/src/program/lwaftr/bench/README
@@ -21,9 +21,6 @@ Usage: bench CONF IPV4-IN.PCAP IPV6-IN.PCAP
                              as the identifier. This must be unique amongst
                              other snabb processes.
   --cpu    <cpu>             Bind lwAFTR bench to the given CPU
-  --reconfigurable           Allow run-time configuration query and update.
-                             This runs as two processes, a leader and a
-                             follower, rather than just one.
 
 Run the lwAFTR with input from IPV4-IN.PCAP and IPV6-IN.PCAP. The bench
 command is used to get an idea of the raw speed of the lwaftr without

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -31,12 +31,8 @@ function parse_args(args)
    function handlers.b(arg) opts.bench_file = arg end
    function handlers.y() opts.hydra = true end
    function handlers.h() show_usage(0) end
-   function handlers.reconfigurable()
-      io.stderr:write("Warning: --reconfigurable flag has been deprecated.\n")
-   end
    args = lib.dogetopt(args, handlers, "n:hyb:D:", {
-      help="h", hydra="y", ["bench-file"]="b", duration="D", name="n", cpu=1,
-      reconfigurable = 0 })
+      help="h", hydra="y", ["bench-file"]="b", duration="D", name="n", cpu=1})
    if #args ~= 3 then show_usage(1) end
    return opts, scheduling, unpack(args)
 end

--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -31,7 +31,9 @@ function parse_args(args)
    function handlers.b(arg) opts.bench_file = arg end
    function handlers.y() opts.hydra = true end
    function handlers.h() show_usage(0) end
-   function handlers.reconfigurable() opts.reconfigurable = true end
+   function handlers.reconfigurable()
+      io.stderr:write("Warning: --reconfigurable flag has been deprecated.\n")
+   end
    args = lib.dogetopt(args, handlers, "n:hyb:D:", {
       help="h", hydra="y", ["bench-file"]="b", duration="D", name="n", cpu=1,
       reconfigurable = 0 })
@@ -50,13 +52,8 @@ function run(args)
    end
 
    local graph = config.new()
-   if opts.reconfigurable then
-      setup.reconfigurable(scheduling, setup.load_bench, graph, conf,
-                           inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
-   else
-      setup.apply_scheduling(scheduling)
-      setup.load_bench(graph, conf, inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
-   end
+   setup.reconfigurable(scheduling, setup.load_bench, graph, conf,
+			inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
    app.configure(graph)
 
    local function start_sampling_for_pid(pid)
@@ -65,27 +62,19 @@ function run(args)
       csv:add_app('sinkv6', { 'input' }, { input=opts.hydra and 'encap' or 'Encap.' })
       csv:activate()
    end
-   if opts.reconfigurable then
-      for _,pid in ipairs(app.configuration.apps['leader'].arg.follower_pids) do
-         -- The worker will be fed its configuration by the
-         -- leader, but we don't know when that will all be ready.
-         -- Just retry if this doesn't succeed.
-         local function start_sampling()
-            if not pcall(start_sampling_for_pid, pid) then
-               io.stderr:write("Waiting on follower "..pid.." to start "..
-                                  "before recording statistics...\n")
-               timer.activate(timer.new('retry_csv', start_sampling, 1e9))
-            end
-         end
-         timer.activate(timer.new('spawn_csv_stats', start_sampling, 10e6))
+   for _,pid in ipairs(app.configuration.apps['leader'].arg.follower_pids) do
+      -- The worker will be fed its configuration by the
+      -- leader, but we don't know when that will all be ready.
+      -- Just retry if this doesn't succeed.
+      local function start_sampling()
+	 if not pcall(start_sampling_for_pid, pid) then
+	    io.stderr:write("Waiting on follower "..pid.." to start "..
+			       "before recording statistics...\n")
+	    timer.activate(timer.new('retry_csv', start_sampling, 1e9))
+	 end
       end
-   else
-      start_sampling_for_pid(S.getpid())
+      timer.activate(timer.new('spawn_csv_stats', start_sampling, 10e6))
    end
 
-   if not opts.reconfigurable then
-      -- The leader does not need all the CPU, only the followers do.
-      app.busywait = true
-   end
    app.main({duration=opts.duration})
 end

--- a/src/program/lwaftr/doc/CHANGELOG.md
+++ b/src/program/lwaftr/doc/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [2017.07.02]
+
+* Deprecate the --reconfigurable flags in favour of the lwaftr always
+  being reconfigurable.
+
 ## [2017.07.01] - 2017-08-04
 
 * New YANG schema snabb-softwire-v2 replaces old snabb-softwire-v1

--- a/src/program/lwaftr/run/README
+++ b/src/program/lwaftr/run/README
@@ -9,9 +9,6 @@ Required arguments:
        --on-a-stick <pci-addr>  One single NIC for INET-side and B4-side
 
 Optional arguments:
-       --reconfigurable         Allow run-time configuration query and update.
-                                This runs as two processes, a leader and a
-                                follower, rather than just one.
        --virtio                 Use virtio-net interfaces instead of Intel 82599
        --ring-buffer-size <size>  Set Intel 82599 receive buffer size
        --cpu    <cpu>           Bind the lwAFTR to the given CPU

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -103,7 +103,8 @@ function parse_args(args)
       end
    end
    function handlers.reconfigurable()
-      io.stderr:write("Warning: --reconfigurable flag has been deprecated.\n")
+      io.stderr:write("Warning: the --reconfigurable flag has been deprecated")
+      io.stderr:write(" as the lwaftr is now always reconfigurable.\n")
    end
    function handlers.h() show_usage(0) end
    lib.dogetopt(args, handlers, "b:c:vD:yhir:n:",

--- a/src/program/lwaftr/tests/propbased/common.lua
+++ b/src/program/lwaftr/tests/propbased/common.lua
@@ -12,16 +12,16 @@ function make_handle_prop_args(name, duration, pidbox)
         print("Usage: snabb lwaftr quickcheck prop_sameval PCI_ADDR")
         os.exit(1)
      end
-  
+
      local pci_addr = prop_args[1]
      assert(S.stat(pci.path(pci_addr)),
             string.format("Invalid PCI address: %s", pci_addr))
-  
+
      local pid = S.fork()
      if pid == 0 then
         local cmdline = {"snabb", "lwaftr", "run", "-D", tostring(duration),
             "--conf", "program/lwaftr/tests/data/icmp_on_fail.conf",
-            "--reconfigurable", "--on-a-stick", pci_addr}
+            "--on-a-stick", pci_addr}
         lib.execv(("/proc/%d/exe"):format(S.getpid()), cmdline)
      else
         pidbox[1] = pid

--- a/src/program/lwaftr/tests/subcommands/bench_test.py
+++ b/src/program/lwaftr/tests/subcommands/bench_test.py
@@ -18,19 +18,12 @@ class TestBench(BaseTestCase):
         str(BENCHDATA_DIR / 'ipv6-0550.pcap'),
     ]
 
-    def execute_bench_test(self, cmd_args):
-        self.run_cmd(cmd_args)
+    def test_bench(self):
+        self.run_cmd(self.cmd_args)
         self.assertTrue(BENCHMARK_PATH.is_file(),
             'Cannot find {}'.format(BENCHMARK_PATH))
         BENCHMARK_PATH.unlink()
 
-    def test_bench_not_reconfigurable(self):
-        self.execute_bench_test(self.cmd_args)
-
-    def test_bench_reconfigurable(self):
-        reconf_args = list(self.cmd_args)
-        reconf_args.insert(3, '--reconfigurable')
-        self.execute_bench_test(reconf_args)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -17,7 +17,7 @@ from test_env import BENCHDATA_DIR, DATA_DIR, ENC, SNABB_CMD, BaseTestCase, \
 
 DAEMON_PROC_NAME = 'config-test-daemon'
 DAEMON_ARGS = [
-    str(SNABB_CMD), 'lwaftr', 'bench', '--reconfigurable',
+    str(SNABB_CMD), 'lwaftr', 'bench',
     '--bench-file', '/dev/null',
     '--name', DAEMON_PROC_NAME,
     str(DATA_DIR / 'icmp_on_fail.conf'),

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -21,18 +21,10 @@ class TestRun(BaseTestCase):
         '--v6', SNABB_PCI1
     )
 
-    def execute_run_test(self, cmd_args):
-        output = self.run_cmd(cmd_args)
+    def test_run(self):
+        output = self.run_cmd(self.cmd_args)
         self.assertIn(b'link report', output,
             b'\n'.join((b'OUTPUT', output)))
-
-    def test_run_not_reconfigurable(self):
-        self.execute_run_test(self.cmd_args)
-
-    def test_run_reconfigurable(self):
-        reconf_args = list(self.cmd_args)
-        reconf_args.insert(3, '--reconfigurable')
-        self.execute_run_test(reconf_args)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This deprecates the `--reconfigurable` flag in favour of having it always be in a multi-process re-configurable mode. The use of the flag will now raise a deprecation warning.

One other thing to note is as of this PR the ingress drop monitor support is no longer available as documented in #902.