### PR TITLE
Shutdown the follower properly when removing

### DIFF
--- a/src/apps/config/action_codec.lua
+++ b/src/apps/config/action_codec.lua
@@ -12,7 +12,7 @@ local shm = require("core.shm")
 local action_names = { 'unlink_output', 'unlink_input', 'free_link',
                        'new_link', 'link_output', 'link_input', 'stop_app',
                        'start_app', 'reconfig_app',
-                       'call_app_method_with_blob', 'commit' }
+                       'call_app_method_with_blob', 'commit', 'shutdown' }
 local action_codes = {}
 for i, name in ipairs(action_names) do action_codes[name] = i end
 
@@ -71,6 +71,9 @@ function actions.call_app_method_with_blob (codec, appname, methodname, blob)
    return codec:finish(appname, methodname, blob)
 end
 function actions.commit (codec)
+   return codec:finish()
+end
+function actions.shutdown (codec)
    return codec:finish()
 end
 

--- a/src/apps/config/follower.lua
+++ b/src/apps/config/follower.lua
@@ -29,6 +29,14 @@ function Follower:new (conf)
    return ret
 end
 
+function Follower:shutdown()
+   -- This will shutdown everything.
+   engine.configure(app_graph.new())
+
+   -- Now we can exit.
+   S.exit(0)
+end
+
 function Follower:commit_pending_actions()
    local to_apply = {}
    local should_flush = false
@@ -42,6 +50,8 @@ function Follower:commit_pending_actions()
          local callee, method, blob = unpack(args)
          local obj = assert(app.app_table[callee])
          assert(obj[method])(obj, blob)
+      elseif name == "shutdown" then
+         self:shutdown()
       else
          if name == 'start_app' or name == 'reconfig_app' then
             should_flush = true

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -100,9 +100,27 @@ function Leader:start_worker(cpu)
    return worker.start("follower", table.concat(start_code, "\n"))
 end
 
-function Leader:stop_worker(worker)
-   if worker.cpu then self.cpuset:release(worker.cpu) end
-   S.kill(worker.pid, 15)
+function Leader:stop_worker(id)
+   -- Tell the worker to terminate
+   local stop_actions = {{'shutdown', {}}, {'commit', {}}}
+   self:enqueue_config_actions_for_follower(id, stop_actions)
+   self:send_messages_to_followers()
+end
+
+function Leader:remove_stale_followers()
+   local stale = {}
+   for id, follower in pairs(self.followers) do
+      if S.waitpid(follower.pid, S.c.W["NOHANG"]) ~= 0 then
+         stale[#stale + 1] = id
+      end
+   end
+   for _, id in ipairs(stale) do
+      if self.followers[id].cpu then
+	 self.cpuset:release(self.followers[id].cpu)
+      end
+      self.followers[id] = nil
+
+   end
 end
 
 function Leader:acquire_cpu_for_follower(id, app_graph)
@@ -518,7 +536,7 @@ function Leader:update_configuration (update_fn, verb, path, ...)
 
    for id, follower in pairs(self.followers) do
       if new_graphs[id] == nil then
-	 self:stop_worker(follower)
+         self:stop_worker(id)
       else
 	 local actions = self.support.compute_config_actions(
 	    follower.graph, new_graphs[id], to_restart, verb, path, ...)
@@ -834,6 +852,7 @@ end
 function Leader:pull ()
    if app.now() < self.next_time then return end
    self.next_time = app.now() + self.period
+   self:remove_stale_followers()
    self:handle_calls_from_peers()
    self:send_messages_to_followers()
    self:receive_alarms_from_followers()

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -66,6 +66,7 @@ function Leader:new (conf)
    ret.followers = {}
    ret.rpc_callee = rpc.prepare_callee('snabb-config-leader-v1')
    ret.rpc_handler = rpc.dispatch_handler(ret, 'rpc_')
+   ret.check_for_stale = false
 
    ret:set_initial_configuration(conf.initial_configuration)
 
@@ -105,6 +106,7 @@ function Leader:stop_worker(id)
    local stop_actions = {{'shutdown', {}}, {'commit', {}}}
    self:enqueue_config_actions_for_follower(id, stop_actions)
    self:send_messages_to_followers()
+   self.check_for_stale = true
 end
 
 function Leader:remove_stale_followers()
@@ -852,7 +854,7 @@ end
 function Leader:pull ()
    if app.now() < self.next_time then return end
    self.next_time = app.now() + self.period
-   self:remove_stale_followers()
+   if self.check_for_stale then self:remove_stale_followers() end
    self:handle_calls_from_peers()
    self:send_messages_to_followers()
    self:receive_alarms_from_followers()


### PR DESCRIPTION
This is the change requested on https://github.com/Igalia/snabb/pull/939#discussion_r140211068. The leader now sends a 'shutdown' action to the follower which reconfigures the follower to have no apps (stopping the current apps properly) and then exiting. The leader periodically looks for any stale follower (followers which have exited) and if they have, removing them from `self.followers`