### PR TITLE
Fix followers iteration

### DIFF
--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -744,7 +744,7 @@ function Leader:pull ()
 end
 
 function Leader:receive_alarms_from_followers ()
-   for _,follower in ipairs(self.followers) do
+   for _,follower in pairs(self.followers) do
       self:receive_alarms_from_follower(follower)
    end
 end


### PR DESCRIPTION
Since https://github.com/Igalia/snabb/pull/911, leader's followers are stored in a sparse table, thus have to be iterated with `pairs`.