### PR TITLE
Add snabb get-state multiprocess support

### DIFF
--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -682,11 +682,14 @@ function Leader:rpc_get_state (args)
       local printer = path_printer_for_schema_by_name(
          self.schema_name, args.path, false, args.format, args.print_default)
       local states = {}
+      local state_reader = self.support.compute_state_reader(self.schema_name)
       for _, follower in pairs(self.followers) do
-         table.insert(states, state.read_state(self.schema_name, follower.pid))
+         local follower_config = self.support.configuration_for_follower(
+            follower, self.current_configuration)
+         table.insert(states, state_reader(follower.pid, follower_config))
       end
-      -- FIXME: How to combine states?  Add counters?
-      local state = printer(states[1], yang.string_output_file())
+      local state = printer(self.support.process_states(states),
+                            yang.string_output_file())
       return { state = state }
    end
    local success, response = pcall(getter)

--- a/src/apps/config/support.lua
+++ b/src/apps/config/support.lua
@@ -190,6 +190,20 @@ local function add_restarts(actions, app_graph, to_restart)
    return actions
 end
 
+local function configuration_for_follower(follower, configuration)
+   return configuration
+end
+
+local function compute_state_reader(schema_name)
+   return function(pid)
+      local reader = state.state_reader_from_schema_by_name(schema_name)
+      return reader(state.counters_for_pid(pid))
+   end
+end
+
+local function process_states(states)
+   return states[1]
+end
 
 generic_schema_config_support = {
    compute_config_actions = function(
@@ -201,6 +215,9 @@ generic_schema_config_support = {
          in_place_dependencies, app_graph, schema_name, verb, path, arg)
       return compute_mutable_objects_embedded_in_app_initargs(app_graph)
    end,
+   compute_state_reader = compute_state_reader,
+   configuration_for_follower = configuration_for_follower,
+   process_states = process_states,
    compute_apps_to_restart_after_configuration_update =
       compute_apps_to_restart_after_configuration_update,
    translators = {}

--- a/src/apps/config/support/snabb-softwire-v2.lua
+++ b/src/apps/config/support/snabb-softwire-v2.lua
@@ -653,7 +653,7 @@ local function process_states(states)
 
       for name, value in pairs(instance.softwire_state) do
          unified.softwire_state[name] = total_counter(
-            unified.softwire_state, name, value)
+            name, unified.softwire_state, value)
       end
    end
 

--- a/src/lib/yang/state.lua
+++ b/src/lib/yang/state.lua
@@ -38,7 +38,11 @@ local function find_counters(pid)
    return apps
 end
 
-local function state_reader_from_grammar(production, maybe_keyword)
+function counters_for_pid(pid)
+   return flatten(find_counters(pid))
+end
+
+function state_reader_from_grammar(production, maybe_keyword)
    local visitor = {}
    local function visit(keyword, production)
       return assert(visitor[production.type])(keyword, production)
@@ -103,11 +107,6 @@ function state_reader_from_schema_by_name(schema_name)
    return state_reader_from_schema(schema)
 end
 state_reader_from_schema_by_name = util.memoize(state_reader_from_schema_by_name)
-
-function read_state(schema_name, pid)
-   local reader = state_reader_from_schema_by_name(schema_name)
-   return reader(flatten(find_counters(pid)))
-end
 
 function selftest ()
    print("selftest: lib.yang.state")

--- a/src/program/lwaftr/counters.lua
+++ b/src/program/lwaftr/counters.lua
@@ -18,7 +18,8 @@ function counter_names ()
 end
 
 function read_counters (pid)
-   local s = state.read_state('snabb-softwire-v2', pid or S.getpid())
+   local reader = state.state_reader_from_schema_by_name('snabb-softwire-v2')
+   local s = reader(state.counters_for_pid(pid or S.getpid()))
    local ret = {}
    for k, id in pairs(counter_names()) do
       ret[k] = s.softwire_state[id]


### PR DESCRIPTION
This updates snabb `get-state` to support multi-processes.

Previously we just had all the state counters under `/softwire-state/` however in the new configuration (`snabb-softwire-v2`), we have added state counters under each instance but left the global state counters intact as it were in `snabb-softwire-v1`. The global counters now act as a summed aggregate of all the instances.

This is achieved by adding a `process_states` function as part of the support which takes the states and provides one unified state structure. The generic case simply takes the first state data in the table (as before) but specific support functions can be written. The lwaftr's combines all the state data so we have a list of all the instances and then sums all the counters for `/softwire-state/`.

One important change which has occurred was previously `tables` (yang lists) were not supported in state.lua. I had to add support to go into the lists, this is done by providing the data (if available) when reading the state. This change had to be made in order to properly enumerate lists with their keys so you can see which key the state data belongs to. 