### PR TITLE
Fix performance

### DIFF
--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -374,8 +374,8 @@ if ffi.abi("be") then
    function htons(b) return b end
 else
   -- htonl is unsigned, matching the C version and expectations.
-   function htonl(b) return tonumber(cast('uint32_t', bswap(b))) end
-   function htons(b) return rshift(bswap(b), 16) end
+   function htonl(b) return (tonumber(cast('uint32_t', bswap(b)))) end
+   function htons(b) return (rshift(bswap(b), 16)) end
 end
 ntohl = htonl
 ntohs = htons

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -374,6 +374,11 @@ if ffi.abi("be") then
    function htons(b) return b end
 else
   -- htonl is unsigned, matching the C version and expectations.
+  -- Wrapping the return call in parenthesis avoids the compiler to do
+  -- a tail call optimization.  In LuaJIT when the number of successive
+  -- tail calls is higher than the loop unroll threshold, the
+  -- compilation of a trace is aborted.  If the trace was long that
+  -- can result in poor performance.
    function htonl(b) return (tonumber(cast('uint32_t', bswap(b)))) end
    function htons(b) return (rshift(bswap(b), 16)) end
 end


### PR DESCRIPTION
The PR makes all code to get compiled in lwaftr branch (no interpreted code). This fixes the performance regression in `bench`, however using lwaftr/loadtest the performance is still bad (See next comment).

Current lwaftr branch performance:

```
$ sudo ./snabb lwaftr bench --cpu 9 test.conf from-inet-test.pcap from-b4-test.pcap
Time (s),Decap. MPPS,Decap. Gbps,Encap. MPPS,Encap. Gbps
0.996602,0.000000,0.000000,0.000000,0.000000
1.996596,0.010200,0.046023,0.010200,0.049287
2.996684,0.081593,0.368147,0.081593,0.394256
3.996637,0.091804,0.414221,0.091804,0.443599
4.996685,0.091796,0.414181,0.091796,0.443556
```

PR performance:

```
$ sudo ./snabb lwaftr bench --cpu 9 test.conf from-inet-test.pcap from-b4-test.pcap
Time (s),Decap. MPPS,Decap. Gbps,Encap. MPPS,Encap. Gbps
0.996210,0.010239,0.046197,0.010239,0.049474
1.996272,0.407975,1.840782,0.407975,1.971334
2.996341,1.580891,7.132981,1.580891,7.638867
3.996296,1.570870,7.087768,1.570870,7.590446
4.996295,1.570802,7.087461,1.570802,7.590118
```

The PR wraps the return value of `htonl` and `htons` in parenthesis to break a possible tail call (optimization reported by Alexg). The PR also refactors `binding_table:load`, which was reported by the profiler as interpreted:

```
52%  C code
  -- 43%  pcap.lua:iterator
  -- 13%  ipv4.lua:ipv4_ntop
  -- 12%  binding_table.lua:pack_psid_map_entry
  --  8%  binding_table.lua:load
  --  7%  util.lua:ipv4_ntop
  --  5%  ctable.lua:lookup_ptr
  --  4%  lib.lua:htonl
27%  Interpreted
  -- 33%  binding_table.lua:load
  -- 31%  binding_table.lua:pack_psid_map_entry
  --  5%  ctable.lua:lookup_ptr
  --  4%  lib.lua:bitfield
  --  4%  counter.lua:add
  --  4%  util.lua:ipv4_ntop
14%  Garbage Collector
  -- 48%  binding_table.lua:pack_psid_map_entry
  -- 16%  binding_table.lua:load
  --  7%  ctable.lua:lookup_ptr
  --  7%  lib.lua:htonl
  --  4%  ipv4.lua:ipv4_ntop
  --  3%  ctable.lua:stream
  --  3%  pcap.lua:iterator
```

The code that builds the `psid_map` does two memory allocations per softwire present in the binding table. The PR refactors the code to use Lua native types that get reused in every iteration. It also replaces the intermediary psid map with a Lua table.