### PR TITLE
Allow either 32/64 pools depending on queuing mode

### DIFF
--- a/src/apps/intel_mp/README.md
+++ b/src/apps/intel_mp/README.md
@@ -72,10 +72,18 @@ For a given NIC, all driver instances should have this parameter either
 enabled or disabled uniformly. If this is enabled, *macaddr* must be
 specified.
 
+— Key **vmdq_queuing_mode**
+
+*Optional*. Sets the queuing mode to use in VMDq mode. Has no effect when
+VMDq is disabled. The available queuing modes are `"rss-64-2"`
+(the default with 64 pools, 2 queues each) and `"rss-32-4"`
+(32 pools, 4 queues each).
+
 — Key **poolnum**
 
 *Optional*. The VMDq pool to associate with, numbered from 0. The default
-is to select a pool number automatically.
+is to select a pool number automatically. The maximum pool number depends
+on the queuing mode.
 
 — Key **macaddr**
 
@@ -194,5 +202,5 @@ Each chipset supports a differing number of receive / transmit queues:
 * Intel1g i210 supports 4 receive and 4 transmit queues, 0-3
 
 The Intel82599 supports both VMDq and RSS with 32/64 pools and 4/2 RSS queues for
-each pool. This driver only supports configurations with 64 pools/2 queues.
+each pool.
 While the i350 supports VMDq, this driver does not currently support it.

--- a/src/apps/intel_mp/test_10g_4q_vmdq.snabb
+++ b/src/apps/intel_mp/test_10g_4q_vmdq.snabb
@@ -1,0 +1,48 @@
+#!../../snabb snsh
+
+-- Snabb test script for testing 4 queue RSS mode
+
+local basic_apps = require("apps.basic.basic_apps")
+local intel      = require("apps.intel_mp.intel_mp")
+local pcap       = require("apps.pcap.pcap")
+local lib        = require("core.lib")
+
+local pciaddr0 = lib.getenv("SNABB_PCI_INTEL0")
+local pciaddr1 = lib.getenv("SNABB_PCI_INTEL1")
+
+local c = config.new()
+
+config.app(c, "source", pcap.PcapReader, "source.pcap")
+config.app(c, 'sink', basic_apps.Sink)
+
+-- send packets on nic0
+config.app(c, "nic0", intel.Intel,
+           { pciaddr = pciaddr0,
+             -- disable rxq
+             rxq = false,
+             txq = 0,
+             wait_for_link = true })
+config.link(c, "source.output -> nic0.input")
+
+-- nic1 with 4-way RSS
+for i=0, 3 do
+   config.app(c, "nic1p" .. i, intel.Intel,
+              { pciaddr = pciaddr1,
+                vmdq = true,
+                vmdq_queuing_mode = "rss-32-4",
+                macaddr = "90:72:82:78:c9:7a",
+                poolnum = 0,
+                rxq = i,
+                txq = i,
+                wait_for_link = true })
+   config.link(c, "nic1p" .. i .. ".output -> sink.input" .. i)
+end
+
+engine.configure(c)
+engine.main({ duration = 1 })
+
+-- check for output on all 4 queues
+for i=0, 3 do
+   assert(link.stats(engine.app_table.sink.input["input" .. i]).rxpackets > 0,
+          "expected packet rx on rss queue " .. i)
+end


### PR DESCRIPTION
PR for removing the limitation of 2 RSS queues per VMDq pool.

Some potential points for feedback:
  * The configuration API is a little verbose (see README changes) because it's trying to allow for future additions (like if the driver allows DCB-based queuing instead of RSS for example)
  * The changes are a little more complex than I initially hoped for, since there's a need to communicate the queuing mode between the main process & non-main processes. This is because:
    - the `PSRTYPE` register needs to be set for every Rx queue and depends on the number of total RSS queues (setting this always to 4 does work in some cases, but I think there are edge cases where it does not), and
    - otherwise it's possible to config different instances with conflicting modes, which will have unexpected behavior.