### PR TITLE
Fix property-based test stall

### DIFF
--- a/src/program/lwaftr/tests/propbased/genyang.lua
+++ b/src/program/lwaftr/tests/propbased/genyang.lua
@@ -36,26 +36,11 @@ function generate_any(pid, schema)
    -- leaf-list cases (for remove, we need a case with a selector too)
    -- Note: this assumes a list or leaf-list case exists in the schema at all
    elseif cmd == "add" then
-      local query, val, schema
-      local ok = false
-      while not ok do
-         query, val, schema = generate_config_xpath_and_val(schema)
-         if string.match(tostring(val), "^{.*}$") then
-            ok = true
-         end
-      end
-      --local query, val, schema = generate_config_xpath_and_val(schema)
+      local query, val, schema = generate_config_xpath_and_val(schema)
       return string.format("./snabb config add -s %s %s \"%s\" \"%s\"",
                            schema, pid, query, val)
    else
-      local query, val, schema
-      local ok = false
-      while not ok do
-         query, val, schema = generate_config_xpath_and_val(schema)
-         if string.match(query, "[]]$") then
-            ok = true
-         end
-      end
+      local query, val, schema = generate_config_xpath_and_val(schema)
       return string.format("./snabb config remove -s %s %s \"%s\"",
                            schema, pid, query)
    end
@@ -297,6 +282,7 @@ local function generate_xpath_and_node_info(schema, for_state)
       if handler then handler(node) end
    end
    local function visit_body(node)
+      if not node then return end
       local ids = {}
       for id, node in pairs(node.body) do
          -- only choose nodes that are used in configs unless

--- a/src/program/lwaftr/tests/subcommands/run_test.py
+++ b/src/program/lwaftr/tests/subcommands/run_test.py
@@ -22,9 +22,8 @@ class TestRun(BaseTestCase):
     )
 
     def test_run(self):
-        output = self.run_cmd(self.cmd_args)
-        self.assertIn(b'link report', output,
-            b'\n'.join((b'OUTPUT', output)))
+        output = self.run_cmd(self.cmd_args).decode(ENC)
+        self.assertIn("Migrating instance", output)
 
     def test_run_on_a_stick_migration(self):
         # The LwAFTR should be abel to migrate from non-on-a-stick -> on-a-stick


### PR DESCRIPTION
Here is a fix that prevents the property-based tests to get stalled. I'm not sure whether the fix is correct though.

The reason why the tests got stalled was an infinite loop when cmd == "add" or cmd == "remove". In those cases the random query is compared to a regular expression. What I observed while debugging is that some times this expression is "br-instances" and since it doesn't match the regular expression, there's another try, but the same string is returned again turning into an infinite loop.

I fixed the issue by simply removing the loops and trying out whatever query is generated.