### PR TITLE
Adapt alarms to multiprocess

### DIFF
--- a/src/apps/config/alarm_codec.lua
+++ b/src/apps/config/alarm_codec.lua
@@ -307,7 +307,7 @@ function selftest ()
    test_raise_alarm()
    test_clear_alarm()
 
-   local a, b = unpack(normalize({b='foo'}, {'a', 'b'}))
+   local a, b = normalize({b='foo'}, {'a', 'b'})
    assert(a == nil and b == 'foo')
 
    print('selftest: ok')

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -894,6 +894,10 @@ function Leader:handle_alarm (follower, alarm)
       local key = alarm_codec.to_alarm(args)
       alarms.clear_alarm(key)
    end
+   if fn == 'add_to_inventory' then
+      local key, args = alarm_codec.to_alarm_type(args)
+      alarms.do_add_to_inventory(key, args)
+   end
 end
 
 function Leader:stop ()

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -887,11 +887,11 @@ end
 function Leader:handle_alarm (follower, alarm)
    local fn, args = unpack(alarm)
    if fn == 'raise_alarm' then
-      local key, args = alarm_codec.parse_args(args)
+      local key, args = alarm_codec.to_alarm(args)
       alarms.raise_alarm(key, args)
    end
    if fn == 'clear_alarm' then
-      local key = alarm_codec.parse_args(args)
+      local key = alarm_codec.to_alarm(args)
       alarms.clear_alarm(key)
    end
 end

--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -898,6 +898,10 @@ function Leader:handle_alarm (follower, alarm)
       local key, args = alarm_codec.to_alarm_type(args)
       alarms.do_add_to_inventory(key, args)
    end
+   if fn == 'declare_alarm' then
+      local key, args = alarm_codec.to_alarm(args)
+      alarms.do_declare_alarm(key, args)
+   end
 end
 
 function Leader:stop ()

--- a/src/apps/ipv4/arp.lua
+++ b/src/apps/ipv4/arp.lua
@@ -20,16 +20,17 @@ local datagram = require("lib.protocol.datagram")
 local ethernet = require("lib.protocol.ethernet")
 local ipv4     = require("lib.protocol.ipv4")
 local alarms = require("lib.yang.alarms")
+local S = require("syscall")
 
 alarms.add_to_inventory {
   [{alarm_type_id='arp-resolution'}] = {
-    resource='nic-v4',
+    resource=tostring(S.getpid()),
     has_clear=true,
     description='Raise up if ARP app cannot resolve IP address',
   }
 }
 local resolve_alarm = alarms.declare_alarm {
-   [{resource='nic-v4', alarm_type_id='arp-resolution'}] = {
+   [{resource=tostring(S.getpid()), alarm_type_id='arp-resolution'}] = {
       perceived_severity = 'critical',
       alarm_text = 'Make sure you can ARP resolve IP addresses on NIC',
    },

--- a/src/apps/ipv4/arp.lua
+++ b/src/apps/ipv4/arp.lua
@@ -23,7 +23,7 @@ local alarms = require("lib.yang.alarms")
 
 alarms.add_to_inventory {
   [{alarm_type_id='arp-resolution'}] = {
-    resource={'nic-v4'},
+    resource='nic-v4',
     has_clear=true,
     description='Raise up if ARP app cannot resolve IP address',
   }

--- a/src/apps/lwaftr/ndp.lua
+++ b/src/apps/lwaftr/ndp.lua
@@ -28,22 +28,21 @@ local datagram = require("lib.protocol.datagram")
 local ethernet = require("lib.protocol.ethernet")
 local ipv6     = require("lib.protocol.ipv6")
 local alarms = require("lib.yang.alarms")
+local S = require("syscall")
 
 alarms.add_to_inventory {
    [{alarm_type_id='ndp-resolution'}] = {
-      resource='nic-v6',
+      resource=tostring(S.getpid()),
       has_clear=true,
       description='Raise up if NDP app cannot resolve IPv6 address'
    }
 }
---[[
 local resolve_alarm = alarms.declare_alarm {
-   [{resource='nic-v6', alarm_type_id='ndp-resolution'}] = {
+   [{resource=tostring(S.getpid()), alarm_type_id='ndp-resolution'}] = {
       perceived_severity = 'critical',
       alarm_text = 'Make sure you can NDP resolve IP addresses on NIC',
    },
 }
---]]
 
 local htons, ntohs = lib.htons, lib.ntohs
 local htonl, ntohl = lib.htonl, lib.ntohl

--- a/src/apps/lwaftr/ndp.lua
+++ b/src/apps/lwaftr/ndp.lua
@@ -31,17 +31,19 @@ local alarms = require("lib.yang.alarms")
 
 alarms.add_to_inventory {
    [{alarm_type_id='ndp-resolution'}] = {
-      resource={'nic-v6'},
+      resource='nic-v6',
       has_clear=true,
       description='Raise up if NDP app cannot resolve IPv6 address'
    }
 }
+--[[
 local resolve_alarm = alarms.declare_alarm {
    [{resource='nic-v6', alarm_type_id='ndp-resolution'}] = {
       perceived_severity = 'critical',
       alarm_text = 'Make sure you can NDP resolve IP addresses on NIC',
    },
 }
+--]]
 
 local htons, ntohs = lib.htons, lib.ntohs
 local htonl, ntohl = lib.htonl, lib.ntohl

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -576,9 +576,28 @@ function selftest ()
       end
    end
 
+   -- ARP alarm.
+   do_add_to_inventory({alarm_type_id='arp-resolution'}, {
+      resource='nic-v4',
+      has_clear=true,
+      description='Raise up if ARP app cannot resolve IP address',
+   })
+   do_declare_alarm({resource='nic-v4', alarm_type_id='arp-resolution'}, {
+      perceived_severity = 'critical',
+      alarm_text = 'Make sure you can ARP resolve IP addresses on NIC',
+   })
+   -- NDP alarm.
+   do_add_to_inventory({alarm_type_id='ndp-resolution'}, {
+      resource='nic-v6',
+      has_clear=true,
+      description='Raise up if NDP app cannot resolve IP address',
+   })
+   do_declare_alarm({resource='nic-v6', alarm_type_id='ndp-resolution'}, {
+      perceived_severity = 'critical',
+      alarm_text = 'Make sure you can NDP resolve IP addresses on NIC',
+   })
+
    -- Check alarm inventory has been loaded.
-   require("apps.ipv4.arp")
-   require("apps.lwaftr.ndp")
    assert(table_size(state.alarm_inventory.alarm_type) > 0)
 
    -- Check number of alarms is zero.

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -198,8 +198,21 @@ function alarm_list:retrieve (key, args)
    end
 end
 
-function declare_alarm (alarm)
-   assert(table_size(alarm) == 1)
+function declare_alarm (alarms)
+   local k, v = next(alarms)
+   alarm_codec.declare_alarm(k, v)
+   local key = alarm_keys:normalize(k)
+   local alarm = {}
+   function alarm:raise (args)
+      alarm_codec.raise_alarm(key, args)
+   end
+   function alarm:clear ()
+      alarm_codec.clear_alarm(key)
+   end
+   return alarm
+end
+
+function do_declare_alarm (key, args)
    local function create_or_update (key, src)
       local dst = alarm_list:lookup(key)
       if dst then
@@ -212,16 +225,8 @@ function declare_alarm (alarm)
          alarm_list:new(key, src)
       end
    end
-   local k, v = next(alarm)
-   local key = alarm_keys:normalize(k)
-   create_or_update(key, v)
-   function alarm:raise (args)
-      alarm_codec.raise_alarm(key, args)
-   end
-   function alarm:clear ()
-      alarm_codec.clear_alarm(key)
-   end
-   return alarm
+   key = alarm_keys:normalize(key)
+   create_or_update(key, args)
 end
 
 -- Raise alarm.

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -124,6 +124,11 @@ function alarm_type_keys:fetch (alarm_type_id, alarm_type_qualifier)
    end
    return key
 end
+function alarm_type_keys:normalize (key)
+   local alarm_type_id = assert(key.alarm_type_id)
+   local alarm_type_qualifier = key.alarm_type_qualifier or ''
+   return self:fetch(alarm_type_id, alarm_type_qualifier)
+end
 
 function add_to_inventory (alarm_types)
    assert(type(alarm_types) == 'table')
@@ -176,12 +181,24 @@ local function table_size (t)
    return size
 end
 
+
 -- Contains a table with all the declared alarms.
 local alarm_list = {
    list = {},
+   defaults = {},
 }
 function alarm_list:new (key, alarm)
    self.list[key] = alarm
+   self:set_defaults_if_any(key)
+end
+function alarm_list:set_defaults_if_any (key)
+   k = alarm_type_keys:normalize(key)
+   for k,v in pairs(self.defaults[k]) do
+      self.list[key][k] = v
+   end
+end
+function add_default (key, args)
+   self.defaults[key] = args
 end
 function alarm_list:lookup (key)
    return self.list[key]
@@ -195,6 +212,13 @@ function alarm_list:retrieve (key, args)
    local alarm = self:lookup(key)
    if alarm then
       return copy(alarm, args)
+   end
+end
+
+function default_alarms (alarms)
+   for k,v in pairs(alarms) do
+      k = alarm_type_keys:normalize(k)
+      alarm_list.defaults[k] = v
    end
 end
 

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -128,6 +128,7 @@ end
 function add_to_inventory (alarm_types)
    for k,v in pairs(alarm_types) do
       local key = alarm_type_keys:fetch(k.alarm_type_id, k.alarm_type_qualifier)
+      v.resource = {v.resource}
       state.alarm_inventory.alarm_type[key] = v
    end
 end

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -126,11 +126,16 @@ function alarm_type_keys:fetch (alarm_type_id, alarm_type_qualifier)
 end
 
 function add_to_inventory (alarm_types)
-   for k,v in pairs(alarm_types) do
-      local key = alarm_type_keys:fetch(k.alarm_type_id, k.alarm_type_qualifier)
-      v.resource = {v.resource}
-      state.alarm_inventory.alarm_type[key] = v
+   assert(type(alarm_types) == 'table')
+   for key,args in pairs(alarm_types) do
+      alarm_codec.add_to_inventory(key, args)
    end
+end
+
+function do_add_to_inventory (k, v)
+   local key = alarm_type_keys:fetch(k.alarm_type_id, k.alarm_type_qualifier)
+   v.resource = {v.resource}
+   state.alarm_inventory.alarm_type[key] = v
 end
 
 -- Single point to access alarm keys.

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -138,9 +138,15 @@ function add_to_inventory (alarm_types)
 end
 
 function do_add_to_inventory (k, v)
-   local key = alarm_type_keys:fetch(k.alarm_type_id, k.alarm_type_qualifier)
-   v.resource = {v.resource}
+   local key = alarm_type_keys:normalize(k)
+   local resource = {v.resource}
+   -- Preserve previously defined resources.
+   if state.alarm_inventory.alarm_type[key] then
+      resource = state.alarm_inventory.alarm_type[key].resource
+      table.insert(resource, v.resource)
+   end
    state.alarm_inventory.alarm_type[key] = v
+   state.alarm_inventory.alarm_type[key].resource = resource
 end
 
 -- Single point to access alarm keys.

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -199,8 +199,11 @@ function alarm_list:new (key, alarm)
 end
 function alarm_list:set_defaults_if_any (key)
    k = alarm_type_keys:normalize(key)
-   for k,v in pairs(self.defaults[k]) do
-      self.list[key][k] = v
+   local default = self.defaults[k]
+   if default then
+      for k,v in pairs(defaults) do
+         self.list[key][k] = v
+      end
    end
 end
 function add_default (key, args)

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -758,6 +758,7 @@ function rpc_output_parser_from_schema(schema)
 end
 
 local function encode_yang_string(str)
+   if #str == 0 then return "''" end
    if str:match("^[^%s;{}\"'/]*$") then return str end
    local out = {}
    table.insert(out, '"')

--- a/src/program/lwaftr/alarms.lua
+++ b/src/program/lwaftr/alarms.lua
@@ -1,9 +1,7 @@
 module(..., package.seeall)
 
-local alarms = require("lib.yang.alarms")
-
-alarms.declare_alarm {
-   [{resource='nic-v4', alarm_type_id='arp-resolution', alarm_type_qualifier=''}] = {
+alarms = {
+   [{alarm_type_id='arp-resolution'}] = {
       perceived_severity = 'critical',
       alarm_text =
          'Make sure you can resolve external-interface.next-hop.ip address '..
@@ -11,10 +9,7 @@ alarms.declare_alarm {
          'address of the next-hop directly.  To do it so, set '..
          'external-interface.next-hop.mac to the value of the MAC address.',
    },
-}
-
-alarms.declare_alarm {
-   [{resource='nic-v6', alarm_type_id='ndp-resolution', alarm_type_qualifier=''}] = {
+   [{alarm_type_id='ndp-resolution'}] = {
       perceived_severity = 'critical',
       alarm_text =
          'Make sure you can resolve internal-interface.next-hop.ip address '..

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -145,9 +145,11 @@ function lwaftr_app(c, conf, device)
                 next_ip = convert_ipv4(iexternal_interface.next_hop.ip),
                 alarm_notification = conf.alarm_notification })
 
+   --[[
    if conf.alarm_notification then
       require('program.lwaftr.alarms')
    end
+   --]]
 
    local preprocessing_apps_v4  = { "reassemblerv4" }
    local preprocessing_apps_v6  = { "reassemblerv6" }

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -30,6 +30,7 @@ local engine     = require("core.app")
 local lib        = require("core.lib")
 local shm        = require("core.shm")
 local yang       = require("lib.yang.yang")
+local alarms     = require("lib.yang.alarms")
 
 local alarm_notification = false
 
@@ -145,11 +146,10 @@ function lwaftr_app(c, conf, device)
                 next_ip = convert_ipv4(iexternal_interface.next_hop.ip),
                 alarm_notification = conf.alarm_notification })
 
-   --[[
    if conf.alarm_notification then
-      require('program.lwaftr.alarms')
+      local lwaftr = require('program.lwaftr.alarms')
+      alarms.default_alarms(lwaftr.alarms)
    end
-   --]]
 
    local preprocessing_apps_v4  = { "reassemblerv4" }
    local preprocessing_apps_v6  = { "reassemblerv6" }


### PR DESCRIPTION
With the multiprocess support in lwAFTR, it would be possible that and alarms definition is declared twice, overwritten its values or being impossible to identified which lwAFTR instance belongs to.

To solve this problem what I implemented was using alarms's resource identifier for storing lwAFTR's pids. This change required that alarm and alarm_type defintions should work as message passing commands, since they start in the worker but all alarm management and storage is done by the leader.

Maybe this design too tight to our needs, but I think this is fair for now while no one else uses the alarms module.