### PR TITLE
Extract IPv6 reassembler from lwAFTR

### DIFF
--- a/src/apps/lwaftr/ipv6_apps.lua
+++ b/src/apps/lwaftr/ipv6_apps.lua
@@ -2,7 +2,6 @@ module(..., package.seeall)
 
 local constants = require("apps.lwaftr.constants")
 local fragmentv6 = require("apps.lwaftr.fragmentv6")
-local fragv6_h = require("apps.lwaftr.fragmentv6_hardened")
 local lwutil = require("apps.lwaftr.lwutil")
 local icmp = require("apps.lwaftr.icmp")
 local lwcounter = require("apps.lwaftr.lwcounter")
@@ -21,7 +20,7 @@ local ffi = require("ffi")
 
 local receive, transmit = link.receive, link.transmit
 local wr16 = lwutil.wr16
-local is_ipv6, is_ipv6_fragment = lwutil.is_ipv6, lwutil.is_ipv6_fragment
+local is_ipv6 = lwutil.is_ipv6
 local htons = lib.htons
 
 local ipv6_fixed_header_size = constants.ipv6_fixed_header_size
@@ -35,60 +34,8 @@ local icmpv6_echo_request = constants.icmpv6_echo_request
 local icmpv6_echo_reply = constants.icmpv6_echo_reply
 local ehs = constants.ethernet_header_size
 
-ReassembleV6 = {}
 Fragmenter = {}
 ICMPEcho = {}
-
-function ReassembleV6:new(conf)
-   local max_ipv6_reassembly_packets = conf.max_ipv6_reassembly_packets
-   local max_fragments_per_reassembly_packet = conf.max_fragments_per_reassembly_packet
-   local o = {
-      counters = lwcounter.init_counters(),
-      ctab = fragv6_h.initialize_frag_table(max_ipv6_reassembly_packets,
-         max_fragments_per_reassembly_packet),
-   }
-   counter.set(o.counters["memuse-ipv6-frag-reassembly-buffer"],
-               o.ctab:get_backing_size())
-   return setmetatable(o, {__index = ReassembleV6})
-end
-
-function ReassembleV6:cache_fragment(fragment)
-   return fragv6_h.cache_fragment(self.ctab, fragment)
-end
-
-function ReassembleV6:push ()
-   local input, output = self.input.input, self.output.output
-   local errors = self.output.errors
-
-   for _ = 1, link.nreadable(input) do
-      local pkt = receive(input)
-      if is_ipv6_fragment(pkt) then
-         counter.add(self.counters["in-ipv6-frag-needs-reassembly"])
-         local status, maybe_pkt, did_evict = self:cache_fragment(pkt)
-         if did_evict then
-            counter.add(self.counters["drop-ipv6-frag-random-evicted"])
-         end
-
-         if status == fragv6_h.REASSEMBLY_OK then
-            counter.add(self.counters["in-ipv6-frag-reassembled"])
-            transmit(output, maybe_pkt)
-         elseif status == fragv6_h.FRAGMENT_MISSING then
-            -- Nothing useful to be done yet, continue
-         elseif status == fragv6_h.REASSEMBLY_INVALID then
-            counter.add(self.counters["drop-ipv6-frag-invalid-reassembly"])
-            if maybe_pkt then -- This is an ICMP packet
-               transmit(errors, maybe_pkt)
-            end
-         else -- unreachable
-            packet.free(pkt)
-         end
-      else
-         -- Forward all packets that aren't IPv6 fragments.
-         counter.add(self.counters["in-ipv6-frag-reassembly-unneeded"])
-         transmit(output, pkt)
-      end
-   end
-end
 
 function Fragmenter:new(conf)
    local o = {

--- a/src/apps/lwaftr/lwcounter.lua
+++ b/src/apps/lwaftr/lwcounter.lua
@@ -41,11 +41,14 @@ end
 -- Temporary hack until we migrate all of the lwAFTR's apps to use the
 -- SHM frame mechanism.
 local ipv4_reassemble = require('apps.ipv4.reassemble')
+local ipv6_reassemble = require('apps.ipv6.reassemble')
 function init_counters ()
    local counters = {}
    for k, id in pairs(counter_names()) do
       if ipv4_reassemble.Reassembler.shm[k] then
          -- Don't create this counter; IPv4 reassemble app handles it.
+      elseif ipv6_reassemble.Reassembler.shm[k] then
+         -- Don't create this counter; IPv6 reassemble app handles it.
       else
          counters[k] = {counter}
       end

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -107,9 +107,9 @@ function lwaftr_app(c, conf, device)
                 max_fragments_per_reassembly =
                    gexternal_interface.reassembly.max_fragments_per_packet })
    config.app(c, "reassemblerv6", ipv6_reassemble.Reassembler,
-              { max_ipv6_reassembly_packets =
+              { max_concurrent_reassemblies =
                    ginternal_interface.reassembly.max_packets,
-                max_fragments_per_reassembly_packet =
+                max_fragments_per_reassembly =
                    ginternal_interface.reassembly.max_fragments_per_packet })
    config.app(c, "icmpechov4", ipv4_apps.ICMPEcho,
               { address = convert_ipv4(iexternal_interface.ip) })

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -16,6 +16,7 @@ local ipv4_apps  = require("apps.lwaftr.ipv4_apps")
 local ipv4_reassemble = require("apps.ipv4.reassemble")
 local arp        = require("apps.ipv4.arp")
 local ipv6_apps  = require("apps.lwaftr.ipv6_apps")
+local ipv6_reassemble = require("apps.ipv6.reassemble")
 local ndp        = require("apps.lwaftr.ndp")
 local vlan       = require("apps.vlan.vlan")
 local numa       = require("lib.numa")
@@ -105,7 +106,7 @@ function lwaftr_app(c, conf, device)
                    gexternal_interface.reassembly.max_packets,
                 max_fragments_per_reassembly =
                    gexternal_interface.reassembly.max_fragments_per_packet })
-   config.app(c, "reassemblerv6", ipv6_apps.ReassembleV6,
+   config.app(c, "reassemblerv6", ipv6_reassemble.Reassembler,
               { max_ipv6_reassembly_packets =
                    ginternal_interface.reassembly.max_packets,
                 max_fragments_per_reassembly_packet =

--- a/src/program/lwaftr/tests/data/counters/arp-for-next-hop.lua
+++ b/src/program/lwaftr/tests/data/counters/arp-for-next-hop.lua
@@ -1,5 +1,5 @@
 return {
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-frag-not"] = 1,
 }

--- a/src/program/lwaftr/tests/data/counters/empty.lua
+++ b/src/program/lwaftr/tests/data/counters/empty.lua
@@ -1,4 +1,4 @@
 return {
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/from-inet-ipv4-in-binding-big-packet-df-set-allow.lua
+++ b/src/program/lwaftr/tests/data/counters/from-inet-ipv4-in-binding-big-packet-df-set-allow.lua
@@ -7,7 +7,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-icmpv4-bytes"] = 590,
    ["out-icmpv4-packets"] = 1,
    ["out-ipv4-bytes"] = 590,

--- a/src/program/lwaftr/tests/data/counters/from-inet-ipv4-in-binding-big-packet-df-set-drop.lua
+++ b/src/program/lwaftr/tests/data/counters/from-inet-ipv4-in-binding-big-packet-df-set-drop.lua
@@ -8,5 +8,5 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/from-to-b4-ipv6-hairpin-n64.lua
+++ b/src/program/lwaftr/tests/data/counters/from-to-b4-ipv6-hairpin-n64.lua
@@ -5,7 +5,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 64,
    ["in-ipv6-packets"] = 64,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 6784,
    ["out-ipv6-frag-not"] = 64,
    ["out-ipv6-packets"] = 64,

--- a/src/program/lwaftr/tests/data/counters/from-to-b4-ipv6-hairpin.lua
+++ b/src/program/lwaftr/tests/data/counters/from-to-b4-ipv6-hairpin.lua
@@ -5,7 +5,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 106,
    ["out-ipv6-frag-not"] = 1,
    ["out-ipv6-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/from-to-b4-tunneled-icmpv4-ping-hairpin-unbound.lua
+++ b/src/program/lwaftr/tests/data/counters/from-to-b4-tunneled-icmpv4-ping-hairpin-unbound.lua
@@ -11,5 +11,5 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/from-to-b4-tunneled-icmpv4-ping-hairpin.lua
+++ b/src/program/lwaftr/tests/data/counters/from-to-b4-tunneled-icmpv4-ping-hairpin.lua
@@ -5,7 +5,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 138,
    ["out-ipv6-frag-not"] = 1,
    ["out-ipv6-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/icmpv6-ping-and-reply.lua
+++ b/src/program/lwaftr/tests/data/counters/icmpv6-ping-and-reply.lua
@@ -1,6 +1,6 @@
 return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-frag-not"] = 1,
 }

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-infrags-out-1p-ipv6-6-outfrags.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-infrags-out-1p-ipv6-6-outfrags.lua
@@ -4,7 +4,7 @@ return {
    ["in-ipv4-frag-reassembled"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 1514,
    ["out-ipv6-frag"] = 2,
    ["out-ipv6-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-0p-drop.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-0p-drop.lua
@@ -1,5 +1,5 @@
 return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-icmpv4.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-icmpv4.lua
@@ -7,7 +7,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-icmpv4-bytes"] = 94,
    ["out-icmpv4-packets"] = 1,
    ["out-ipv4-bytes"] = 94,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-1.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-1.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 106,
    ["out-ipv6-frag-not"] = 1,
    ["out-ipv6-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-2.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-2.lua
@@ -4,7 +4,7 @@ return {
    ["in-ipv4-frag-reassembled"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 1500,
    ["out-ipv6-frag-not"] = 1,
    ["out-ipv6-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-3.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-3.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 1534,
    ["out-ipv6-frag"] = 2,
    ["out-ipv6-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-4.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-4.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 2774,
    ["out-ipv6-frag"] = 3,
    ["out-ipv6-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-6-outfrags.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-6-outfrags.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 1514,
    ["out-ipv6-frag"] = 2,
    ["out-ipv6-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-6.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-6.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 1514,
    ["out-ipv6-frag-not"] = 1,
    ["out-ipv6-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-7.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-7.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 138,
    ["out-ipv6-frag-not"] = 1,
    ["out-ipv6-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-8.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-8.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 110,
    ["out-ipv6-frag-not"] = 1,
    ["out-ipv6-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-echo.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-1p-ipv6-echo.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 2,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-frag-not"] = 1,
    ["out-ipv6-bytes"] = 106,
    ["out-ipv6-frag-not"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-none-1.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-none-1.lua
@@ -8,5 +8,5 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-none-2.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-none-2.lua
@@ -7,5 +7,5 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-none-3.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-none-3.lua
@@ -7,5 +7,5 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-none-4.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv4-out-none-4.lua
@@ -9,5 +9,5 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-0p-ipv4.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-0p-ipv4.lua
@@ -2,5 +2,5 @@ return {
    ["drop-ipv6-frag-invalid-reassembly"] = 1,
    ["in-ipv6-frag-needs-reassembly"] = 2,
    ["memuse-ipv4-frag-reassembly-buffer"] = 456549312,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 247200,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 247104,
 }

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-icmpv4-1.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-icmpv4-1.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-icmpv4-bytes"] = 94,
    ["out-icmpv4-packets"] = 1,
    ["out-ipv4-bytes"] = 94,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-icmpv6-1.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-icmpv6-1.lua
@@ -7,7 +7,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-icmpv6-bytes"] = 154,
    ["out-icmpv6-packets"] = 1,
    ["out-ipv6-bytes"] = 154,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-icmpv6-2.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-icmpv6-2.lua
@@ -7,7 +7,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-icmpv6-bytes"] = 186,
    ["out-icmpv6-packets"] = 1,
    ["out-ipv6-bytes"] = 186,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-1.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-1.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-bytes"] = 1006,
    ["out-ipv4-frag"] = 2,
    ["out-ipv4-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-2.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-2.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-bytes"] = 1460,
    ["out-ipv4-frag"] = 3,
    ["out-ipv4-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-3.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-3.lua
@@ -4,7 +4,7 @@ return {
    ["in-ipv6-frag-reassembled"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-bytes"] = 1494,
    ["out-ipv4-frag-not"] = 1,
    ["out-ipv4-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-4-and-echo.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-4-and-echo.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 2,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-bytes"] = 66,
    ["out-ipv4-frag-not"] = 1,
    ["out-ipv4-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-4.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-4.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-bytes"] = 66,
    ["out-ipv4-frag-not"] = 1,
    ["out-ipv4-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-5-frags.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-5-frags.lua
@@ -4,7 +4,7 @@ return {
    ["in-ipv6-frag-reassembled"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-bytes"] = 1474,
    ["out-ipv4-frag-not"] = 1,
    ["out-ipv4-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-5.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-5.lua
@@ -4,7 +4,7 @@ return {
    ["in-ipv6-frag-reassembled"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-bytes"] = 1474,
    ["out-ipv4-frag"] = 3,
    ["out-ipv4-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-hoplimhair.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-1p-ipv4-hoplimhair.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-icmpv4-bytes"] = 94,
    ["out-icmpv4-packets"] = 1,
    ["out-ipv6-bytes"] = 134,

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-none-1.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-none-1.lua
@@ -8,5 +8,5 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-none-2.lua
+++ b/src/program/lwaftr/tests/data/counters/in-1p-ipv6-out-none-2.lua
@@ -7,5 +7,5 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/in-ipv4-ipv6-out-icmpv4-ipv6-hairpin-1-drop.lua
+++ b/src/program/lwaftr/tests/data/counters/in-ipv4-ipv6-out-icmpv4-ipv6-hairpin-1-drop.lua
@@ -10,5 +10,5 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/in-ipv4-ipv6-out-icmpv4-ipv6-hairpin-1.lua
+++ b/src/program/lwaftr/tests/data/counters/in-ipv4-ipv6-out-icmpv4-ipv6-hairpin-1.lua
@@ -9,7 +9,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["in-ipv6-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-icmpv4-bytes"] = 94,
    ["out-icmpv4-packets"] = 1,
    ["out-ipv6-bytes"] = 134,

--- a/src/program/lwaftr/tests/data/counters/ndp-no-na-next-hop6-mac-not-set-2pkts.lua
+++ b/src/program/lwaftr/tests/data/counters/ndp-no-na-next-hop6-mac-not-set-2pkts.lua
@@ -5,7 +5,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 2,
    ["in-ipv6-packets"] = 2,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-bytes"] = 66,
    ["out-ipv4-frag-not"] = 1,
    ["out-ipv4-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/ndp-no-na-next-hop6-mac-not-set-3pkts.lua
+++ b/src/program/lwaftr/tests/data/counters/ndp-no-na-next-hop6-mac-not-set-3pkts.lua
@@ -5,7 +5,7 @@ return {
    ["in-ipv6-frag-reassembly-unneeded"] = 3,
    ["in-ipv6-packets"] = 2,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-bytes"] = 66,
    ["out-ipv4-frag-not"] = 1,
    ["out-ipv4-packets"] = 1,

--- a/src/program/lwaftr/tests/data/counters/ndp-ns-for-next-hop.lua
+++ b/src/program/lwaftr/tests/data/counters/ndp-ns-for-next-hop.lua
@@ -1,5 +1,5 @@
 return {
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-frag-not"] = 1,
 }

--- a/src/program/lwaftr/tests/data/counters/ndp-secondary.lua
+++ b/src/program/lwaftr/tests/data/counters/ndp-secondary.lua
@@ -1,5 +1,5 @@
 return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/nofrag4.lua
+++ b/src/program/lwaftr/tests/data/counters/nofrag4.lua
@@ -1,6 +1,6 @@
 return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv4-frag-not"] = 1,
 }

--- a/src/program/lwaftr/tests/data/counters/nofrag6-sol.lua
+++ b/src/program/lwaftr/tests/data/counters/nofrag6-sol.lua
@@ -1,6 +1,6 @@
 return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-frag-not"] = 1,
 }

--- a/src/program/lwaftr/tests/data/counters/nofrag6.lua
+++ b/src/program/lwaftr/tests/data/counters/nofrag6.lua
@@ -1,5 +1,5 @@
 return {
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/non-ipv4-traffic-to-ipv4-interface.lua
+++ b/src/program/lwaftr/tests/data/counters/non-ipv4-traffic-to-ipv4-interface.lua
@@ -5,5 +5,5 @@ return {
    ["drop-misplaced-not-ipv6-packets"] = 1,
    ["in-ipv6-frag-reassembly-unneeded"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/non-ipv6-traffic-to-ipv6-interface.lua
+++ b/src/program/lwaftr/tests/data/counters/non-ipv6-traffic-to-ipv6-interface.lua
@@ -5,5 +5,5 @@ return {
    ["drop-misplaced-not-ipv4-packets"] = 1,
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/regressiontest-endaddr.lua
+++ b/src/program/lwaftr/tests/data/counters/regressiontest-endaddr.lua
@@ -3,7 +3,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 4,
    ["in-ipv4-packets"] = 4,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-ipv6-bytes"] = 6136,
    ["out-ipv6-frag-not"] = 4,
    ["out-ipv6-packets"] = 4,

--- a/src/program/lwaftr/tests/data/counters/regressiontest-signedntohl-frags-counters.lua
+++ b/src/program/lwaftr/tests/data/counters/regressiontest-signedntohl-frags-counters.lua
@@ -9,5 +9,5 @@ return {
    ["in-ipv6-frag-reassembled"] = 5,
    ["in-ipv6-packets"] = 5,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
 }

--- a/src/program/lwaftr/tests/data/counters/tcp-frominet-bound-ttl1.lua
+++ b/src/program/lwaftr/tests/data/counters/tcp-frominet-bound-ttl1.lua
@@ -7,7 +7,7 @@ return {
    ["in-ipv4-frag-reassembly-unneeded"] = 1,
    ["in-ipv4-packets"] = 1,
    ["memuse-ipv4-frag-reassembly-buffer"] = 463482888,
-   ["memuse-ipv6-frag-reassembly-buffer"] = 464727376,
+   ["memuse-ipv6-frag-reassembly-buffer"] = 464549592,
    ["out-icmpv4-bytes"] = 94,
    ["out-icmpv4-packets"] = 1,
    ["out-ipv4-bytes"] = 94,

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -10,6 +10,7 @@ local ethernet = require("lib.protocol.ethernet")
 local ipv4_apps = require("apps.lwaftr.ipv4_apps")
 local ipv4_reassemble = require("apps.ipv4.reassemble")
 local ipv6_apps = require("apps.lwaftr.ipv6_apps")
+local ipv6_reassemble = require("apps.ipv6.reassemble")
 local lib = require("core.lib")
 local lwaftr = require("apps.lwaftr.lwaftr")
 local lwutil = require("apps.lwaftr.lwutil")
@@ -190,7 +191,7 @@ function lwaftr_app(c, conf, lwconf, sock_path)
              conf.ipv6_interface.fragmentation)))
       if conf.ipv6_interface.fragmentation then
          local mtu = conf.ipv6_interface.mtu or internal_interface.mtu
-         config.app(c, "reassemblerv6", ipv6_apps.ReassembleV6, {
+         config.app(c, "reassemblerv6", ipv6_reassemble.Reassembler, {
             max_ipv6_reassembly_packets =
                ginternal_interface.reassembly.max_packets,
             max_fragments_per_reassembly_packet =
@@ -350,7 +351,7 @@ local function lwaftr_app_check (c, conf, lwconf, sources, sinks)
    if conf.ipv6_interface then
       if conf.ipv6_interface.fragmentation then
          local mtu = conf.ipv6_interface.mtu or internal_interface.mtu
-         config.app(c, "reassemblerv6", ipv6_apps.ReassembleV6, {
+         config.app(c, "reassemblerv6", ipv6_reassemble.Reassembler, {
             max_ipv6_reassembly_packets =
                internal_interface.reassembly.max_packets,
             max_fragments_per_reassembly_packet =

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -192,9 +192,9 @@ function lwaftr_app(c, conf, lwconf, sock_path)
       if conf.ipv6_interface.fragmentation then
          local mtu = conf.ipv6_interface.mtu or internal_interface.mtu
          config.app(c, "reassemblerv6", ipv6_reassemble.Reassembler, {
-            max_ipv6_reassembly_packets =
+            max_concurrent_reassemblies =
                ginternal_interface.reassembly.max_packets,
-            max_fragments_per_reassembly_packet =
+            max_fragments_per_reassembly =
                ginternal_interface.reassembly.max_fragments_per_packet
          })
          config.app(c, "fragmenterv6", ipv6_apps.Fragmenter, {
@@ -352,9 +352,9 @@ local function lwaftr_app_check (c, conf, lwconf, sources, sinks)
       if conf.ipv6_interface.fragmentation then
          local mtu = conf.ipv6_interface.mtu or internal_interface.mtu
          config.app(c, "reassemblerv6", ipv6_reassemble.Reassembler, {
-            max_ipv6_reassembly_packets =
+            max_concurrent_reassemblies =
                internal_interface.reassembly.max_packets,
-            max_fragments_per_reassembly_packet =
+            max_fragments_per_reassembly =
                internal_interface.reassembly.max_fragments_per_packet
          })
          config.app(c, "fragmenterv6", ipv6_apps.Fragmenter, {


### PR DESCRIPTION
This is a follow-on to #891 that does the same work to the IPv6 reassembler.  In the process it fixes some bugs I think -- there wasn't very good test coverage before, and porting the new tests over from the IPv4 reassembler exposed some cases where the packet would not be correctly reassembled.