### PR TITLE
Snabb config multiprocess support

### DIFF
--- a/src/program/lwaftr/tests/data/empty.conf
+++ b/src/program/lwaftr/tests/data/empty.conf
@@ -1,0 +1,21 @@
+softwire-config {
+  binding-table {}
+  external-interface {
+    allow-incoming-icmp false;
+    error-rate-limiting {
+      packets 600000;
+    }
+    reassembly {
+      max-fragments-per-packet 40;
+    }
+  }
+  internal-interface {
+    allow-incoming-icmp false;
+    error-rate-limiting {
+      packets 600000;
+    }
+    reassembly {
+      max-fragments-per-packet 40;
+    }
+  }
+}

--- a/src/program/lwaftr/tests/data/icmp_on_fail_multiproc.conf
+++ b/src/program/lwaftr/tests/data/icmp_on_fail_multiproc.conf
@@ -1,0 +1,170 @@
+softwire-config {
+  binding-table {
+    softwire {
+      ipv4 178.79.150.3;
+      psid 4;
+      b4-ipv6 127:14:25:36:47:58:69:128;
+      br-address 1e:2:2:2:2:2:2:af;
+      port-set {
+        psid-length 6;
+      }
+    }
+    softwire {
+      ipv4 178.79.150.233;
+      psid 22788;
+      b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
+      port-set {
+        psid-length 16;
+      }
+    }
+    softwire {
+      ipv4 178.79.150.1;
+      psid 0;
+      b4-ipv6 127:10:20:30:40:50:60:128;
+      br-address 8:9:a:b:c:d:e:f;
+      port-set {
+        psid-length 0;
+      }
+    }
+    softwire {
+      ipv4 178.79.150.233;
+      psid 2700;
+      b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
+      port-set {
+        psid-length 16;
+      }
+    }
+    softwire {
+      ipv4 178.79.150.233;
+      psid 4660;
+      b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
+      port-set {
+        psid-length 16;
+      }
+    }
+    softwire {
+      ipv4 178.79.150.233;
+      psid 54192;
+      b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
+      port-set {
+        psid-length 16;
+      }
+    }
+    softwire {
+      ipv4 178.79.150.233;
+      psid 7850;
+      b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
+      port-set {
+        psid-length 16;
+      }
+    }
+    softwire {
+      ipv4 178.79.150.15;
+      psid 1;
+      b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
+      port-set {
+        psid-length 4;
+      }
+    }
+    softwire {
+      ipv4 178.79.150.233;
+      psid 2300;
+      b4-ipv6 127:11:12:13:14:15:16:128;
+      br-address 8:9:a:b:c:d:e:f;
+      port-set {
+        psid-length 16;
+      }
+    }
+    softwire {
+      ipv4 178.79.150.15;
+      psid 0;
+      b4-ipv6 127:22:33:44:55:66:77:128;
+      br-address 8:9:a:b:c:d:e:f;
+      port-set {
+        psid-length 4;
+      }
+    }
+    softwire {
+      ipv4 178.79.150.233;
+      psid 80;
+      b4-ipv6 127:2:3:4:5:6:7:128;
+      br-address 8:9:a:b:c:d:e:f;
+      port-set {
+        psid-length 16;
+      }
+    }
+    softwire {
+      ipv4 178.79.150.2;
+      psid 7850;
+      b4-ipv6 127:24:35:46:57:68:79:128;
+      br-address 1e:1:1:1:1:1:1:af;
+      port-set {
+        psid-length 16;
+      }
+    }
+  }
+  external-interface {
+    allow-incoming-icmp false;
+    error-rate-limiting {
+      packets 600000;
+    }
+    reassembly {
+      max-fragments-per-packet 40;
+    }
+  }
+  instance {
+    device test;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
+    }
+  }
+  instance {
+    device test1;
+    queue {
+      id 1;
+      external-interface {
+        ip 10.10.10.10;
+        mac 12:12:12:12:12:12;
+        next-hop {
+          mac 68:68:68:68:68:68;
+        }
+      }
+      internal-interface {
+        ip 8:9:a:b:c:d:e:f;
+        mac 22:22:22:22:22:22;
+        next-hop {
+          mac 44:44:44:44:44:44;
+        }
+      }
+    }
+  }
+  internal-interface {
+    allow-incoming-icmp false;
+    error-rate-limiting {
+      packets 600000;
+    }
+    reassembly {
+      max-fragments-per-packet 40;
+    }
+  }
+}

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -12,9 +12,7 @@ import time
 import unittest
 
 from test_env import BENCHDATA_DIR, DATA_DIR, ENC, SNABB_CMD, \
-                     DAEMON_STARTUP_WAIT, BaseTestCase, nic_names, \
-                     DaemonException
-
+                     DAEMON_STARTUP_WAIT, BaseTestCase, nic_names
 
 DAEMON_PROC_NAME = 'config-test-daemon'
 DAEMON_ARGS = [
@@ -113,7 +111,15 @@ class TestConfigMultiproc(BaseTestCase):
         time.sleep(DAEMON_STARTUP_WAIT)
         return_code = self.daemon.poll()
         if return_code is not None:
-            raise DaemonException("Error starting daemon: " + str(return_code))
+            stdout = self.daemon.stdout.read().decode(ENC)
+            stderr = self.daemon.stderr.read().decode(ENC)
+            self.fail("\n".join((
+                "Failed starting daemon",
+                "Command:", " ".join(daemon_args),
+                "Exit code: {0}".format(return_code),
+                "STDOUT", stdout,
+                "STDOUT", stderr,
+            )))
         return self.daemon.pid
 
     @property

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -11,8 +11,9 @@ from subprocess import PIPE, Popen
 import time
 import unittest
 
-from test_env import BENCHDATA_DIR, DATA_DIR, ENC, SNABB_CMD, BaseTestCase, \
-                     nic_names
+from test_env import BENCHDATA_DIR, DATA_DIR, ENC, SNABB_CMD, \
+                     DAEMON_STARTUP_WAIT, BaseTestCase, nic_names, \
+                     DaemonException
 
 
 DAEMON_PROC_NAME = 'config-test-daemon'
@@ -77,6 +78,142 @@ class TestConfigGet(BaseTestCase):
         self.assertEqual(
             output.strip(), b'178.79.150.15',
             '\n'.join(('OUTPUT', str(output, ENC))))
+
+
+class TestConfigMultiproc(BaseTestCase):
+    """
+    Test the ability to start, stop, get, etc. multiple processes.
+    """
+
+    daemon = None
+    daemon_args = DAEMON_ARGS
+    ps_args = (str(SNABB_CMD), 'ps')
+    config_args = (str(SNABB_CMD), 'config', 'XXX', DAEMON_PROC_NAME)
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def start_daemon(self, config, additional=None):
+        """ Starts the daemon with a specific config """
+        if self.daemon is not None:
+            raise Exception("Daemon already started")
+
+        daemon_args = list(self.daemon_args)
+        daemon_args[7] = config
+        for option in (additional or []):
+            daemon_args.insert(3, option)
+
+        # Start the daemon itself
+        self.daemon = Popen(daemon_args, stdout=PIPE, stderr=PIPE)
+        time.sleep(DAEMON_STARTUP_WAIT)
+        return_code = self.daemon.poll()
+        if return_code is not None:
+            raise DaemonException("Error starting daemon: " + str(return_code))
+        return self.daemon.pid
+
+    @property
+    def instances(self):
+        """ Gets list of all the instance PIDs for lwaftr """
+        mypid = self.daemon.pid
+        output = self.run_cmd(self.ps_args).decode("utf-8")
+        my_lines = [inst for inst in output.split("\n") if str(mypid) in inst]
+
+        # The list won't be clean and have lots of text, extract the PIDs
+        instances = {}
+        for inst in my_lines:
+            # parts example: ['\\-', '20422', 'worker', 'for', '20420']
+            parts = inst.split()
+            if parts[0] == "\\-":
+                instances[int(parts[-1])].add(int(parts[1]))
+            else:
+                instances[int(parts[0])] = set()
+
+        return instances
+
+
+    def tearDown(self):
+        self.stop_daemon(self.daemon)
+        self.daemon = None
+        return super().tearDown()
+
+    def test_start_empty(self):
+        """ Lwaftr can be started with no instances """
+        config = str(DATA_DIR / "empty.conf")
+        pid = self.start_daemon(config)
+        self.assertEqual(len(self.instances[pid]), 0)
+
+
+    def test_snabb_config(self):
+        """ New instance can be started by snabb config """
+        config = str(DATA_DIR / "icmp_on_fail.conf")
+        pid = self.start_daemon(config)
+        initial_instance_amount = len(self.instances[pid])
+
+        # add an instance
+        device = """{
+        device addtest1;
+        queue {
+          id 1;
+          external-interface {
+            ip 72.72.72.72;
+            mac 14:14:14:14:14:14;
+            next-hop {
+              mac 15:15:15:15:15:15;
+            }
+          }
+          internal-interface {
+            ip 7:8:9:A:B:C:D:E;
+            mac 16:16:16:16:16:16;
+            next-hop {
+              mac 17:17:17:17:17:17;
+            }
+          }
+        }}"""
+        config_add_cmd = list(self.config_args)
+        config_add_cmd[2] = 'add'
+        config_add_cmd.extend((
+            '/softwire-config/instance',
+            device
+        ))
+
+        # Add the instance
+        self.run_cmd(config_add_cmd)
+
+        # Wait around for it to start the instance
+        time.sleep(1)
+
+        # Verify we've got one more instance
+        self.assertEqual(
+            len(self.instances[pid]), (initial_instance_amount + 1)
+        )
+
+    def test_snabb_config(self):
+        """ Removed instances are stopped by snabb config """
+        config = str(DATA_DIR / "icmp_on_fail.conf")
+        pid = self.start_daemon(config)
+        initial_instance_amount = len(self.instances[pid])
+
+        # There should be an instance called "test" in the initial
+        # config that's loaded. We'll try removing that.
+        config_remove_cmd = list(self.config_args)
+        config_remove_cmd[2] = 'remove'
+        config_remove_cmd.append('/softwire-config/instance[device=test]')
+
+        # Remove it
+        self.run_cmd(config_remove_cmd)
+
+        # Wait for the isntance to shutdown
+        time.sleep(1)
+
+        # Verify we've got one less instance than when we started.
+        self.assertEqual(
+            len(self.instances[pid]), (initial_instance_amount - 1)
+        )
 
 
 class TestConfigListen(BaseTestCase):

--- a/src/program/lwaftr/tests/test_env.py
+++ b/src/program/lwaftr/tests/test_env.py
@@ -37,9 +37,6 @@ def nic_names():
 def jit_config_dir():
     return os.environ.get("JIT_CONFIG_DIR")
 
-class DaemonException(Exception):
-    pass
-
 class BaseTestCase(unittest.TestCase):
     """
     Base class for TestCases. It has a "run_cmd" method and daemon handling,
@@ -109,7 +106,7 @@ class BaseTestCase(unittest.TestCase):
             daemon.stdout.close()
             daemon.stderr.close()
         else:
-            raise DaemonException('Error terminating deamon: ' + str(ret_code))
+            raise Exception('Error terminating deamon: ' + str(ret_code))
 
     @classmethod
     def tearDownClass(cls):

--- a/src/program/lwaftr/tests/test_env.py
+++ b/src/program/lwaftr/tests/test_env.py
@@ -37,6 +37,9 @@ def nic_names():
 def jit_config_dir():
     return os.environ.get("JIT_CONFIG_DIR")
 
+class DaemonException(Exception):
+    pass
+
 class BaseTestCase(unittest.TestCase):
     """
     Base class for TestCases. It has a "run_cmd" method and daemon handling,
@@ -96,16 +99,20 @@ class BaseTestCase(unittest.TestCase):
             self.fail('\n'.join(msg_lines))
         return output
 
+    @staticmethod
+    def stop_daemon(daemon):
+        ret_code = daemon.poll()
+        if ret_code is None:
+            daemon.terminate()
+            ret_code = daemon.wait()
+        if ret_code in (0, -SIGTERM):
+            daemon.stdout.close()
+            daemon.stderr.close()
+        else:
+            raise DaemonException('Error terminating deamon: ' + str(ret_code))
+
     @classmethod
     def tearDownClass(cls):
         if not cls.daemon_args:
             return
-        ret_code = cls.daemon.poll()
-        if ret_code is None:
-            cls.daemon.terminate()
-            ret_code = cls.daemon.wait()
-        if ret_code in (0, -SIGTERM):
-            cls.daemon.stdout.close()
-            cls.daemon.stderr.close()
-        else:
-            cls.reportAndFail('Error terminating daemon:', ret_code)
+        cls.stop_daemon(cls.daemon)


### PR DESCRIPTION
The work done on this is to add support to the leader for snabb config commands. These being:

- [X] Start a follower and configure it on `snabb config add`
- [X] Stop a follower on `snabb config remove`
- [X] Translation layer (ietf-softwire)

Using `snabb-softwire-v2` you can add a instance and the leader will create and configure said instance, it can then be removed with `snabb config remove` and it will be shutdown. These instances also appear in the `ietf-softwire`, the schema itself uses numeric identifiers to show each instance, these are generated when they're used in a `get` and kept for the device so they can then be used in a remove command. Due to the limitations of the schema instances cannot be added via `ietf-softwire`, that must still be done with `snabb-softwire-v2`.

This is missing the `snabb get-state` which will come in a followup PR.