### PR TITLE
Fix selection of modes based on instance config

### DIFF
--- a/src/program/lwaftr/bench/bench.lua
+++ b/src/program/lwaftr/bench/bench.lua
@@ -66,8 +66,12 @@ function run(args)
    end
 
    local graph = config.new()
-   setup.reconfigurable(scheduling, setup.load_bench, graph, conf,
-			inv4_pcap, inv6_pcap, 'sinkv4', 'sinkv6')
+   local function setup_fn(graph, lwconfig)
+      return setup.load_bench(graph, lwconfig, inv4_pcap, inv6_pcap, 'sinkv4',
+			      'sinkv6')
+   end
+
+   setup.reconfigurable(scheduling, setup_fn, graph, conf)
    app.configure(graph)
 
    local function start_sampling_for_pid(pid, write_header)
@@ -76,8 +80,8 @@ function run(args)
       csv:add_app('sinkv6', { 'input' }, { input=opts.hydra and 'encap' or 'Encap.' })
       csv:activate(write_header)
    end
-   
+
    setup.start_sampling(start_sampling_for_pid)
-   
+
    app.main({duration=opts.duration})
 end

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -171,12 +171,12 @@ function run(args)
       local name, instance = next(lwconfig.softwire_config.instance)
       local queue = instance.queue.values[1]
       if queue.external_interface.device then
-	 return setup.load_phy(graph, lwconfig, 'inetNick', 'b4sideNic',
+	 return setup.load_phy(graph, lwconfig, 'inetNic', 'b4sideNic',
 			       opts.ring_buffer_size)
       else
 	 local use_splitter = requires_splitter(opts, lwconfig)
 	 local options = {
-	    v4_nic_name = 'inetNic', v6_nic_name = 'b4sideNick',
+	    v4_nic_name = 'inetNic', v6_nic_name = 'b4sideNic',
 	    v4v6 = use_splitter and 'v4v6', mirror = opts.mirror,
 	    ring_buffer_size = opts.ring_buffer_size
 	 }

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -684,9 +684,7 @@ function start_sampling(sample_fn)
       1e9, 'repeating'))
 end
 
-function reconfigurable(scheduling, f, graph, conf, ...)
-   local args = {...}
-
+function reconfigurable(scheduling, f, graph, conf)
    -- Always enabled in reconfigurable mode.
    alarm_notification = true
 
@@ -694,7 +692,7 @@ function reconfigurable(scheduling, f, graph, conf, ...)
       local mapping = {}
       for device, inst_config in pairs(lwutil.produce_instance_configs(conf)) do
          local instance_app_graph = config.new()
-         f(instance_app_graph, inst_config, unpack(args))
+         f(instance_app_graph, inst_config)
          mapping[device] = instance_app_graph
       end
       return mapping

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -4,7 +4,7 @@ Test the "snabb lwaftr run" subcommand. Needs NIC names.
 
 import unittest
 
-from test_env import DATA_DIR, SNABB_CMD, BaseTestCase, nic_names
+from test_env import DATA_DIR, SNABB_CMD, BaseTestCase, nic_names, ENC
 
 
 SNABB_PCI0, SNABB_PCI1 = nic_names()
@@ -25,6 +25,21 @@ class TestRun(BaseTestCase):
         output = self.run_cmd(self.cmd_args)
         self.assertIn(b'link report', output,
             b'\n'.join((b'OUTPUT', output)))
+
+    def test_run_on_a_stick_migration(self):
+        # The LwAFTR should be abel to migrate from non-on-a-stick -> on-a-stick
+        run_cmd = list(self.cmd_args)[:-4]
+        run_cmd.extend((
+            "--on-a-stick",
+            SNABB_PCI0
+        ))
+
+        # The best way to check is to see if it's what it's saying it'll do.
+        output = self.run_cmd(run_cmd).decode(ENC)
+        self.assertIn("Migrating instance", output)
+
+        migration_line = [l for l in output.split("\n") if "Migrating" in l][0]
+        self.assertIn(SNABB_PCI0, migration_line)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes #957.

As #957 states there is a migration when `--on-a-stick` or `--v4`/`--v6` is specified however it doesn't allow you to run in multiprocessing mode. The problem actually ended up being deeper than that. When you did provide one of these flags (or lack there of) it'd pick the appropriate mode based on the initial configuration and command line arguments and use that for everything. That means when a `snabb config add` command was issued, it will use whatever was appropriate when it initially started irregardless of what the configuration says.

The fix changes how the `setup_fn` we pass to `setup.reconfiguration` and thus the leader works. Instead of giving it for example `setup.load_phy` or `setup.load_on_a_stick`, etc. it provides a single setup_fn which takes in the graph and configuration (with a single instance) and decides based on that which mode to use.

I've tested on snabb1 that you can now provide an on-a-stick configuration and it'll configure itself in an on-a-stick fashion (I've also tested for bump-in-the-wire). I'd have liked to improve the unit tests around this to make them a bit more robust (especially with adding new instances) - to do that though I think i'd need something like #962.