### PR TITLE
Merge lwaftr alarms

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -953,6 +953,19 @@ lib.parse({foo=42, bar=43}, {foo={required=true}, bar={}, baz={default=44}})
   => {foo=42, bar=43, baz=44}
 ```
 
+- Function **lib.set** *vargs*
+
+Reads a variable number of arguments and returns a table representing a set.
+The returned value can be used to query whether an element belongs or not to
+the set.
+
+Example:
+
+```
+local t = set('foo', 'bar')
+t['foo']  -- yields true.
+t['quax'] -- yields false.
+```
 
 ## Multiprocess operation (core.worker)
 

--- a/src/apps/config/alarm_codec.lua
+++ b/src/apps/config/alarm_codec.lua
@@ -124,6 +124,21 @@ local function normalize_args (t)
    return normalize(t, args_attrs)
 end
 
+-- To be used by the leader to group args into key and args.
+function parse_args (args)
+   local resource, alarm_type_id, alarm_type_qualifier, perceived_severity, alarm_text = unpack(args)
+   local key = {
+      resource = resource,
+      alarm_type_id = alarm_type_id,
+      alarm_type_qualifier = alarm_type_qualifier,
+   }
+   local args = {
+      perceived_severity = perceived_severity,
+      alarm_text = alarm_text,
+   }
+   return key, args
+end
+
 function raise_alarm (key, args)
    local channel = get_channel()
    if channel then

--- a/src/apps/config/alarm_codec.lua
+++ b/src/apps/config/alarm_codec.lua
@@ -103,6 +103,8 @@ function get_channel()
    local success, value = pcall(channel.open, name)
    if success then
       alarms_channel = value
+   else
+      alarms_channel = channel.create('alarms-follower-channel', 1e6)
    end
    return alarms_channel
 end

--- a/src/apps/config/alarm_codec.lua
+++ b/src/apps/config/alarm_codec.lua
@@ -1,0 +1,95 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(...,package.seeall)
+
+local ffi = require("ffi")
+
+local alarm_names = { 'raise_alarm', 'clear_alarm' }
+local alarm_codes = {}
+for i, name in ipairs(alarm_names) do alarm_codes[name] = i end
+
+local alarms = {}
+
+function alarms.raise_alarm (codec, key, args)
+   local key = codec:string(key)
+   local args = codec:string(args)
+   return codec:finish(key, args)
+end
+function alarms.clear_alarm (codec, key, args)
+   local key = codec:string(key)
+   local args = codec:string(args)
+   return codec:finish(key, args)
+end
+
+local function encoder()
+   local encoder = { out = {} }
+   function encoder:uint32(len)
+      table.insert(self.out, ffi.new('uint32_t[1]', len))
+   end
+   function encoder:string(str)
+      self:uint32(#str)
+      local buf = ffi.new('uint8_t[?]', #str)
+      ffi.copy(buf, str, #str)
+      table.insert(self.out, buf)
+   end
+   function encoder:finish()
+      local size = 0
+      for _,src in ipairs(self.out) do size = size + ffi.sizeof(src) end
+      local dst = ffi.new('uint8_t[?]', size)
+      local pos = 0
+      for _,src in ipairs(self.out) do
+         ffi.copy(dst + pos, src, ffi.sizeof(src))
+         pos = pos + ffi.sizeof(src)
+      end
+      return dst, size
+   end
+   return encoder
+end
+
+function encode(alarm)
+   local name, args = unpack(alarm)
+   local codec = encoder()
+   codec:uint32(assert(alarm_codes[name], name))
+   return assert(alarms[name], name)(codec, unpack(args))
+end
+
+local uint32_ptr_t = ffi.typeof('uint32_t*')
+local function decoder(buf, len)
+   local decoder = { buf=buf, len=len, pos=0 }
+   function decoder:read(count)
+      local ret = self.buf + self.pos
+      self.pos = self.pos + count
+      assert(self.pos <= self.len)
+      return ret
+   end
+   function decoder:uint32()
+      return ffi.cast(uint32_ptr_t, self:read(4))[0]
+   end
+   function decoder:string()
+      local len = self:uint32()
+      return ffi.string(self:read(len), len)
+   end
+   function decoder:finish(...)
+      return { ... }
+   end
+   return decoder
+end
+
+function decode(buf, len)
+   local codec = decoder(buf, len)
+   local name = assert(alarm_names[codec:uint32()])
+   return { name, assert(alarms[name], name)(codec) }
+end
+
+function selftest ()
+   print('selftest: apps.config.alarm_codec')
+   local lib = require("core.lib")
+   local function test_alarm(alarm)
+      local encoded, len = encode(alarm)
+      local decoded = decode(encoded, len)
+      assert(lib.equal(alarm, decoded))
+   end
+   test_alarm({'raise_alarm', {'foo', 'bar'}})
+   test_alarm({'clear_alarm', {'foo', 'bar'}})
+   print('selftest: ok')
+end

--- a/src/apps/config/follower.lua
+++ b/src/apps/config/follower.lua
@@ -23,6 +23,7 @@ function Follower:new (conf)
    ret.period = 1/conf.Hz
    ret.next_time = app.now()
    ret.channel = channel.create('config-follower-channel', 1e6)
+   ret.alarms_channel = channel.create('alarms-follower-channel', 1e6)
    ret.pending_actions = {}
    return ret
 end

--- a/src/apps/config/follower.lua
+++ b/src/apps/config/follower.lua
@@ -11,6 +11,7 @@ local shm = require("core.shm")
 local app_graph = require("core.config")
 local channel = require("apps.config.channel")
 local action_codec = require("apps.config.action_codec")
+local alarm_codec = require("apps.config.alarm_codec")
 
 Follower = {
    config = {
@@ -23,7 +24,7 @@ function Follower:new (conf)
    ret.period = 1/conf.Hz
    ret.next_time = app.now()
    ret.channel = channel.create('config-follower-channel', 1e6)
-   ret.alarms_channel = channel.create('alarms-follower-channel', 1e6)
+   ret.alarms_channel = alarm_codec.get_channel()
    ret.pending_actions = {}
    return ret
 end

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -754,10 +754,12 @@ end
 function Leader:handle_alarm (follower, alarm)
    local fn, args = unpack(alarm)
    if fn == 'raise_alarm' then
-      alarms.raise_alarm(unpack(args))
+      local key, args = alarm_codec.parse_args(args)
+      alarms.raise_alarm(key, args)
    end
    if fn == 'clear_alarm' then
-      alarms.clear_alarm(unpack(args))
+      local key = alarm_codec.parse_args(args)
+      alarms.clear_alarm(key)
    end
 end
 

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -17,8 +17,10 @@ local app = require("core.app")
 local shm = require("core.shm")
 local app_graph = require("core.config")
 local action_codec = require("apps.config.action_codec")
+local alarm_codec = require("apps.config.alarm_codec")
 local support = require("apps.config.support")
 local channel = require("apps.config.channel")
+local alarms = require("lib.yang.alarms")
 
 Leader = {
    config = {
@@ -723,6 +725,40 @@ function Leader:pull ()
    self.next_time = app.now() + self.period
    self:handle_calls_from_peers()
    self:send_messages_to_followers()
+   self:receive_alarms_from_followers()
+end
+
+function Leader:receive_alarms_from_followers ()
+   for _,follower in ipairs(self.followers) do
+      self:receive_alarms_from_follower(follower)
+   end
+end
+
+function Leader:receive_alarms_from_follower (follower)
+   if not follower.alarms_channel then
+      local name = '/'..tostring(follower.pid)..'/alarms-follower-channel'
+      local success, channel = pcall(channel.open, name)
+      if not success then return end
+      follower.alarms_channel = channel
+   end
+   local channel = follower.alarms_channel
+   while true do
+      local buf, len = channel:peek_message()
+      if not buf then break end
+      local alarm = alarm_codec.decode(buf, len)
+      self:handle_alarm(follower, alarm)
+      channel:discard_message(len)
+   end
+end
+
+function Leader:handle_alarm (follower, alarm)
+   local fn, args = unpack(alarm)
+   if fn == 'raise_alarm' then
+      alarms.raise_alarm(unpack(args))
+   end
+   if fn == 'clear_alarm' then
+      alarms.clear_alarm(unpack(args))
+   end
 end
 
 function Leader:stop ()

--- a/src/apps/ipv4/arp.lua
+++ b/src/apps/ipv4/arp.lua
@@ -143,7 +143,6 @@ function ARP:new(conf)
       o.arp_request_pkt = make_arp_request(o.self_mac, o.self_ip, o.next_ip)
       self.arp_request_interval = 3 -- Send a new arp_request every three seconds.
    end
-   o.alarm_notification = conf.alarm_notification
    return setmetatable(o, {__index=ARP})
 end
 

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -780,6 +780,12 @@ function parse (arg, config)
    return ret
 end
 
+function set(...)
+   local ret = {}
+   for k, v in pairs({...}) do ret[v] = true end
+   return ret
+end
+
 function selftest ()
    print("selftest: lib")
    print("Testing equal")

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -97,12 +97,6 @@ local function make_equal_fn(key_type)
    end
 end
 
-local function set(...)
-   local ret = {}
-   for k, v in pairs({...}) do ret[v] = true end
-   return ret
-end
-
 local function parse_params(params, required, optional)
    local ret = {}
    for k, _ in pairs(required) do
@@ -123,7 +117,7 @@ end
 -- FIXME: For now the value_type option is required, but in the future
 -- we should allow for a nil value type to create a set instead of a
 -- map.
-local required_params = set('key_type', 'value_type')
+local required_params = lib.set('key_type', 'value_type')
 local optional_params = {
    hash_seed = false,
    initial_size = 8,

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -2,6 +2,11 @@ module(..., package.seeall)
 
 function raise_alarm (key, args)
    print('raise_alarm')
-   print('key: '..key)
-   print('args: '..args)
+   assert(type(key) == 'table')
+   assert(type(args) == 'table')
+end
+
+function clear_alarm (key)
+   print('clear alarm')
+   assert(type(key) == 'table')
 end

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -1,0 +1,7 @@
+module(..., package.seeall)
+
+function raise_alarm (key, args)
+   print('raise_alarm')
+   print('key: '..key)
+   print('args: '..args)
+end

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -10,6 +10,7 @@ local stream = require("lib.yang.stream")
 local data = require('lib.yang.data')
 local ctable = require('lib.ctable')
 local cltable = require('lib.cltable')
+local lib = require("core.lib")
 
 local MAGIC = "yangconf"
 local VERSION = 0x00005000
@@ -233,11 +234,7 @@ local function data_emitter(production)
          end
       end
    end
-   local native_types = {
-      enumeration = true,
-      identityref = true,
-      string = true,
-   }
+   local native_types = lib.set('enumeration', 'identityref', 'string')
    function handlers.scalar(production)
       local primitive_type = production.argument_type.primitive_type
       local type = assert(value.types[primitive_type], "unsupported type: "..primitive_type)

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -244,6 +244,11 @@ local function data_emitter(production)
             stream:write_stringref('stringref')
             stream:write_stringref(data)
          end
+      elseif primitive_type == 'empty' then
+         return function (data, stream)
+            stream:write_stringref('stringref')
+            stream:write_stringref('')
+         end
       elseif type.ctype then
          local ctype = type.ctype
          local emit_value = value_emitter(ctype)
@@ -508,6 +513,12 @@ function selftest()
             }
          }
       }
+
+      container foo {
+         leaf enable-qos {
+            type empty;
+         }
+      }
    }]])
    local data = data.load_config_for_schema(test_schema, [[
       is-active true;
@@ -524,6 +535,9 @@ function selftest()
       }
       next-hop {
          ipv4 5.6.7.8;
+      }
+      foo {
+         enable-qos;
       }
    ]])
 

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -246,8 +246,8 @@ local function data_emitter(production)
          end
       elseif primitive_type == 'empty' then
          return function (data, stream)
-            stream:write_stringref('stringref')
-            stream:write_stringref('')
+            stream:write_stringref('flag')
+            stream:write_uint32(data and 1 or 0)
          end
       elseif type.ctype then
          local ctype = type.ctype
@@ -426,6 +426,10 @@ local function read_compiled_data(stream, strtab)
    function readers.cdata()
       local ctype = scalar_type(read_string())
       return stream:read_ptr(ctype)[0]
+   end
+   function readers.flag()
+      if stream:read_uint32() ~= 0 then return true end
+      return nil
    end
    return read1()
 end

--- a/src/lib/yang/ietf-alarms.yang
+++ b/src/lib/yang/ietf-alarms.yang
@@ -372,6 +372,9 @@ module ietf-alarms {
                 3GPP Distinguished names for example.";
         }
 
+
+        /*
+         * XXX: Temporarily replace leafref datatype for string as leafref is not supported.
         list related-alarm {
             key "resource alarm-type-id alarm-type-qualifier";
 
@@ -409,6 +412,31 @@ module ietf-alarms {
                     "The alarm qualifier for the related alarm.";
             }
         }
+        */
+        list related-alarm {
+            key "resource alarm-type-id alarm-type-qualifier";
+
+            description
+                "References to related alarms.  Note that the related alarm
+                might have been removed from the alarm list.";
+
+            leaf resource {
+                type string;
+                description
+                    "The alarming resource for the related alarm.";
+            }
+            leaf alarm-type-id {
+                type string;
+                description
+                    "The alarm type identifier for the related alarm.";
+            }
+            leaf alarm-type-qualifier {
+                type string;
+                description
+                    "The alarm qualifier for the related alarm.";
+            }
+        }
+
         leaf-list impacted-resource {
             type resource;
             description
@@ -959,6 +987,8 @@ module ietf-alarms {
             alarms.  Conditions in the input are logically ANDed.  If no
             input condition is given, all alarms are compressed.";
         input {
+            /*
+             * XXX: Temporarily replace leafref datatype for string as leafref is not supported.
             leaf resource {
                 type leafref {
                     path "/alarms/alarm-list/alarm/resource";
@@ -978,6 +1008,22 @@ module ietf-alarms {
                 type leafref {
                     path "/alarms/alarm-list/alarm/alarm-type-qualifier";
                 }
+                description
+                    "Compress the alarms with this alarm-type-qualifier.";
+            }
+            */
+            leaf resource {
+                type string;
+                description
+                    "Compress the alarms with this resource.";
+            }
+            leaf alarm-type-id {
+                type string;
+                description
+                    "Compress alarms with this alarm-type-id.";
+            }
+            leaf alarm-type-qualifier {
+                type string;
                 description
                     "Compress the alarms with this alarm-type-qualifier.";
             }
@@ -1148,6 +1194,8 @@ module ietf-alarms {
             "This notification is used to report that an operator
             acted upon an alarm.";
 
+        /*
+         * XXX: Temporarily replace leafref datatype for string as leafref is not supported.
         leaf resource {
             type leafref {
                 path "/alarms/alarm-list/alarm/resource";
@@ -1174,6 +1222,22 @@ module ietf-alarms {
                     + "/alarm-type-qualifier";
                 require-instance false;
             }
+            description
+                "The alarm qualifier for the alarm.";
+        }
+        */
+        leaf resource {
+            type string;
+            description
+                "The alarming resource.";
+        }
+        leaf alarm-type-id {
+            type string;
+            description
+                "The alarm type identifier for the alarm.";
+        }
+        leaf alarm-type-qualifier {
+            type string;
             description
                 "The alarm qualifier for the alarm.";
         }

--- a/src/lib/yang/ietf-alarms.yang
+++ b/src/lib/yang/ietf-alarms.yang
@@ -152,11 +152,14 @@ module ietf-alarms {
 
     typedef resource {
         type union {
+            type string;
+            /*
+             * Comment use of instance-identifier as it's not currently supported.
             type instance-identifier {
                 require-instance false;
             }
+            */
             type yang:object-identifier;
-            type string;
         }
         description
             "This is an identification of the alarming resource, such as an

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -1,6 +1,7 @@
 -- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 module(..., package.seeall)
 
+local lib = require("core.lib")
 local parser = require("lib.yang.parser")
 local util = require("lib.yang.util")
 
@@ -583,13 +584,7 @@ local function schema_from_ast(ast)
    return ret
 end
 
-local function set(...)
-   local ret = {}
-   for k, v in pairs({...}) do ret[v] = true end
-   return ret
-end
-
-local primitive_types = set(
+local primitive_types = lib.set(
    'int8', 'int16', 'int32', 'int64', 'uint8', 'uint16', 'uint32', 'uint64',
    'binary', 'bits', 'boolean', 'decimal64', 'empty', 'enumeration',
    'identityref', 'instance-identifier', 'leafref', 'string', 'union')
@@ -899,9 +894,9 @@ function resolve(schema, features)
 end
 
 local primitive_types = {
-   ['ietf-inet-types']=set('ipv4-address', 'ipv6-address',
+   ['ietf-inet-types']=lib.set('ipv4-address', 'ipv6-address',
                            'ipv4-prefix', 'ipv6-prefix'),
-   ['ietf-yang-types']=set('mac-address')
+   ['ietf-yang-types']=lib.set('mac-address')
 }
 
 -- NB: mutates schema in place!

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -4,6 +4,7 @@ module snabb-softwire-v2 {
 
   import ietf-inet-types { prefix inet; }
   import ietf-yang-types { prefix yang; }
+  import ietf-alarms { prefix al; }
 
   organization "Igalia, S.L.";
   contact "Jessica Tallon <tsyesika@igalia.com>";
@@ -400,6 +401,289 @@ module snabb-softwire-v2 {
       leaf out-ipv6-packets {
         type yang:zero-based-counter64;
         description "All valid outgoing IPv6 packets.";
+      }
+
+      container alarms {
+        description
+          "Container for alarms status information. The container is composed of
+           four major subcontainers: alarm-inventory, alarm-list, summary and
+           shelved-alarms";
+
+        container alarm-inventory {
+          config false;
+          description
+            "This list contains all possible alarm types for the system.
+            If the system knows for wich resources a a specific alarm
+            type can appear, this is also identified in the inventory.
+            The list also tells if each alarm type has a corresponding
+            clear state.  The inventory shall only contain concrete
+            alarm types.
+
+            The alarm inventory MUST be updated by the system when new
+            alarms can appear.  This can be the case when installing new
+            software modules or inserting new card types.  A
+            notification 'alarm-inventory-changed' is sent when the
+            inventory is changed.";
+
+          list alarm-type {
+            key "alarm-type-id alarm-type-qualifier";
+            description
+              "An entry in this list defines a possible alarm.";
+            leaf alarm-type-id {
+              type al:alarm-type-id;
+              mandatory true;
+              description
+                "The statically defined alarm type identifier for this
+                possible alarm.";
+            }
+            leaf alarm-type-qualifier {
+              type al:alarm-type-qualifier;
+              description
+                "The optionally dynamically defined alarm type identifier
+                for this possible alarm.";
+            }
+            leaf-list resource {
+              type string;
+              description
+                "Optionally, specifies for which resources the alarm type
+                is valid.  This string is for human consumption but
+                SHOULD refer to paths in the model.";
+            }
+            leaf has-clear {
+              type boolean;
+              mandatory true;
+              description
+                "This leaf tells the operator if the alarm will be
+                cleared when the correct corrective action has been
+                taken.  Implementations SHOULD strive for detecting the
+                cleared state for all alarm types.  If this leaf is
+                true, the operator can monitor the alarm until it
+                becomes cleared after the corrective action has been
+                taken.  If this leaf is false the operator needs to
+                validate that the alarm is not longer active using other
+                mechanisms.  Alarms can lack a corresponding clear due
+                to missing instrumentation or that there is no logical
+                corresponding clear state.";
+            }
+            leaf description {
+              type string;
+              mandatory true;
+              description
+                "A description of the possible alarm.  It SHOULD include
+                information on possible underlying root causes and
+                corrective actions.";
+            }
+          }
+        }
+
+        container summary {
+          config false;
+          description
+            "This container gives a summary of number of alarms
+            and shelved alarms";
+          list alarm-summary {
+            key severity;
+            description
+              "A global summary of all alarms in the system.";
+            leaf severity {
+              type al:severity;
+              description
+                "Alarm summary for this severity level.";
+            }
+            leaf total {
+              type yang:gauge32;
+              description
+                "Total number of alarms of this severity level.";
+            }
+            leaf cleared {
+              type yang:gauge32;
+              description
+                "For this severity level, the number of alarms that are
+                cleared.";
+            }
+            leaf cleared-not-closed {
+              if-feature al:operator-actions;
+              type yang:gauge32;
+              description
+                "For this severity level, the number of alarms that are
+                cleared but not closed.";
+            }
+            leaf cleared-closed {
+              if-feature al:operator-actions;
+              type yang:gauge32;
+              description
+                "For this severity level, the number of alarms that are
+                cleared and closed.";
+            }
+            leaf not-cleared-closed {
+              if-feature al:operator-actions;
+              type yang:gauge32;
+              description
+                "For this severity level, the number of alarms that are
+                not cleared but closed.";
+            }
+            leaf not-cleared-not-closed {
+              if-feature al:operator-actions;
+              type yang:gauge32;
+              description
+                "For this severity level, the number of alarms that are
+                not cleared and not closed.";
+            }
+          }
+          leaf shelves-active {
+            if-feature al:alarm-shelving;
+            type empty;
+            description
+              "This is a hint to the operator that there are active
+              alarm shelves.  This leaf MUST exist if the
+              alarms/shelved-alarms/number-of-shelved-alarms is > 0.";
+          }
+        }
+
+        container alarm-list {
+          config false;
+          description
+            "The alarms in the system.";
+          leaf number-of-alarms {
+            type yang:gauge32;
+            description
+              "This object shows the total number of
+              alarms in the system, i.e., the total number
+              of entries in the alarm list.";
+          }
+
+          leaf last-changed {
+            type yang:date-and-time;
+            description
+              "A timestamp when the alarm list was last
+              changed.  The value can be used by a manager to
+              initiate an alarm resynchronization procedure.";
+          }
+
+          list alarm {
+            key "resource alarm-type-id alarm-type-qualifier";
+
+            description
+              "The list of alarms.  Each entry in the list holds one
+              alarm for a given alarm type and resource.
+              An alarm can be updated from the underlying resource or
+              by the user.  The following leafs are maintained by the
+              resource:  is-cleared, last-change, perceived-severity,
+              and alarm-text.  An operator can change: operator-state
+                and operator-text.
+
+                Entries appear in the alarm list the first time an
+                alarm becomes active for a given alarm-type and resource.
+                Entries do not get deleted when the alarm is cleared, this
+                is a boolean state in the alarm.
+
+                Alarm entries are removed, purged, from the list by an
+                explicit purge action.  For example, delete all alarms
+                that are cleared and in closed operator-state that are
+                older than 24 hours.  Systems may also remove alarms based
+                on locally configured policies which is out of scope for
+                this module.";
+            leaf time-created {
+              type yang:date-and-time;
+              mandatory true;
+              description
+                "The time-stamp when this alarm entry was created. This
+                represents the first time the alarm appeared, it can
+                also represent that the alarm re-appeared after a purge.
+                Further state-changes of the same alarm does not change
+                this leaf, these changes will update the 'last-changed'
+                leaf.";
+            }
+
+            uses al:common-alarm-parameters;
+            uses al:resource-alarm-parameters;
+
+            list operator-state-change {
+              if-feature al:operator-actions;
+              key time;
+              description
+                "This list is used by operators to indicate
+                the state of human intervention on an alarm.
+                For example, if an operator has seen an alarm,
+                  the operator can add a new item to this list indicating
+                    that the alarm is acknowledged.";
+              uses al:operator-parameters;
+            }
+
+            action set-operator-state {
+              if-feature al:operator-actions;
+              description
+                "This is a means for the operator to indicate
+                the level of human intervention on an alarm.";
+              input {
+                leaf state {
+                  type operator-state;
+                  mandatory true;
+                  description
+                    "Set this operator state.";
+                }
+                leaf text {
+                  type string;
+                  description
+                    "Additional optional textual information.";
+                }
+              }
+            }
+          }
+        }
+
+        container shelved-alarms {
+          if-feature al:alarm-shelving;
+          config false;
+          description
+            "The shelved alarms.  Alarms appear here if they match the
+            criterias in /alarms/control/alarm-shelving.  This list does
+            not generate any notifications.  The list represents alarms
+            that are considered not relevant by the operator.  Alarms in
+            this list have an operator-state of 'shelved'.  This can not
+            be changed.";
+          leaf number-of-shelved-alarms {
+            type yang:gauge32;
+            description
+              "This object shows the total number of currently
+              alarms, i.e., the total number of entries
+              in the alarm list.";
+          }
+
+          leaf alarm-shelf-last-changed {
+            type yang:date-and-time;
+            description
+              "A timestamp when the shelved alarm list was last
+              changed.  The value can be used by a manager to
+              initiate an alarm resynchronization procedure.";
+          }
+
+          list shelved-alarm {
+            key "resource alarm-type-id alarm-type-qualifier";
+
+            description
+              "The list of shelved alarms.  Each entry in the list holds
+              one alarm for a given alarm type and resource.  An alarm
+              can be updated from the underlying resource or by the
+              user.  These changes are reflected in different lists
+              below the corresponding alarm.";
+
+            uses al:common-alarm-parameters;
+            uses al:resource-alarm-parameters;
+
+            list operator-state-change {
+              if-feature al:operator-actions;
+              key time;
+              description
+                "This list is used by operators to indicate
+                the state of human intervention on an alarm.
+                For example, if an operator has seen an alarm,
+                  the operator can add a new item to this list indicating
+                    that the alarm is acknowledged.";
+              uses al:operator-parameters;
+            }
+          }
+        }
       }
     }
   }
@@ -840,6 +1124,97 @@ module snabb-softwire-v2 {
         leaf date {
           type yang:date-and-time;
           description "Timestamp of last change.";
+        }
+      }
+    }
+
+    container alarms {
+      description
+        "Container for alarms configuration information";
+
+      container control {
+        description
+          "Configuration to control the alarm behaviour.";
+
+        leaf max-alarm-status-changes {
+          type union {
+            type uint16;
+            type enumeration {
+              enum infinite {
+                description
+                  "The status change entries are accumulated
+                  infinitely.";
+              }
+            }
+          }
+          default 32;
+          description
+            "The status-change entries are kept in a circular list
+            per alarm.  When this number is exceeded, the oldest
+            status change entry is automatically removed.  If the
+            value is 'infinite', the status change entries are
+            accumulated infinitely.";
+        }
+
+        leaf notify-status-changes {
+          type boolean;
+          default false;
+          description
+            "This leaf controls whether notifications are sent on all
+            alarm status updates, e.g., updated perceived-severity or
+            alarm-text.  By default the notifications are only sent
+            when a new alarm is raised, re-raised after being cleared
+            and when an alarm is cleared.";
+        }
+        container alarm-shelving {
+          if-feature al:alarm-shelving;
+          description
+            "This list is used to shelve alarms.  The server will move
+            any alarms corresponding to the shelving criteria from the
+            alarms/alarm-list/alarm list to the
+            alarms/shelved-alarms/shelved-alarm list.  It will also
+            stop sending notifications for the shelved alarms.  The
+            conditions in the shelf criteria are logically ANDed.
+            When the shelving criteria is deleted or changed, the
+            non-matching alarms MUST appear in the
+            alarms/alarm-list/alarm list according to the real state.
+            This means that the instrumentation MUST maintain states
+            for the shelved alarms.  Alarms that match the criteria
+              shall have an operator-state 'shelved'.";
+          list shelf {
+            key shelf-name;
+            leaf shelf-name {
+              type string;
+              description
+                "An arbitrary name for the alarm shelf.";
+            }
+            description
+              "Each entry defines the criteria for shelving alarms.
+              Criterias are ANDed.";
+
+            leaf resource {
+              type al:resource;
+              description
+                "Shelve alarms for this resource.";
+            }
+            leaf alarm-type-id {
+              type al:alarm-type-id;
+              description
+                "Shelve alarms for this alarm type identifier.";
+            }
+            leaf alarm-type-qualifier {
+              type al:alarm-type-qualifier;
+              description
+                "Shelve alarms for this alarm type qualifier.";
+            }
+            leaf description {
+              type string;
+              description
+                "An optional textual description of the shelf.  This
+                description should include the reason for shelving
+                these alarms.";
+            }
+          }
         }
       }
     }

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -175,6 +175,7 @@ function run(args)
       setup_fn, setup_args = setup.load_phy, { 'inetNic', 'b4sideNic' }
    end
 
+   conf.alarm_notification = true
    setup.reconfigurable(scheduling, setup_fn, c, conf, unpack(setup_args))
    engine.configure(c)
 

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -131,7 +131,8 @@ function lwaftr_app(c, conf, device)
               { self_ip = convert_ipv4(iexternal_interface.ip),
                 self_mac = iexternal_interface.mac,
                 next_mac = iexternal_interface.next_hop.mac,
-                next_ip = convert_ipv4(iexternal_interface.next_hop.ip) })
+                next_ip = convert_ipv4(iexternal_interface.next_hop.ip),
+                alarm_notification = conf.alarm_notification })
 
    local preprocessing_apps_v4  = { "reassemblerv4" }
    local preprocessing_apps_v6  = { "reassemblerv6" }

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -31,6 +31,8 @@ local engine     = require("core.app")
 local lib        = require("core.lib")
 
 
+local alarm_notification = false
+
 local capabilities = {['ietf-softwire']={feature={'binding', 'br'}}}
 require('lib.yang.schema').set_default_capabilities(capabilities)
 
@@ -605,6 +607,9 @@ end
 
 function reconfigurable(scheduling, f, graph, conf, ...)
    local args = {...}
+
+   -- Always enabled in reconfigurable mode.
+   alarm_notification = true
 
    local function setup_fn(conf)
       local graph = config.new()

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -33,7 +33,10 @@ local lib        = require("core.lib")
 
 local alarm_notification = false
 
-local capabilities = {['ietf-softwire']={feature={'binding', 'br'}}}
+local capabilities = {
+   ['ietf-softwire']={feature={'binding', 'br'}},
+   ['ietf-alarms']={feature={'operator-actions', 'alarm-shelving', 'alarm-history'}},
+}
 require('lib.yang.schema').set_default_capabilities(capabilities)
 
 local function convert_ipv4(addr)


### PR DESCRIPTION
This PR merges lwaftr-alarms branch into lwaftr.

So far this PR only contains the skeleton of alarms with a mock implementation of raise-alarm and clear-alarm. To test it, I start the lwAFTR with an external-interface with it's IP (instead of MAC). The ARP app should raise an alarm while is resolving the address.

```bash
$ sudo ./snabb lwaftr run --conf icmp_on_fail.conf --on-a-stick 83:00.1
icmp_on_fail.conf: loading compiled configuration from icmp_on_fail.o
icmp_on_fail.conf: compiled configuration is up to date.
Migrating instance 'test' to '83:00.1'
Warning: No NUMA memory affinity.
Pass --cpu to bind to a CPU and its NUMA node.
ARP: Resolving '8.8.8.8'
raise_alarm
ARP: Resolving '8.8.8.8'
raise_alarm
```