### PR TITLE
Migrate lwaftr to intel mp

### DIFF
--- a/src/apps/intel_mp/loadgen.lua
+++ b/src/apps/intel_mp/loadgen.lua
@@ -1,0 +1,96 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(...,package.seeall)
+
+local ffi = require("ffi")
+local C = ffi.C
+
+local lib = require("core.lib")
+local app = require("core.app")
+local link = require("core.link")
+local intel_mp = require("apps.intel_mp.intel_mp")
+local memory = require("core.memory")
+local register = require("lib.hardware.register")
+local receive, empty = link.receive, link.empty
+
+local can_transmit, transmit
+local num_descriptors = 1024
+
+LoadGen = {}
+
+function LoadGen:new (pciaddress)
+   local function new_driver(conf)
+      conf = lib.parse(conf, intel_mp.Intel82599.config)
+      return intel_mp.Intel82599:new(conf)
+   end
+   local o = {
+      pciaddress = pciaddress,
+      dev = new_driver({
+         pciaddr = pciaddress,
+         ring_buffer_size = num_descriptors,
+         wait_for_link = true,
+      })
+   }
+--   o.dev:open()
+--   o.dev:wait_linkup()
+   disable_tx_descriptor_writeback(o.dev)
+   zero_descriptors(o.dev)
+   return setmetatable(o, {__index = LoadGen})
+end
+
+function disable_tx_descriptor_writeback (dev)
+   -- Disable writeback of transmit descriptors.
+   -- That way our transmit descriptors stay fresh and reusable.
+   -- Tell hardware write them to this other memory instead.
+   local bytes = num_descriptors * ffi.sizeof(intel_mp.rxdesc_t)
+   local ptr, phy = memory.dma_alloc(bytes)
+   dev.r.TDWBAL(phy % 2^32)
+   dev.r.TDWBAH(phy / 2^32)
+end
+
+function zero_descriptors (dev)
+   -- Clear unused descriptors
+   local b = memory.dma_alloc(4096)
+   for i = 0, num_descriptors-1 do
+      -- Make each descriptors point to valid DMA memory but be 0 bytes long.
+      dev.txdesc[i].address = memory.virtual_to_physical(b)
+      dev.txdesc[i].flags = bit.lshift(1, 24) -- End of Packet flag
+   end
+end
+
+function LoadGen:push ()
+   local dev = self.dev
+   if self.input.input then
+      while not link.empty(self.input.input) and dev:can_transmit() do
+         do local p = receive(self.input.input)
+            dev:transmit(p)
+         end
+      end
+   end
+end
+
+function LoadGen:pull ()
+   -- Set TDT behind TDH to make all descriptors available for TX.
+   local dev = self.dev
+   local tdh = dev.r.TDH()
+   if dev.tdt == 0 then return end
+   C.full_memory_barrier()
+   if tdh == 0 then
+      dev.r.TDT(num_descriptors)
+   else
+      dev.r.TDT(tdh - 1)
+   end
+end
+
+function LoadGen:report ()
+   print(self.pciaddress,
+         "TXDGPC (TX packets)", lib.comma_value(tonumber(self.dev.r.TXDGPC())),
+         "GOTCL (TX bytes)", lib.comma_value(tonumber(self.dev.r.GOTCL())))
+   print(self.pciaddress,
+         "RXDGPC (RX packets)", lib.comma_value(tonumber(self.dev.r.RXDGPC())),
+         "GORCL (RX bytes)", lib.comma_value(tonumber(self.dev.r.GORCL())))
+   self.dev.r.TXDGPC:reset()
+   self.dev.r.GOTCL:reset()
+   self.dev.r.RXDGPC:reset()
+   self.dev.r.GORCL:reset()
+end

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -22,7 +22,7 @@ devices = {}
 --- * `device` id hex string e.g. `"0x10fb"` for 82599 chip.
 --- * `interface` name of Linux interface using this device e.g. `"eth0"`.
 --- * `status` string Linux operational status, or `nil` if not known.
---- * `driver` Lua module that supports this hardware e.g. `"intel10g"`.
+--- * `driver` Lua module that supports this hardware e.g. `"intel_mp"`.
 --- * `usable` device was suitable to use when scanned? `yes` or `no`
 
 --- Initialize (or re-initialize) the `devices` table.
@@ -70,12 +70,12 @@ model = {
 -- Supported cards indexed by vendor and device id.
 local cards = {
    ["0x8086"] =  {
-      ["0x10fb"] = {model = model["82599_SFP"], driver = 'apps.intel.intel_app'},
-      ["0x10d3"] = {model = model["82574L"],    driver = 'apps.intel.intel_app'},
-      ["0x105e"] = {model = model["82571"],     driver = 'apps.intel.intel_app'},
-      ["0x151c"] = {model = model["82599_T3"],  driver = 'apps.intel.intel_app'},
-      ["0x1528"] = {model = model["X540"],      driver = 'apps.intel.intel_app'},
-      ["0x154d"] = {model = model["X520"],      driver = 'apps.intel.intel_app'},
+      ["0x10fb"] = {model = model["82599_SFP"], driver = 'apps.intel_mp.intel_mp'},
+      ["0x10d3"] = {model = model["82574L"],    driver = 'apps.intel_mp.intel_mp'},
+      ["0x105e"] = {model = model["82571"],     driver = 'apps.intel_mp.intel_mp'},
+      ["0x151c"] = {model = model["82599_T3"],  driver = 'apps.intel_mp.intel_mp'},
+      ["0x1528"] = {model = model["X540"],      driver = 'apps.intel_mp.intel_mp'},
+      ["0x154d"] = {model = model["X520"],      driver = 'apps.intel_mp.intel_mp'},
       ["0x1521"] = {model = model["i350"],      driver = 'apps.intel_mp.intel_mp'},
       ["0x1533"] = {model = model["i210"],      driver = 'apps.intel_mp.intel_mp'},
       ["0x157b"] = {model = model["i210"],      driver = 'apps.intel_mp.intel_mp'},

--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -6,11 +6,11 @@ local engine    = require("core.app")
 local timer     = require("core.timer")
 local lib       = require("core.lib")
 local pci       = require("lib.hardware.pci")
-local LoadGen   = require("apps.intel.loadgen").LoadGen
-local Intel82599 = require("apps.intel.intel_app").Intel82599
+local LoadGen   = require("apps.intel_mp.loadgen").LoadGen
+local Intel82599 = require("apps.intel_mp.intel_mp").Intel82599
 
 local function is_device_suitable (pcidev, patterns)
-   if not pcidev.usable or pcidev.driver ~= 'apps.intel.intel_app' then
+   if not pcidev.usable or not pcidev.driver:match('intel') then
       return false
    end
    if #patterns == 0 then
@@ -34,11 +34,10 @@ function run_loadgen (c, patterns, opts)
          local name = "nic"..nics
          if use_loadgen then
             config.app(c, name, LoadGen, device.pciaddress)
-            config.link(c, "source."..tostring(nics).."->"..name..".input")
          else
             config.app(c, name, Intel82599, {pciaddr = device.pciaddress})
-            config.link(c, "source."..tostring(nics).."->"..name..".rx")
          end
+         config.link(c, "source."..tostring(nics).."->"..name..".input")
       end
    end
    assert(nics > 0, "<PCI> matches no suitable devices.")


### PR DESCRIPTION
This is a merge of https://github.com/snabbco/snabb/pull/1237 to `lwaftr`, basically switching over Snabb to default to `intel_mp`.