### PR TITLE
Use different pool numbers for on-a-stick VMDq interfaces

### DIFF
--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -304,7 +304,7 @@ function load_on_a_stick(c, conf, args)
          vmdq=true, -- Needed to enable MAC filtering/stamping.
          rxq=id,
          txq=id,
-         poolnum=0,
+         poolnum=1,
          vlan=queue.internal_interface.vlan_tag,
          ring_buffer_size=args.ring_buffer_size,
          macaddr = ethernet:ntop(queue.internal_interface.mac)})


### PR DESCRIPTION
In #977, we made it so that pool numbers were manually chosen, so that different RSS workers could share a pool.  This however is not the right thing for on-a-stick mode with VMDq; in that case, you want the IPv4 interface which has a different MAC or VLAN configuration than the IPv6 interface to have its own queue.  Fix that by setting the IPv6 interface to pool 1 instead of pool 0 (which the IPv4 interface is using).