### PR TITLE
Add new ietf softwire schemas

### DIFF
--- a/src/lib/yang/ietf-softwire-br.yang
+++ b/src/lib/yang/ietf-softwire-br.yang
@@ -1,0 +1,389 @@
+module ietf-softwire-br {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-softwire-br";
+  prefix "softwire-br";
+
+  import ietf-inet-types {prefix inet; }
+  import ietf-yang-types {prefix yang; }
+  import ietf-softwire-common {prefix softwire-common; }
+
+  organization "Softwire Working Group";
+
+  contact
+    "
+    Qi Sun <sunqi.ietf@gmail.com>
+    Hao Wang <wangh13@mails.tsinghua.edu.cn>
+    Yong Cui <yong@csnet1.cs.tsinghua.edu.cn>
+    Ian <Farrer ian.farrer@telekom.de>
+    Sladjana Zoric <sladjana.zoric@telekom.de>
+    Mohamed Boucadair <mohamed.boucadair@orange.com>
+    Rajiv <Asati rajiva@cisco.com>
+    ";
+
+  description
+    "This document defines a YANG data module for the configuration and
+    management of A+P Softwire Border Routers. It covers Lightweight 4over6,
+    MAP-E, and MAP-T mechanisms.
+
+    Copyright (c) 2017 IETF Trust and the persons identified
+    as authors of the code. All rights reserved.
+    This version of this YANG module is part of RFC XXX; see the RFC
+    itself for full legal notices.";
+
+  revision 2017-10-19 {
+    description
+      "Update...";
+    reference "-02";
+  }
+
+  revision 2017-06-14 {
+    description
+      "Monolithic version of ietf-softwire divided into separate CE and BR
+      models. Added icmp handling and improved counters.";
+    reference "-06";
+  }
+  revision 2016-06-04 {
+    description
+      "Version-05: Combined MAP-E/MAP-T into a single tree. Added binding
+      table/algorthm versioning";
+    reference "-05";
+  }
+
+  revision 2015-09-30 {
+    description
+      "Version-04: Fix YANG syntax; Add flags to map-rule; Remove
+      the map-rule-type element. ";
+    reference "-04";
+  }
+
+  revision 2015-04-07 {
+    description
+      "Version-03: Integrate lw4over6; Updata state nodes; Correct
+      grammar errors; Reuse groupings; Update descriptions.
+      Simplify the model.";
+    reference "-03";
+  }
+
+  revision 2015-02-10 {
+    description
+      "Version-02: Add notifications.";
+    reference "-02";
+  }
+
+
+  revision 2015-02-06 {
+    description
+      "Version-01: Correct grammar errors; Reuse groupings; Update
+      descriptions.";
+    reference "-01";
+  }
+
+  revision 2015-02-02 {
+    description
+      "Initial revision.";
+    reference "-00";
+  }
+
+  /*
+   * Features
+   */
+
+  feature binding {
+    description
+      "Binding is used for configuring Lightweight 4over6 mechanism.
+
+      Binding softwire mechanisms are IPv4-over-IPv6 tunnelling transition mechanisms specifically for complete independence between IPv6 subnet prefix (and /128 IPv6 address) and IPv4 address with or without IPv4 address sharing.
+
+      This is accomplished by maintaining state for each softwire (per-subscriber state) in the central Border Relay (BR) and a hub-and-spoke forwarding architecture. In order to delegate the NAPT function and achieve IPv4 address sharing, port-restricted IPv4 addresses needs to be allocated to CEs.";
+
+    reference
+      "RFC7596, RFC7597 & RFC7599";
+  }
+
+  feature algorithm {
+    description
+      "MAP-E is an IPv6 transition mechanism for transporting IPv4
+      packets across an IPv6 network using IP encapsulation. MAP-E
+      allows for a reduction of the amount of centralized state using
+      rules to express IPv4/IPv6 address mappings. This introduces an
+      algorithmic relationship between the IPv6 subnet and IPv4 address.
+
+      MAP-T is an IPv6 transition mechanism for transporting IPv4 packets across an IPv6 network using IP translation. It leverages double stateless NAT64 based solution as well as the stateless algorithmic address & transport layer port mapping algorithm defined for MAP-E.
+
+      This feature indicates the instance functions as a MAP-E or
+      MAP-T instance.";
+
+    reference
+      "RFC7597 & RFC7599";
+  }
+
+  container br-instances {
+    description
+      "BR Instances";
+
+    choice br-type {
+      description
+        "Select binding or algorithmic BR functionality.";
+      case binding {
+        if-feature binding;
+        container binding {
+          if-feature binding;
+          description
+            "lw4over6 (binding table) configuration.";
+          list br-instance {
+            key "id";
+            description
+              "A set of lwAFTRs to be configured.";
+            container binding-table-versioning {
+              description "binding table's version";
+              leaf version{
+                type uint64;
+                description "Incremental version number of the binding
+                  table";
+              }
+              leaf date {
+                type yang:date-and-time;
+                description "Timestamp of the binding
+                  table";
+              }
+            }
+            leaf id {
+              type uint32;
+              mandatory true;
+              description "An instance identifier.";
+            }
+            leaf name {
+              type string;
+              description "The name for the lwaftr.";
+            }
+            leaf softwire-num-threshold {
+              type uint32;
+              mandatory true;
+              description
+                "The maximum number of softwires that can be created on
+                the lwAFTR.";
+            }
+            leaf softwires-payload-mtu {
+              type uint16;
+              units bytes;
+              mandatory true;
+              description
+                "The payload MTU for Lightweight 4over6 softwire.";
+            }
+            leaf softwire-path-mru {
+              type uint16;
+              units bytes;
+              mandatory true;
+              description
+                "The path MRU for Lightweight 4over6 softwire.";
+            }
+            leaf enable-hairpinning {
+              type boolean;
+              default true;
+              description
+                "Enables/disables support for locally forwarding
+                (hairpinning) traffic between two CEs (RFC7596
+                    Section 6.2)";
+            }
+            container binding-table {
+              description "binding table";
+              list binding-entry {
+                key "binding-ipv6info";
+                description "binding entry";
+                uses softwire-common:binding-entry;
+              }
+            }
+            container icmp-policy {
+              description
+                "The lwAFTR can be configured to process or drop incoming ICMP
+                messages, and to generate outgoing ICMP error messages or
+                not.";
+
+              container icmpv4-errors {
+                description
+                  "ICMPv4 error processing configuration";
+                leaf allow-incoming-icmpv4 {
+                  type boolean;
+                  default true;
+                  description
+                    "Whether to allow processing of incoming ICMPv4 packets.
+                    (RFC7596 )";
+                }
+
+                leaf generate-icmpv4-errors {
+                  type boolean;
+                  default true;
+                  description
+                    "Whether to generate outgoing ICMP error messages on
+                    receipt of an inbound IPv4 packet with no matching
+                    binding table entry (RFC7596 Seciton 5.2).";
+                }
+              }
+
+              container icmpv6-errors {
+                description
+                  "ICMPv6 error processing configuration";
+                leaf generate-icmpv6-errors {
+                  type boolean;
+                  default true;
+                  description
+                    "Whether to generate ICMPv6 errors messages if no
+                    matching binding table entry is found (RFC7596
+                        Section 6.2)";
+                }
+                leaf icmpv6-errors-rate {
+                  type uint16;
+                  description
+                    "Rate limit threshold in messages per-second
+                    for sending ICMPv6 errors messages (RFC7596
+                        Section 9.)";
+                }
+              }
+            }
+
+            container traffic-stat {
+              config false;
+              description
+                "traffic-stat";
+              uses softwire-common:traffic-stat;
+            }
+
+            leaf hairpin-ipv4-bytes {
+              type yang:zero-based-counter64;
+              description "IPv4 packets locally routed between two CEs
+                (hairpinned).";
+            }
+
+            leaf hairpin-ipv4-packets {
+              type yang:zero-based-counter64;
+              description "IPv4 bytes locally routed between two CEs
+                (hairpinned).";
+            }
+
+            leaf active-softwire-num {
+              type uint32;
+              config false;
+              description
+                "The number of currently active softwires on the
+                lw4over6 (binding) instance.";
+            }
+          }
+        }
+      }
+      case algorithm {
+        if-feature algorithm;
+        container algorithm {
+          if-feature algorithm;
+          description
+            "Indicate the instances support the MAP-E and MAP-T function.
+            The instances advertise the map-e/map-t feature through the
+            capability exchange mechanism when a NETCONF session is
+            established.";
+          list algo-instance {
+            key "id";
+            description "Instances of algorithm";
+            leaf id {
+              type uint32;
+              mandatory true;
+              description "id";
+            }
+            leaf name {
+              type string;
+              description "The MAP instance name.";
+            }
+            uses softwire-common:algorithm {
+              augment "algo-instances/algo-instance"{
+                description "Augments the port-set group for the algorithm.";
+                uses softwire-common:port-set;
+            }
+            }
+            container traffic-stat {
+              description
+                "traffic-stat";
+              uses softwire-common:traffic-stat;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /*
+   * Notifications
+   */
+  notification softwire-br-event {
+    if-feature binding;
+    description "Notifications for BR.";
+    leaf br-id {
+      type leafref {
+        path
+          "/br-instances/binding/"
+          + "br-instance/id";
+      }
+      description "...";
+    }
+    leaf-list invalid-entry {
+      type leafref {
+        path
+          "/br-instances/binding/"
+          + "br-instance[id=current()/../br-id]/"
+          + "binding-table/binding-entry/binding-ipv6info";
+      }
+      description
+        "Notify the client that a specific binding entry has been
+        expired/invalid. The binding-ipv6info identifies an entry.";
+    }
+    leaf-list added-entry {
+      type inet:ipv6-address;
+      description
+        "Notify the client that a binding entry has been added.
+        The ipv6 address of that entry is the index. The client
+        get other information from the lwaftr about the entry
+        indexed by that ipv6 address.
+        ";
+    }
+    leaf-list modified-entry {
+      type leafref {
+        path
+          "/br-instances/binding/"
+          + "br-instance[id=current()/../br-id]/"
+          + "binding-table/binding-entry/binding-ipv6info";
+      }
+      description "...";
+    }
+  }
+
+  notification softwire-algorithm-instance-event {
+    if-feature algorithm;
+    description "Notifications for MAP-E or MAP-T.";
+    leaf algo-id {
+      type leafref {
+        path
+          "/br-instances/algorithm/algo-instance/id";
+      }
+      mandatory true;
+      description "MAP-E or MAP-T event.";
+    }
+    leaf-list invalid-entry-id {
+      type leafref {
+        path
+          "/br-instances/algorithm/algo-instance/id";
+      }
+      description "Invalid entry event.";
+    }
+    leaf-list added-entry {
+      type leafref {
+        path
+          "/br-instances/algorithm/algo-instance/id";
+      }
+      description "Added entry.";
+    }
+    leaf-list modified-entry {
+      type leafref {
+        path
+          "/br-instances/algorithm/algo-instance/id";
+      }
+      description "Modified entry.";
+    }
+  }
+}

--- a/src/lib/yang/ietf-softwire-common.yang
+++ b/src/lib/yang/ietf-softwire-common.yang
@@ -1,0 +1,298 @@
+module ietf-softwire-common {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-softwire-common";
+  prefix "softwire-common";
+
+  import ietf-inet-types { prefix inet; }
+  import ietf-yang-types { prefix yang; }
+
+  organization "Softwire Working Group";
+
+  contact
+    "
+    Qi Sun <sunqi.ietf@gmail.com>
+    Hao Wang <wangh13@mails.tsinghua.edu.cn>
+    Yong Cui <yong@csnet1.cs.tsinghua.edu.cn>
+    Ian <Farrer ian.farrer@telekom.de>
+    Sladjana Zoric <sladjana.zoric@telekom.de>
+    Mohamed Boucadair <mohamed.boucadair@orange.com>
+    Rajiv <Asati rajiva@cisco.com>
+    ";
+
+  description
+    "This document defines a YANG data model for the configuration and
+    management of A+P Softwire Customer Premises Equipment (CEs). It
+    covers Lightweight 4over6, MAP-E and MAP-T mechanisms.
+
+    Copyright (c) 2017 IETF Trust and the persons identified
+    as authors of the code. All rights reserved.
+    This version of this YANG module is part of RFC XXX; see the RFC
+    itself for full legal notices.";
+
+  revision 2017-10-19 {
+    description
+      "Initial version of containing a model for common softwire elements.";
+    reference "-02";
+  }
+
+  /*
+   * Grouping
+   */
+
+  grouping port-set {
+    description
+      "Indicates a set of ports.
+      It may be a simple port range, or use the PSID algorithm
+      to represent a range of transport layer ports which will
+      be used by a NAPT.";
+
+    leaf psid-offset {
+      type uint8 {
+        range 0..16;
+      }
+      description
+        "The number of offset bits. In Lightweight 4over6,
+        the default value is 0 for assigning one contiguous
+          port range. In MAP-E/T, the default value is 6,
+        which means the system ports (0-1023) are excluded by
+        default and assigns port ranges distributed across the
+        entire port space, depending on either psid-len or the
+        number of contiguous ports.";
+    }
+
+    leaf psid-len {
+      type uint8 {
+        range 0..15;
+      }
+      mandatory true;
+      description
+        "The length of PSID, representing the sharing
+        ratio for an IPv4 address. This, along with ea-len, also
+        helps to calculate the number of contiguous ports per
+        port range";
+    }
+
+    leaf psid {
+      type uint16;
+      mandatory true;
+      description
+        "Port Set Identifier (PSID) value, which
+        identifies a set of ports algorithmically.";
+    }
+  }
+
+  grouping binding-entry {
+    description
+      "The lwAFTR maintains an address binding table that contains
+      the binding between the lwB4's IPv6 address, the allocated IPv4
+      address and restricted port-set.";
+    leaf binding-ipv6info {
+      type union {
+        type inet:ipv6-address;
+        type inet:ipv6-prefix;
+      }
+      description
+        "The IPv6 information for a binding entry.
+        If this is an IPv6 prefix, it indicates that
+        the IPv6 source address of the CE is constructed
+        according to the description in RFC7596;
+      if it is an IPv6 address, it means the CE uses
+        any /128 address from the assigned CE prefix.
+          ";
+    }
+    leaf binding-ipv4-addr {
+      type inet:ipv4-address;
+      description
+        "The IPv4 address assigned to the lwB4, which is
+        used as the IPv4 external address
+        for lwB4 local NAPT44.";
+    }
+    container port-set {
+      description
+        "For Lightweight 4over6, the default value
+        of offset should be 0, to configure one contiguous
+        port range.";
+      uses port-set {
+        refine "psid-offset" {
+          default "0";
+        }
+      }
+    }
+    leaf br-ipv6-addr {
+      type inet:ipv6-address;
+      description
+        "The IPv6 address for lwaftr.";
+    }
+  }
+
+  grouping algorithm {
+    description
+      "Indicate the instances support the MAP-E and MAP-T function.
+      The instances advertise the map-e feature through the
+      capability exchange mechanism when a NETCONF session is
+      established.";
+    container algo-instances {
+      description
+        "A set of MAP-E or MAP-T instances to be configured,
+        applying to BRs and CEs. A MAP-E/T instance defines a MAP
+          domain comprising one or more MAP-CE and MAP-BR";
+      list algo-instance {
+        key "id";
+        description "MAP forwarding rule instance for MAP-E/MAP-T";
+        leaf enable {
+          type boolean;
+          description
+            "Enable/disable individual MAP-E or MAP-T rule.";
+        }
+        container algo-versioning {
+          description "algorithm's version";
+          leaf version {
+            type uint64;
+            description "Incremental version number for the algorithm";
+          }
+          leaf date {
+            type yang:date-and-time;
+            description "Timestamp to the algorithm";
+          }
+        }
+        leaf id {
+          type uint32;
+          mandatory true;
+          description "Algorithm Instance ID";
+        }
+        leaf name {
+          type string;
+          description "The name for the instance.";
+        }
+        choice data-plane {
+          description "Selects MAP-E (encapsulation) or MAP-T (translation)";
+          case encapsulation {
+            description "encapsulation for MAP-E";
+            leaf br-ipv6-addr {
+              type inet:ipv6-address;
+              mandatory true;
+              description
+                "The IPv6 address of the MAP-E BR.";
+            }
+          }
+          case translation {
+            description "translation for MAP-T";
+            leaf dmr-ipv6-prefix {
+              type inet:ipv6-prefix;
+              description
+                "The IPv6 prefix of the MAP-T BR. ";
+            }
+          }
+        }
+        leaf ea-len {
+          type uint8;
+          mandatory true;
+          description
+            "Embedded Address (EA) bits are the IPv4 EA-bits in the IPv6
+            address identify an IPv4 prefix/address (or part thereof) or
+            a shared IPv4 address (or part thereof) and a port-set identifier.
+            The length of the EA-bits is defined as part of a MAP rule for a
+            MAP domain.";
+        }
+        leaf rule-ipv6-prefix {
+          type inet:ipv6-prefix;
+          mandatory true;
+          description
+            "The Rule IPv6 prefix defined in the mapping rule.";
+        }
+        leaf rule-ipv4-prefix {
+          type inet:ipv4-prefix;
+          mandatory true;
+          description
+            "The Rule IPv4 prefix defined in the mapping rule.";
+        }
+        leaf forwarding {
+          type boolean;
+          mandatory true;
+          description
+            "This parameter specifies whether the rule may be used for
+            forwarding (FMR). If set, this rule is used as an FMR;
+          if not set, this rule is a BMR only and must not be used
+            for forwarding.";
+        }
+      }
+    }
+  }
+
+  grouping traffic-stat {
+    description "Traffic statistics";
+    leaf sent-ipv4-packet {
+      type yang:zero-based-counter64;
+      description "Number of decapsulated/translated IPv4 packets sent.";
+    }
+    leaf sent-ipv4-byte {
+      type yang:zero-based-counter64;
+      description "Decapsulated/translated IPv4 traffic sent, in bytes";
+    }
+    leaf sent-ipv6-packet {
+      type yang:zero-based-counter64;
+      description "Number of encapsulated/translated IPv6 packets sent.";
+    }
+    leaf sent-ipv6-byte {
+      type yang:zero-based-counter64;
+      description "Encapsulated/translated IPv6 traffic sent, in bytes";
+    }
+    leaf rcvd-ipv4-packet {
+      type yang:zero-based-counter64;
+      description "Number of IPv4 packets received for processing.";
+    }
+    leaf rcvd-ipv4-byte {
+      type yang:zero-based-counter64;
+      description "IPv4 traffic received for processing, in bytes";
+    }
+    leaf rcvd-ipv6-packet {
+      type yang:zero-based-counter64;
+      description "Number of IPv6 packets received for processing.";
+    }
+    leaf rcvd-ipv6-byte {
+      type yang:zero-based-counter64;
+      config false;
+      description "IPv6 traffic received for processing, in bytes";
+    }
+    leaf dropped-ipv4-packet {
+      type yang:zero-based-counter64;
+      description "Number of IPv4 packets dropped.";
+    }
+    leaf dropped-ipv4-byte {
+      type yang:zero-based-counter64;
+      description "IPv4traffic dropped, in bytes";
+    }
+    leaf dropped-ipv6-packet {
+      type yang:zero-based-counter64;
+      description "Number of IPv4 packets dropped.";
+    }
+    leaf dropped-ipv6-byte {
+      type yang:zero-based-counter64;
+      description "IPv4 traffic dropped, in bytes";
+    }
+    leaf dropped-ipv4-fragments {
+      type yang:zero-based-counter64;
+      description "Number of fragmented IPv4 packets dropped";
+    }
+    leaf dropped-ipv4-bytes {
+      type yang:zero-based-counter64;
+      description "Fragmented IPv4 traffic dropped, in bytes";
+    }
+    leaf ipv6-fragments-reassembled {
+      type yang:zero-based-counter64;
+      description "Number of IPv6 fragments successfully reassembled";
+    }
+    leaf ipv6-fragments-bytes-reassembled {
+      type yang:zero-based-counter64;
+      description "IPv6 fragments successfully reassembled, in bytes";
+    }
+    leaf out-icmpv4-error-packets {
+      type yang:zero-based-counter64;
+      description "Internally generated ICMPv4 error packets.";
+    }
+    leaf out-icmpv6-error-packets {
+      type yang:zero-based-counter64;
+      description "Internally generted ICMPv6 error packets.";
+    }
+  }
+}

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -817,7 +817,7 @@ function resolve(schema, features)
                   -- FIXME: Add additional "must" statements.
                   for _,k in ipairs({'config', 'description', 'reference',
                                      'presence', 'default', 'mandatory',
-                                     'min_elements', 'max-elements'}) do
+                                     'min_elements', 'max_elements'}) do
                      if refine[k] ~= nil then target[k] = refine[k] end
                   end
                end


### PR DESCRIPTION
This PR adds the `ietf-softwire-common` and `ietf-softwire-br` schemas from https://tools.ietf.org/html/draft-ietf-softwire-yang-02.  As part of that, it adds support for the `refine` YANG statement, which is a facility used by this new schema that we hadn't needed before.