### PR TITLE
Adapt requires_splitter to new configuration format

### DIFF
--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -137,8 +137,9 @@ end
 -- are the same for the internal and external interfaces.
 local function requires_splitter (opts, conf)
    if opts["on-a-stick"] then
-      local internal_interface = conf.softwire_config.internal_interface
-      local external_interface = conf.softwire_config.external_interface
+      local _, instance = next(conf.softwire_config.instance)
+      local internal_interface = instance.queue.values[1].internal_interface
+      local external_interface = instance.queue.values[1].external_interface
       return internal_interface.vlan_tag == external_interface.vlan_tag
    end
    return false

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -267,6 +267,7 @@ function load_on_a_stick(c, conf, args)
       args.v6_nic_name, args.v4v6, args.mirror
 
    if v4v6 then
+      assert(queue.external_interface.vlan_tag == queue.internal_interface.vlan_tag)
       config.app(c, 'nic', Intel82599, {
          pciaddr = pciaddr,
          vmdq=queue.external_interface.vlan_tag,


### PR DESCRIPTION
This fixes ping6 to an internal interface when using --on-a-stick flag.

When using --on-a-stick flag, only one physical NIC is used if both the internal and external interfaces use the same VLAN tag (or neither of them use it). Working with only one NIC requires using the V4V6 to split IPv4/IPv6 traffic. The method `requires_splitter` determines whether an V4V6 app should be instantiated and added to the app graph.

Since the method was using the old configuration format, `requires_splitter` always returned `true` (nil == nil), thus only one NIC was instantiated using the external interface VLAN tag.