### PR TITLE
Use false instead of "off" to disable intel_mp txq/rxq

### DIFF
--- a/src/apps/intel_mp/README.md
+++ b/src/apps/intel_mp/README.md
@@ -53,12 +53,12 @@ specified but assumed to be broadly applicable.
 
 *Optional*. The receive queue to attach to, numbered from 0. The default is 0.
 When VMDq is enabled, this number is used to index a queue (0 or 1)
-for the selected pool. Passing `"off"` will disable the receive queue.
+for the selected pool. Passing `false` will disable the receive queue.
 
 — Key **txq**
 
 *Optional*. The transmit queue to attach to, numbered from 0. The default is 0.
-Passing `"off"` will disable the transmit queue.
+Passing `false` will disable the transmit queue.
 
 — Key **vmdq**
 

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -339,10 +339,6 @@ function Intel:new (conf)
       priority = conf.priority
    }
 
-   -- txq/rxq have defaults so nil can't represent off state
-   if conf.txq == "off" then self.txq = nil end
-   if conf.rxq == "off" then self.rxq = nil end
-
    local vendor = lib.firstline(self.path .. "/vendor")
    local device = lib.firstline(self.path .. "/device")
    local byid = byPciID[tonumber(device)]
@@ -576,7 +572,7 @@ function Intel:offset(reg, key)
 end
 function Intel:push ()
    if not self.txq then return end
-   local li = self.input["input"]
+   local li = self.input.input
    if li == nil then return end
 
    while not empty(li) and self:can_transmit() do
@@ -607,7 +603,7 @@ function Intel:push ()
 
    -- same code as in pull, but we only call it in case the rxq
    -- is disabled for this app
-   if self.rxq and self.output["output"] then return end
+   if self.rxq and self.output.output then return end
    if self.run_stats and self.sync_timer() then
       self:sync_stats()
    end
@@ -615,7 +611,7 @@ end
 
 function Intel:pull ()
    if not self.rxq then return end
-   local lo = self.output["output"]
+   local lo = self.output.output
    if lo == nil then return end
 
    local pkts = 0

--- a/src/apps/intel_mp/test_10g_rxq_disable.snabb
+++ b/src/apps/intel_mp/test_10g_rxq_disable.snabb
@@ -19,8 +19,8 @@ config.app(c, "n0", intel.Intel,
 
 config.app(c, "n1", intel.Intel,
            { pciaddr = pciaddr1,
-             rxq = "off",
-             txq = "off",
+             rxq = false,
+             txq = false,
              wait_for_link = true })
 
 config.app(c, "source0", basic_apps.Source)

--- a/src/apps/intel_mp/test_10g_sw_sem.snabb
+++ b/src/apps/intel_mp/test_10g_sw_sem.snabb
@@ -6,7 +6,7 @@ local parse = require("core.lib").parse
 local function new_intel (arg)
    return intel.Intel:new(parse(arg, intel.Intel.config))
 end
-local nic = new_intel({pciaddr = pci0, rxq = "off", txq = "off"})
+local nic = new_intel({pciaddr = pci0, rxq = false, txq = false})
 
 nic:unlock_sw_sem()
 nic:lock_sw_sem()


### PR DESCRIPTION
Also clean up access to inputs and outputs.