### PR TITLE
Multiqueue fixes

### DIFF
--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -401,7 +401,7 @@ local function path_adder_for_grammar(grammar, path)
          return function(config, subconfig)
             local tab = getter(config)
             for k,_ in pairs(subconfig) do
-               if tab[k] ~= nil then error('already-existing entry', k) end
+               if tab[k] ~= nil then error('already-existing entry') end
             end
             for k,v in pairs(subconfig) do tab[k] = v end
             return config

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -342,15 +342,11 @@ local function select_instance(conf)
       for k,v in pairs(t2) do ret[k] = v end
       return ret
    end
-   local device = next(conf.softwire_config.instance)
+   local device, id, queue = lwutil.parse_instance(conf)
    conf.softwire_config.external_interface = table_merge(
-      conf.softwire_config.external_interface,
-      conf.softwire_config.instance[device].queue.values[1].external_interface
-   )
+      conf.softwire_config.external_interface, queue.external_interface)
    conf.softwire_config.internal_interface = table_merge(
-      conf.softwire_config.internal_interface,
-      conf.softwire_config.instance[device].queue.values[1].internal_interface
-   )
+      conf.softwire_config.internal_interface, queue.internal_interface)
    return conf
 end
 

--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -6,6 +6,7 @@ local S = require("syscall")
 local bit = require("bit")
 local ffi = require("ffi")
 local lib = require("core.lib")
+local cltable = require("lib.cltable")
 
 local band = bit.band
 local cast = ffi.cast
@@ -17,6 +18,23 @@ local constants_ipv6_frag = constants.ipv6_frag
 local ehs = constants.ethernet_header_size
 local o_ipv4_flags = constants.o_ipv4_flags
 local ntohs = lib.ntohs
+
+-- Return device PCI address, queue ID, and queue configuration.
+function parse_instance(conf)
+   local device, instance
+   for k, v in pairs(conf.softwire_config.instance) do
+      assert(device == nil, "configuration has more than one instance")
+      device, instance = k, v
+   end
+   assert(device ~= nil, "configuration has no instance")
+   local id, queue
+   for k, v in cltable.pairs(instance.queue) do
+      assert(id == nil, "configuration has more than one RSS queue")
+      id, queue = k.id, v
+   end
+   assert(id ~= nil, "configuration has no RSS queues")
+   return device, id, queue
+end
 
 function get_ihl_from_offset(pkt, offset)
    local ver_and_ihl = pkt.data[offset]

--- a/src/lib/cltable.lua
+++ b/src/lib/cltable.lua
@@ -28,8 +28,9 @@ function set(cltable, key, value)
       cltable.values[entry.value] = value
       if value == nil then cltable.keys:remove_ptr(entry) end
    elseif value ~= nil then
-      table.insert(cltable.values, value)
-      cltable.keys:add(key, #cltable.values)
+      local idx = #cltable.values + 1
+      cltable.values[idx] = value
+      cltable.keys:add(key, idx)
    end
 end
 

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -14,7 +14,7 @@ local ctable = require('lib.ctable')
 local cltable = require('lib.cltable')
 
 local MAGIC = "yangconf"
-local VERSION = 0x00005000
+local VERSION = 0x00006000
 
 local header_t = ffi.typeof([[
 struct {
@@ -217,7 +217,10 @@ local function data_emitter(production)
             stream:write_stringref('cltable')
             emit_keys(data.keys, stream)
             stream:write_uint32(#data.values)
-            for i=1,#data.values do emit_value(data.values[i], stream) end
+            for i, value in ipairs(data.values) do
+               stream:write_uint32(i)
+               emit_value(value, stream)
+            end
          end
       else
          local emit_key = visit1({type='struct', members=production.keys,
@@ -410,7 +413,10 @@ local function read_compiled_data(stream, strtab)
    function readers.cltable()
       local keys = read1()
       local values = {}
-      for i=1,stream:read_uint32() do table.insert(values, read1()) end
+      for i=1,stream:read_uint32() do
+         local i = stream:read_uint32()
+         values[i] = read1()
+      end
       return cltable.build(keys, values)
    end
    function readers.lltable()

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -218,7 +218,7 @@ local function data_emitter(production)
          return function(data, stream)
             stream:write_stringref('cltable')
             emit_keys(data.keys, stream)
-            for i, value in ipairs(data.values) do
+            for i, value in pairs(data.values) do
                stream:write_uint32(i)
                emit_value(value, stream)
             end

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -132,10 +132,10 @@ end
 -- Requires a V4V6 splitter if running in on-a-stick mode and VLAN tag values
 -- are the same for the internal and external interfaces.
 local function requires_splitter (opts, conf)
+   local device, id, queue = lwutil.parse_instance(conf)
    if opts["on-a-stick"] then
-      local _, instance = next(conf.softwire_config.instance)
-      local internal_interface = instance.queue.values[1].internal_interface
-      local external_interface = instance.queue.values[1].external_interface
+      local internal_interface = queue.internal_interface
+      local external_interface = queue.external_interface
       return internal_interface.vlan_tag == external_interface.vlan_tag
    end
    return false
@@ -161,8 +161,7 @@ function run(args)
 
       -- If instance has external-interface.device configure as bump-in-the-wire
       -- otherwise configure it in on-a-stick mode.
-      local name, instance = next(lwconfig.softwire_config.instance)
-      local queue = instance.queue.values[1]
+      local device, id, queue = lwutil.parse_instance(lwconfig)
       if queue.external_interface.device then
 	 return setup.load_phy(graph, lwconfig, 'inetNic', 'b4sideNic',
 			       opts.ring_buffer_size)

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -18,7 +18,6 @@ local lwaftr = require("apps.lwaftr.lwaftr")
 local lwutil = require("apps.lwaftr.lwutil")
 local constants = require("apps.lwaftr.constants")
 local nh_fwd = require("apps.lwaftr.nh_fwd")
-local cltable = require("lib.cltable")
 local pci = require("lib.hardware.pci")
 local raw = require("apps.socket.raw")
 local tap = require("apps.tap.tap")
@@ -45,26 +44,9 @@ local function load_driver (pciaddr)
    return require(device_info.driver).driver, device_info.rx, device_info.tx
 end
 
--- Return device PCI address, queue ID, and queue configuration.
-local function parse_instance(conf)
-   local device, instance
-   for k, v in pairs(conf.softwire_config.instance) do
-      assert(device == nil, "configuration has more than one instance")
-      device, instance = k, v
-   end
-   assert(device ~= nil, "configuration has no instance")
-   local id, queue
-   for k, v in cltable.pairs(instance.queue) do
-      assert(id == nil, "configuration has more than one RSS queue")
-      id, queue = k.id, v
-   end
-   assert(id ~= nil, "configuration has no RSS queues")
-   return device, id, queue
-end
-
 local function load_virt (c, nic_id, lwconf, interface)
    -- Validate the lwaftr and split the interfaces into global and instance.
-   local device, id, queue = parse_instance(lwconf)
+   local device, id, queue = lwutil.parse_instance(lwconf)
 
    local gexternal_interface = lwconf.softwire_config.external_interface
    local ginternal_interface = lwconf.softwire_config.internal_interface
@@ -161,7 +143,7 @@ function lwaftr_app(c, conf, lwconf, sock_path)
    assert(type(lwconf) == 'table')
 
    -- Validate the lwaftr and split the interfaces into global and instance.
-   local device, id, queue = parse_instance(lwconf)
+   local device, id, queue = lwutil.parse_instance(lwconf)
 
    local gexternal_interface = lwconf.softwire_config.external_interface
    local ginternal_interface = lwconf.softwire_config.internal_interface


### PR DESCRIPTION
THis PR builds on #972 and fixes a few errors.  With this, running the icmp_on_fail.conf on 83:00.{0,1} like this:

```
$ make && sudo ./snabb lwaftr run --name lwaftr --cpu 7-11 --conf program/lwaftr/tests/data/icmp_on_fail.conf --v4 83:00.0 --v6 83:00.1
```

I can then get the config:

```
$ make && sudo ./snabb config get lwaftr /softwire-config/instance
make: 'snabb' is up to date.
{
  device 83:00.0;
  queue {
    id 0;
    external-interface {
      device 83:00.1;
      ip 10.10.10.10;
      mac 12:12:12:12:12:12;
      next-hop {
        mac 68:68:68:68:68:68;
      }
    }
    internal-interface {
      ip 8:9:a:b:c:d:e:f;
      mac 22:22:22:22:22:22;
      next-hop {
        mac 44:44:44:44:44:44;
      }
    }
  }
}
```

And add an RSS worker:

```
$ cat second-queue.conf
{
  id 1;
  external-interface {
    device 83:00.1;
    ip 10.10.10.10;
    mac 12:12:12:12:12:12;
    next-hop {
      mac 68:68:68:68:68:68;
    }
  }
  internal-interface {
    ip 8:9:a:b:c:d:e:f;
    mac 22:22:22:22:22:22;
    next-hop {
      mac 44:44:44:44:44:44;
    }
  }
}

$ make && sudo ./snabb config add lwaftr /softwire-config/instance[device=83:00.0]/queue < second-queue.conf
make: 'snabb' is up to date.
lib/yang/binary.lua:159: attempt to index local 'data' (a nil value)
```

OK so weird error there, need to look into it.  However:

```
$ sudo ./snabb ps
2875
19769
20061
24491
25025	[lwaftr] * [schema: snabb-softwire-v2]
  \- 25031   worker for 25025
  \- 25175   worker for 25025

$ make && sudo ./snabb config get lwaftr /softwire-config/instance
make: 'snabb' is up to date.
{
  device 83:00.0;
  queue {
    id 0;
    external-interface {
      device 83:00.1;
      ip 10.10.10.10;
      mac 12:12:12:12:12:12;
      next-hop {
        mac 68:68:68:68:68:68;
      }
    }
    internal-interface {
      ip 8:9:a:b:c:d:e:f;
      mac 22:22:22:22:22:22;
      next-hop {
        mac 44:44:44:44:44:44;
      }
    }
  }
  queue {
    id 1;
    external-interface {
      device 83:00.1;
      ip 10.10.10.10;
      mac 12:12:12:12:12:12;
      next-hop {
        mac 68:68:68:68:68:68;
      }
    }
    internal-interface {
      ip 8:9:a:b:c:d:e:f;
      mac 22:22:22:22:22:22;
      next-hop {
        mac 44:44:44:44:44:44;
      }
    }
  }
}
```