### PR TITLE
Process tree runs data-plane processes with busywait=true by default

### DIFF
--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -40,7 +40,7 @@ local manager_config_spec = {
    -- Could relax this requirement.
    initial_configuration = {required=true},
    schema_name = {required=true},
-   worker_default_scheduling = {default={busywait=true}},
+   worker_default_scheduling = {default={}},
    default_schema = {},
    log_level = {default=default_log_level},
    rpc_trace_file = {},

--- a/src/lib/scheduling.lua
+++ b/src/lib/scheduling.lua
@@ -16,7 +16,7 @@ local scheduling_opts = {
    cpu = {},                  -- CPU index (integer).
    real_time = {},            -- Boolean.
    ingress_drop_monitor = {}, -- Action string: one of 'flush' or 'warn'.
-   busywait = {},             -- Boolean.
+   busywait = {default=true}, -- Boolean.
    j = {},                    -- Profiling argument string, e.g. "p" or "v".
    eval = {}                  -- String.
 }
@@ -99,7 +99,7 @@ end
 function selftest ()
    print('selftest: lib.scheduling')
    loadstring(stage({}))()
-   loadstring(stage({busywait=true}))()
+   loadstring(stage({busywait=false}))()
    loadstring(stage({eval='print("lib.scheduling: eval test")'}))()
    print('selftest: ok')
 end


### PR DESCRIPTION
Fixes a bug where `snabb lwaftr run` was running data-plane processes with the default busywait=false :/