### PR TITLE
Give snabb-softwire-v2 a different namespace from snabb-softwire-v1

### DIFF
--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -1,6 +1,6 @@
 module snabb-softwire-v2 {
   yang-version 1.1;
-  namespace snabb:lwaftr;
+  namespace snabb:softwire-v2;
   prefix softwire;
 
   import ietf-inet-types { prefix inet; }


### PR DESCRIPTION
This makes the lives of NCS people easier, and it doesn't matter at all
to us.