### PR TITLE
Implement alarm raise and clear

### DIFF
--- a/src/apps/config/alarm_codec.lua
+++ b/src/apps/config/alarm_codec.lua
@@ -133,9 +133,7 @@ local args_attrs = {'perceived_severity', 'alarm_text'}
 local function normalize (t, attrs)
    t = t or {}
    local ret = {}
-   for _, k in ipairs(attrs) do
-      table.insert(ret, t[k])
-   end
+   for i, k in ipairs(attrs) do ret[i] = t[k] end
    return ret
 end
 local function normalize_key (t)
@@ -217,6 +215,9 @@ function selftest ()
 
    test_raise_alarm()
    test_clear_alarm()
+
+   local a, b = unpack(normalize({b='foo'}, {'a', 'b'}))
+   assert(a == nil and b == 'foo')
 
    print('selftest: ok')
 end

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -115,17 +115,17 @@ function alarm_list:new (key, alarm)
    self.list[key] = alarm
 end
 function alarm_list:lookup (key)
-   return alarm_list.list[key]
-end
-function alarm_list:copy (src, args)
-   local ret = {}
-   for k,v in pairs(src) do ret[k] = args[k] or v end
-   return ret
+   return self.list[key]
 end
 function alarm_list:retrieve (key, args)
+   local function copy (src, args)
+      local ret = {}
+      for k,v in pairs(src) do ret[k] = args[k] or v end
+      return ret
+   end
    local alarm = self:lookup(key)
    if alarm then
-      return self:copy(alarm, args)
+      return copy(alarm, args)
    end
 end
 

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -244,8 +244,15 @@ end
 -- Clear alarm.
 
 function clear_alarm (key)
-   print('clear alarm')
-   assert(type(key) == 'table')
+   assert(key)
+   local args = {is_cleared = true}
+   key = alarm_keys:normalize(key)
+   local alarm = lookup_alarm(key)
+   if not alarm then
+      create_alarm(key, args)
+   else
+      update_alarm(alarm, args)
+   end
 end
 
 ---
@@ -314,6 +321,26 @@ function selftest ()
    raise_alarm(key, {alarm_text='new text'})
    assert(table_size(alarm.status_change) == number_of_status_change + 1)
    assert(alarm.alarm_text == 'new text')
+
+   -- Clear alarm. Should clear alarm and create a new status change in the alarm.
+   local alarm = state.alarm_list.alarm[key]
+   local number_of_status_change = table_size(alarm.status_change)
+   assert(not alarm.is_cleared)
+   sleep(1)
+   clear_alarm(key)
+   assert(alarm.is_cleared)
+   assert(table_size(alarm.status_change) == number_of_status_change + 1)
+
+   -- Clear alarm again. Nothing should change.
+   local alarm = state.alarm_list.alarm[key]
+   local last_changed = alarm.last_changed
+   local number_of_status_change = table_size(alarm.status_change)
+   assert(alarm.is_cleared)
+   clear_alarm(key)
+   assert(alarm.is_cleared)
+   assert(table_size(alarm.status_change) == number_of_status_change,
+          table_size(alarm.status_change).." == "..number_of_status_change)
+   assert(alarm.last_changed == last_changed)
 
    print("ok")
 end

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -1,18 +1,43 @@
 module(..., package.seeall)
 
 local data = require('lib.yang.data')
+local lib = require('core.lib')
 local util = require('lib.yang.util')
 local alarm_codec = require('apps.config.alarm_codec')
+
+local iso_8601 = util.iso_8601
 
 local state = {
    alarm_inventory = {
       alarm_type = {},
    },
+   alarm_list = {
+      alarm = {},
+      number_of_alarms = 0,
+   },
 }
 
 function get_state ()
+   -- status-change is stored as an array while according to ietf-alarms schema
+   -- it should be a hashmap indexed by time.
+   local function transform_status_change (status_change)
+      local ret = {}
+      for _, v in pairs(status_change) do ret[v.time] = v end
+      return ret
+   end
+   local function transform_alarm_list (alarm_list)
+      local alarm = alarm_list.alarm
+      local ret = {}
+      for k,v in pairs(alarm) do
+         ret[k] = lib.deepcopy(v)
+         ret[k].status_change = transform_status_change(ret[k].status_change)
+      end
+      alarm_list.alarm = ret
+      return alarm_list
+   end
    return {
       alarm_inventory = state.alarm_inventory,
+      alarm_list = transform_alarm_list(state.alarm_list),
    }
 end
 
@@ -84,6 +109,20 @@ end
 
 -- Contains a table with all the declared alarms.
 local alarm_list = {}
+function alarm_list:lookup (key)
+   return alarm_list[key]
+end
+function alarm_list:copy (src, args)
+   local ret = {}
+   for k,v in pairs(src) do ret[k] = args[k] or v end
+   return ret
+end
+function alarm_list:retrieve (key, args)
+   local alarm = self:lookup(key)
+   if alarm then
+      return self:copy(alarm, args)
+   end
+end
 
 function declare_alarm (alarm)
    assert(table_size(alarm) == 1)
@@ -101,13 +140,108 @@ function declare_alarm (alarm)
    return alarm
 end
 
----
+-- Raise alarm.
+
+-- The entry with latest time-stamp in this list MUST correspond to the leafs
+-- 'is-cleared', 'perceived-severity' and 'alarm-text' for the alarm.
+-- The time-stamp for that entry MUST be equal to the 'last-changed' leaf.
+local function add_status_change (alarm, status)
+   alarm.status_change = alarm.status_change or {}
+   alarm.perceived_severity = status.perceived_severity
+   alarm.alarm_text = status.alarm_text
+   alarm.last_changed = status.time
+   state.alarm_list.last_changed = status.time
+   table.insert(alarm.status_change, status)
+end
+
+-- Creates a new alarm.
+--
+-- The alarm is retrieved from the db of predefined alarms. Default values got
+-- overridden by args. Additional fields are initialized too and an initial
+-- status change is added to the alarm.
+local function new_alarm (key, args)
+   local ret = assert(alarm_list:retrieve(key, args), 'Not supported alarm')
+   local status = {
+      time = iso_8601(),
+      perceived_severity = args.perceived_severity or ret.perceived_severity,
+      alarm_text = args.alarm_text or ret.alarm_text,
+   }
+   add_status_change(ret, status)
+   ret.last_changed = assert(status.time)
+   ret.time_created = assert(ret.last_changed)
+   ret.is_cleared = args.is_cleared
+   ret.operator_state_change = {}
+   state.alarm_list.number_of_alarms = state.alarm_list.number_of_alarms + 1
+   return ret
+end
+
+-- Adds alarm to state.alarm_list.
+local function create_alarm (key, args)
+   local alarm = assert(new_alarm(key, args))
+   state.alarm_list.alarm[key] = alarm
+end
+
+-- The following state changes creates a new status change:
+--   - changed severity (warning, minor, major, critical).
+--   - clearance status, this also updates the 'is-cleared' leaf.
+--   - alarm text update.
+local function needs_status_change (alarm, args)
+   if alarm.is_cleared ~= args.is_cleared then
+      return true
+   elseif args.perceived_severity and
+          alarm.perceived_severity ~= args.perceived_severity then
+      return true
+   elseif args.alarm_text and alarm.alarm_text ~= args.alarm_text then
+      return true
+   end
+   return false
+end
+
+-- An alarm gets updated if it needs a status change.  A status change implies
+-- to add a new status change to the alarm and update the alarm 'is_cleared'
+-- flag.
+local function update_alarm (alarm, args)
+   if needs_status_change(alarm, args) then
+      local status = {
+         time = assert(iso_8601()),
+         perceived_severity = assert(args.perceived_severity or alarm.perceived_severity),
+         alarm_text = assert(args.alarm_text or alarm.alarm_text),
+      }
+      add_status_change(alarm, status)
+      alarm.is_cleared = args.is_cleared
+   end
+end
+
+-- Check up if the alarm already exists in state.alarm_list.
+local function lookup_alarm (key)
+   return state.alarm_list.alarm[key]
+end
+
+-- Codec serializes nil values as empty strings. Convert them back to nil values.
+local function remove_empty_values (t)
+   assert(t)
+   for k, v in pairs(t) do
+      if type(v) == 'string' and v == '' then
+         t[k] = nil
+      end
+   end
+end
 
 function raise_alarm (key, args)
-   print('raise_alarm')
-   assert(type(key) == 'table')
-   assert(type(args) == 'table')
+   assert(key)
+   args = args or {}
+   args.is_cleared = false
+   remove_empty_values(args)
+   key = alarm_keys:normalize(key)
+   local alarm = lookup_alarm(key)
+   if not alarm then
+      create_alarm(key, args)
+   else
+      update_alarm(alarm, args)
+   end
 end
+
+-- Clear alarm.
 
 function clear_alarm (key)
    print('clear alarm')
@@ -118,9 +252,68 @@ end
 
 function selftest ()
    print("selftest: alarms")
+   local function sleep (seconds)
+      os.execute("sleep "..tonumber(seconds))
+   end
+   local function check_status_change (alarm)
+      local status_change = alarm.status_change
+      for k, v in pairs(status_change) do
+         assert(v.perceived_severity)
+         assert(v.time)
+         assert(v.alarm_text)
+      end
+   end
 
+   -- Check alarm inventory has been loaded.
    require("apps.ipv4.arp")
    assert(table_size(state.alarm_inventory.alarm_type) > 0)
+
+   -- Check number of alarms is zero.
+   assert(state.alarm_list.number_of_alarms == 0)
+
+   -- Raising an alarm when alarms is empty, creates an alarm.
+   local key = alarm_keys:fetch('external-interface', 'arp-resolution')
+   raise_alarm(key)
+   local alarm = assert(state.alarm_list.alarm[key])
+   assert(table_size(alarm.status_change) == 1)
+   assert(state.alarm_list.number_of_alarms == 1)
+
+   -- Raise same alarm again. Since there are not changes, everything remains the same.
+   local alarm = state.alarm_list.alarm[key]
+   local last_changed = alarm.last_changed
+   local number_of_status_change = table_size(alarm.status_change)
+   local number_of_alarms = state.alarm_list.number_of_alarms
+   sleep(1)
+   raise_alarm(key)
+   assert(state.alarm_list.alarm[key].last_changed == last_changed)
+   assert(table_size(alarm.status_change) == number_of_status_change)
+   assert(state.alarm_list.number_of_alarms == number_of_alarms)
+
+   -- Raise alarm again but changing severity.
+   local alarm = state.alarm_list.alarm[key]
+   local last_changed = alarm.last_changed
+   local number_of_status_change = table_size(alarm.status_change)
+   raise_alarm(key, {perceived_severity='minor'})
+   assert(alarm.perceived_severity == 'minor')
+   assert(last_changed ~= alarm.last_changed)
+   assert(table_size(alarm.status_change) == number_of_status_change + 1)
+   check_status_change(alarm)
+
+   -- Raise alarm again with same severity. Should not produce changes.
+   local alarm = state.alarm_list.alarm[key]
+   local last_changed = alarm.last_changed
+   local number_of_status_change = table_size(alarm.status_change)
+   raise_alarm(key, {perceived_severity='minor'})
+   assert(alarm.perceived_severity == 'minor')
+   assert(last_changed == alarm.last_changed)
+   assert(table_size(alarm.status_change) == number_of_status_change)
+
+   -- Raise alarm again but changing alarm_text. A new status change is added.
+   local alarm = state.alarm_list.alarm[key]
+   local number_of_status_change = table_size(alarm.status_change)
+   raise_alarm(key, {alarm_text='new text'})
+   assert(table_size(alarm.status_change) == number_of_status_change + 1)
+   assert(alarm.alarm_text == 'new text')
 
    print("ok")
 end

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -222,21 +222,10 @@ local function lookup_alarm (key)
    return state.alarm_list.alarm[key]
 end
 
--- Codec serializes nil values as empty strings. Convert them back to nil values.
-local function remove_empty_values (t)
-   assert(t)
-   for k, v in pairs(t) do
-      if type(v) == 'string' and v == '' then
-         t[k] = nil
-      end
-   end
-end
-
 function raise_alarm (key, args)
    assert(key)
    args = args or {}
    args.is_cleared = false
-   remove_empty_values(args)
    key = alarm_keys:normalize(key)
    local alarm = lookup_alarm(key)
    if not alarm then

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -138,7 +138,7 @@ local function gmtime ()
    return now + timediff
 end
 
-function iso_8601 (time)
+function format_date_as_iso_8601 (time)
    time = time or gmtime()
    return os.date("%Y-%m-%dT%H:%M:%SZ", time)
 end

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -129,6 +129,20 @@ function memoize(f, max_occupancy)
    end
 end
 
+local function gmtime ()
+   local now = os.time()
+   local utcdate = os.date("!*t", now)
+   local localdate = os.date("*t", now)
+   localdate.isdst = false
+   local timediff = os.difftime(os.time(utcdate), os.time(localdate))
+   return now + timediff
+end
+
+function iso_8601 (time)
+   time = time or gmtime()
+   return os.date("%Y-%m-%dT%H:%M:%SZ", time)
+end
+
 function selftest()
    print('selftest: lib.yang.util')
    assert(tointeger('0') == 0)


### PR DESCRIPTION
This PR implements the alarm raise and clear logic.

An alarm is raised on calling `alarm:raise()` in `lib.yang.alarms`. An alarm keeps a track of status changes. There are 3 conditions on which a new status change is created for an alarm:
- `is_cleared` changes.
- `severity_priority` changes.
- `alarm_text` changes.

The field `is_cleared` marks whether an alarm was cleared by the system or not. When an alarm is raised, `is_cleared` is false, while on running `alarm:clear` this field is set to true.

The alarm:raise method admits a list or arguments that can set the fields of an alarm. For instance, an alarm is raise with priority 'minor'.

```lua
alarm:raise({perceived_severity='minor'})
```

After several attempts, the priority of the alarm increases to critical:

```lua
alarm:raise({perceived_severity='critical'})
```

The change is priority will cause a new status change in the alarm.