### PR TITLE
Change default schema to ietf-softwire

### DIFF
--- a/src/apps/config/leader.lua
+++ b/src/apps/config/leader.lua
@@ -32,6 +32,7 @@ Leader = {
       initial_configuration = {required=true},
       schema_name = {required=true},
       worker_start_code = {required=true},
+      default_schema = {},
       cpuset = {default=cpuset.global_cpuset()},
       Hz = {default=100},
    }
@@ -56,6 +57,7 @@ function Leader:new (conf)
       ret.socket_file_name = instance_dir..'/'..ret.socket_file_name
    end
    ret.schema_name = conf.schema_name
+   ret.default_schema = conf.default_schema or conf.schema_name
    ret.support = support.load_schema_config_support(conf.schema_name)
    ret.socket = open_socket(ret.socket_file_name)
    ret.peers = {}
@@ -177,6 +179,7 @@ function Leader:rpc_describe (args)
       table.insert(alternate_schemas, schema_name)
    end
    return { native_schema = self.schema_name,
+	    default_schema = self.default_schema,
             alternate_schema = alternate_schemas,
             capability = schema.get_default_capabilities() }
 end

--- a/src/lib/yang/snabb-config-leader-v1.yang
+++ b/src/lib/yang/snabb-config-leader-v1.yang
@@ -9,6 +9,10 @@ module snabb-config-leader-v1 {
   description
    "RPC interface for ConfigLeader Snabb app.";
 
+  revision 2017-09-28 {
+    description "Add default display schema for describe.";
+  }
+
   revision 2016-12-20 {
     description "Add basic error reporting.";
   }
@@ -26,6 +30,7 @@ module snabb-config-leader-v1 {
   rpc describe {
     output {
       leaf native-schema { type string; mandatory true; }
+      leaf default-schema { type string; mandatory true; }
       leaf-list alternate-schema { type string; }
       list capability {
         key module;

--- a/src/program/config/common.lua
+++ b/src/program/config/common.lua
@@ -88,7 +88,7 @@ function parse_command_line(args, opts)
    local descr = call_leader(ret.instance_id, 'describe', {})
    if not ret.schema_name then
       if opts.require_schema then err("missing --schema arg") end
-      ret.schema_name = descr.native_schema
+      ret.schema_name = descr.default_schema
    end
    require('lib.yang.schema').set_default_capabilities(descr.capability)
    if opts.with_config_file then

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -721,5 +721,6 @@ function reconfigurable(scheduling, f, graph, conf)
    config.app(graph, 'leader', leader.Leader,
               { setup_fn = setup_fn, initial_configuration = conf,
                 worker_start_code = worker_code,
-                schema_name = 'snabb-softwire-v2'})
+                schema_name = 'snabb-softwire-v2',
+		default_schema = 'ietf-softwire'})
 end

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -722,5 +722,5 @@ function reconfigurable(scheduling, f, graph, conf)
               { setup_fn = setup_fn, initial_configuration = conf,
                 worker_start_code = worker_code,
                 schema_name = 'snabb-softwire-v2',
-		default_schema = 'ietf-softwire'})
+                default_schema = 'ietf-softwire'})
 end

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -87,7 +87,7 @@ class TestConfigMultiproc(BaseTestCase):
     daemon = None
     daemon_args = DAEMON_ARGS
     ps_args = (str(SNABB_CMD), 'ps')
-    config_args = (str(SNABB_CMD), 'config', "--schema=snabb-softwire-v2", 'XXX', DAEMON_PROC_NAME)
+    config_args = (str(SNABB_CMD), 'config', 'XXX', '--schema=snabb-softwire-v2', DAEMON_PROC_NAME)
 
     @classmethod
     def setUpClass(cls):
@@ -180,7 +180,7 @@ class TestConfigMultiproc(BaseTestCase):
           }
         }}"""
         config_add_cmd = list(self.config_args)
-        config_add_cmd[3] = 'add'
+        config_add_cmd[2] = 'add'
         config_add_cmd.extend((
             '/softwire-config/instance',
             device
@@ -205,7 +205,7 @@ class TestConfigMultiproc(BaseTestCase):
         # There should be an instance called "test" in the initial
         # config that's loaded. We'll try removing that.
         config_remove_cmd = list(self.config_args)
-        config_remove_cmd[3] = 'remove'
+        config_remove_cmd[2] = 'remove'
         config_remove_cmd.append('/softwire-config/instance[device=test]')
 
         # Remove it
@@ -224,7 +224,7 @@ class TestConfigMultiproc(BaseTestCase):
         pid = self.start_daemon(config)
 
         get_state_cmd = list(self.config_args)
-        get_state_cmd[3] = "get-state"
+        get_state_cmd[2] = "get-state"
         get_state_cmd.insert(4, "-f")
         get_state_cmd.insert(5, "xpath")
         get_state_cmd.append("/")
@@ -258,7 +258,7 @@ class TestConfigMultiproc(BaseTestCase):
         pid = self.start_daemon(config)
 
         get_state_cmd = list(self.config_args)
-        get_state_cmd[3] = "get-state"
+        get_state_cmd[2] = "get-state"
         get_state_cmd.insert(4, "-f")
         get_state_cmd.insert(5, "xpath")
         get_state_cmd.append("/")
@@ -327,8 +327,8 @@ class TestConfigMisc(BaseTestCase):
     daemon_args = DAEMON_ARGS
 
     def get_cmd_args(self, action):
-        cmd_args = list((str(SNABB_CMD), 'config', '--schema=snabb-softwire-v2', 'XXX', DAEMON_PROC_NAME))
-        cmd_args[3] = action
+        cmd_args = list((str(SNABB_CMD), 'config', 'XXX', '--schema=snabb-softwire-v2', DAEMON_PROC_NAME))
+        cmd_args[2] = action
         return cmd_args
 
     def test_add(self):
@@ -430,8 +430,9 @@ class TestConfigMisc(BaseTestCase):
         # We actually need to look this up backwards, let's just check the
         # same IPv4 address as was used to set it above.
         get_args = self.get_cmd_args('get')[:-1]
+        get_args[3] = '--schema=ietf-softwire'
         get_args.extend((
-            '--schema=ietf-softwire', DAEMON_PROC_NAME,
+            DAEMON_PROC_NAME,
             # Implicit string concatenation, no summing needed.
             '/softwire-config/binding/br/br-instances/'
             'br-instance[id=1]/binding-table/binding-entry'
@@ -444,8 +445,9 @@ class TestConfigMisc(BaseTestCase):
 
         # Check the portset: the IPv4 address alone is not unique.
         get_args = self.get_cmd_args('get')[:-1]
+        get_args[3] = '--schema=ietf-softwire'
         get_args.extend((
-            '--schema=ietf-softwire', DAEMON_PROC_NAME,
+            DAEMON_PROC_NAME,
             # Implicit string concatenation, no summing needed.
             '/softwire-config/binding/br/br-instances/br-instance[id=1]/'
             'binding-table/binding-entry[binding-ipv6info=::1]/port-set/psid',

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -32,7 +32,7 @@ class TestConfigGet(BaseTestCase):
     """
 
     daemon_args = DAEMON_ARGS
-    config_args = (str(SNABB_CMD), 'config', 'get', DAEMON_PROC_NAME)
+    config_args = (str(SNABB_CMD), 'config', 'get', '--schema=snabb-softwire-v2', DAEMON_PROC_NAME)
 
     def test_get_internal_iface(self):
         cmd_args = list(self.config_args)
@@ -65,8 +65,9 @@ class TestConfigGet(BaseTestCase):
 
     def test_get_ietf_path(self):
         cmd_args = list(self.config_args)[:-1]
+        cmd_args[3] = '--schema=ietf-softwire'
         cmd_args.extend((
-            '--schema=ietf-softwire', DAEMON_PROC_NAME,
+            DAEMON_PROC_NAME,
             # Implicit string concatenation, do not add commas.
             '/softwire-config/binding/br/br-instances/'
             'br-instance[id=1]/binding-table/binding-entry'
@@ -86,7 +87,7 @@ class TestConfigMultiproc(BaseTestCase):
     daemon = None
     daemon_args = DAEMON_ARGS
     ps_args = (str(SNABB_CMD), 'ps')
-    config_args = (str(SNABB_CMD), 'config', 'XXX', DAEMON_PROC_NAME)
+    config_args = (str(SNABB_CMD), 'config', "--schema=snabb-softwire-v2", 'XXX', DAEMON_PROC_NAME)
 
     @classmethod
     def setUpClass(cls):
@@ -179,7 +180,7 @@ class TestConfigMultiproc(BaseTestCase):
           }
         }}"""
         config_add_cmd = list(self.config_args)
-        config_add_cmd[2] = 'add'
+        config_add_cmd[3] = 'add'
         config_add_cmd.extend((
             '/softwire-config/instance',
             device
@@ -204,7 +205,7 @@ class TestConfigMultiproc(BaseTestCase):
         # There should be an instance called "test" in the initial
         # config that's loaded. We'll try removing that.
         config_remove_cmd = list(self.config_args)
-        config_remove_cmd[2] = 'remove'
+        config_remove_cmd[3] = 'remove'
         config_remove_cmd.append('/softwire-config/instance[device=test]')
 
         # Remove it
@@ -223,9 +224,9 @@ class TestConfigMultiproc(BaseTestCase):
         pid = self.start_daemon(config)
 
         get_state_cmd = list(self.config_args)
-        get_state_cmd[2] = "get-state"
-        get_state_cmd.insert(3, "-f")
-        get_state_cmd.insert(4, "xpath")
+        get_state_cmd[3] = "get-state"
+        get_state_cmd.insert(4, "-f")
+        get_state_cmd.insert(5, "xpath")
         get_state_cmd.append("/")
 
         state = self.run_cmd(get_state_cmd).decode(ENC)
@@ -257,9 +258,9 @@ class TestConfigMultiproc(BaseTestCase):
         pid = self.start_daemon(config)
 
         get_state_cmd = list(self.config_args)
-        get_state_cmd[2] = "get-state"
-        get_state_cmd.insert(3, "-f")
-        get_state_cmd.insert(4, "xpath")
+        get_state_cmd[3] = "get-state"
+        get_state_cmd.insert(4, "-f")
+        get_state_cmd.insert(5, "xpath")
         get_state_cmd.append("/")
 
         state = self.run_cmd(get_state_cmd).decode(ENC)
@@ -326,8 +327,8 @@ class TestConfigMisc(BaseTestCase):
     daemon_args = DAEMON_ARGS
 
     def get_cmd_args(self, action):
-        cmd_args = list((str(SNABB_CMD), 'config', 'XXX', DAEMON_PROC_NAME))
-        cmd_args[2] = action
+        cmd_args = list((str(SNABB_CMD), 'config', '--schema=snabb-softwire-v2', 'XXX', DAEMON_PROC_NAME))
+        cmd_args[3] = action
         return cmd_args
 
     def test_add(self):


### PR DESCRIPTION
This changes the default value of the `--schema` flag on `snabb config` commands to `ietf-softwire`. Changing this should be as easy as modifying the `default_schema` parameter whilst setting up the leader and since the schema used in the tests is now explicit those should not need to change.