### PR TITLE
Declare alarms

### DIFF
--- a/src/apps/lwaftr/ndp.lua
+++ b/src/apps/lwaftr/ndp.lua
@@ -36,6 +36,16 @@ alarms.add_to_inventory {
       description='Raise up if NDP app cannot resolve IPv6 address'
    }
 }
+local resolve_alarm = alarms.declare_alarm {
+   [{resource='internal-interface', alarm_type_id='ndp-resolution', alarm_type_qualifier=''}] = {
+      perceived_severity = 'critical',
+      alarm_text =
+         'Make sure you can resolve internal-interface.next-hop.ip address '..
+         'manually.  If it cannot be resolved, consider setting the MAC '..
+         'address of the next-hop directly.  To do it so, set '..
+         'internal-interface.next-hop.mac to the value of the MAC address.',
+   },
+}
 
 local htons, ntohs = lib.htons, lib.ntohs
 local htonl, ntohl = lib.htonl, lib.ntohl
@@ -270,7 +280,9 @@ local ndp_config_params = {
    next_mac  = { default=false },
    -- But if the next-hop MAC isn't configured, NDP will figure it out.
    next_ip   = { default=false },
-   is_router = { default=true }
+   is_router = { default=true },
+   -- Emit alarms if set.
+   alarm_notification = { default=false },
 }
 
 function NDP:new(conf)
@@ -285,14 +297,28 @@ function NDP:new(conf)
    return setmetatable(o, {__index=NDP})
 end
 
+function NDP:ndp_resolving (ip)
+   print(("NDP: Resolving '%s'"):format(ipv6:ntop(ip)))
+   if self.alarm_notification then
+      resolve_alarm:raise()
+   end
+end
+
 function NDP:maybe_send_ns_request (output)
    if self.next_mac then return end
    self.next_ns_time = self.next_ns_time or engine.now()
    if self.next_ns_time <= engine.now() then
-      print(("NDP: Resolving '%s'"):format(ipv6:ntop(self.next_ip)))
+      self:ndp_resolving(self.next_ip)
       transmit(self.output.south,
                make_ns_packet(self.self_mac, self.self_ip, self.next_ip))
       self.next_ns_time = engine.now() + self.ns_interval
+   end
+end
+
+function NDP:ndp_resolved (ip, mac)
+   print(("NDP: '%s' resolved (%s)"):format(ipv6:ntop(ip), ethernet:ntop(mac)))
+   if self.alarm_notification then
+      resolve_alarm:clear()
    end
 end
 
@@ -302,8 +328,7 @@ function NDP:resolve_next_hop(next_mac)
    -- link layer address in the NDP options).  Just take the first
    -- one.
    if self.next_mac then return end
-   print(("NDP: '%s' resolved (%s)"):format(ipv6:ntop(self.next_ip),
-                                            ethernet:ntop(next_mac)))
+   self:ndp_resolved(self.next_ip, next_mac)
    self.next_mac = next_mac
 end
 

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -2,6 +2,7 @@ module(..., package.seeall)
 
 local data = require('lib.yang.data')
 local util = require('lib.yang.util')
+local alarm_codec = require('apps.config.alarm_codec')
 
 local state = {
    alarm_inventory = {
@@ -43,6 +44,63 @@ function add_to_inventory (alarm_types)
    end
 end
 
+-- Single point to access alarm keys.
+alarm_keys = {}
+
+function alarm_keys:fetch (...)
+   self.cache = self.cache or {}
+   local function lookup (resource, alarm_type_id, alarm_type_qualifier)
+      if not self.cache[resource] then
+         self.cache[resource] = {}
+      end
+      if not self.cache[resource][alarm_type_id] then
+         self.cache[resource][alarm_type_id] = {}
+      end
+      return self.cache[resource][alarm_type_id][alarm_type_qualifier]
+   end
+   local resource, alarm_type_id, alarm_type_qualifier = unpack({...})
+   assert(resource and alarm_type_id)
+   alarm_type_qualifier = alarm_type_qualifier or ''
+   local key = lookup(resource, alarm_type_id, alarm_type_qualifier)
+   if not key then
+      key = {resource=resource, alarm_type_id=alarm_type_id,
+             alarm_type_qualifier=alarm_type_qualifier}
+      self.cache[resource][alarm_type_id][alarm_type_qualifier] = key
+   end
+   return key
+end
+function alarm_keys:normalize (key)
+   local resource = assert(key.resource)
+   local alarm_type_id = assert(key.alarm_type_id)
+   local alarm_type_qualifier = key.alarm_type_qualifier or ''
+   return self:fetch(resource, alarm_type_id, alarm_type_qualifier)
+end
+
+local function table_size (t)
+   local size = 0
+   for _ in pairs(t) do size = size + 1 end
+   return size
+end
+
+-- Contains a table with all the declared alarms.
+local alarm_list = {}
+
+function declare_alarm (alarm)
+   assert(table_size(alarm) == 1)
+   local key
+   for k, v in pairs(alarm) do
+      key = alarm_keys:normalize(k)
+      alarm_list[key] = v
+   end
+   function alarm:raise (args)
+      alarm_codec.raise_alarm(key, args)
+   end
+   function alarm:clear ()
+      alarm_codec.clear_alarm(key)
+   end
+   return alarm
+end
+
 ---
 
 function raise_alarm (key, args)
@@ -60,11 +118,6 @@ end
 
 function selftest ()
    print("selftest: alarms")
-   local function table_size (t)
-      local size = 0
-      for _ in pairs(t) do size = size + 1 end
-      return size
-   end
 
    require("apps.ipv4.arp")
    assert(table_size(state.alarm_inventory.alarm_type) > 0)

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -137,7 +137,8 @@ function lwaftr_app(c, conf, device)
               { self_ip = iinternal_interface.ip,
                 self_mac = iinternal_interface.mac,
                 next_mac = iinternal_interface.next_hop.mac,
-                next_ip = iinternal_interface.next_hop.ip })
+                next_ip = iinternal_interface.next_hop.ip,
+                alarm_notification = conf.alarm_notification })
    config.app(c, "arp", arp.ARP,
               { self_ip = convert_ipv4(iexternal_interface.ip),
                 self_mac = iexternal_interface.mac,


### PR DESCRIPTION
This PR adds a `declare_alarm` method that enables app to create alarms. The alarms are stored in `lib.yang.alarms` module into the `alarm_list` local table. Existing alarms are not the same as a raised alarm, which are only created when an alarm is raised (NYI).