### PR TITLE
Reassembly/fragmentation alarms

### DIFF
--- a/src/apps/ipv4/fragment.lua
+++ b/src/apps/ipv4/fragment.lua
@@ -11,7 +11,10 @@ local packet     = require("core.packet")
 local counter    = require("core.counter")
 local link       = require("core.link")
 local ipsum      = require("lib.checksum").ipsum
+local alarms     = require('lib.yang.alarms')
+local S          = require('syscall')
 
+local CounterAlarm = alarms.CounterAlarm
 local receive, transmit = link.receive, link.transmit
 local ntohs, htons = lib.ntohs, lib.htons
 
@@ -89,6 +92,23 @@ function Fragmenter:new(conf)
    assert(o.mtu >= 68)
    o.next_fragment_id = deterministic_first_fragment_id or
       math.random(0, 0xffff)
+
+   alarms.add_to_inventory {
+      [{alarm_type_id='outgoing-ipv4-fragments'}] = {
+         resource=tostring(S.getpid()),
+         has_clear=true,
+         description='Outgoing IPv4 fragments over N fragments/s',
+      }
+   }
+   local outgoing_fragments_alarm = alarms.declare_alarm {
+      [{resource=tostring(S.getpid()),alarm_type_id='outgoing-ipv4-fragments'}] = {
+         perceived_severity='warning',
+         alarm_text='More than 10,000 outgoing IPv4 fragments per second',
+      }
+   }
+   o.outgoing_ipv4_fragments_alarm = CounterAlarm.new(outgoing_fragments_alarm,
+      1, 1e4, o, "out-ipv4-frag")
+
    return setmetatable(o, {__index=Fragmenter})
 end
 
@@ -149,6 +169,8 @@ end
 function Fragmenter:push ()
    local input, output = self.input.input, self.output.output
    local max_length = self.mtu + ether_header_len
+
+   self.outgoing_ipv4_fragments_alarm:check()
 
    for _ = 1, link.nreadable(input) do
       local pkt = link.receive(input)


### PR DESCRIPTION
Implements the following alarms:

* incoming ipv4 fragments over N fragments/s
* incoming ipv6 fragments over N fragments/s
* outgoing ipv4 packets needing fragmentation over N packets/s
* outgoing ipv6 packets needing fragmentation over N packets/s

Partially fixes #965