### PR TITLE
Reenable alarm notification

### DIFF
--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -290,8 +290,7 @@ end
 function Manager:rpc_set_alarm_operator_state (args)
    local function getter()
       if args.schema ~= self.schema_name then
-         return false, ("Set-operator-state operation not supported in"..
-                        "'%s' schema"):format(args.schema)
+         error(("Set-operator-state operation not supported in '%s' schema"):format(args.schema))
       end
       local key = {resource=args.resource, alarm_type_id=args.alarm_type_id,
                    alarm_type_qualifier=args.alarm_type_qualifier}
@@ -305,8 +304,7 @@ end
 function Manager:rpc_purge_alarms (args)
    local function purge()
       if args.schema ~= self.schema_name then
-         return false, ("Purge-alarms operation not supported in"..
-                        "'%s' schema"):format(args.schema)
+         error(("Purge-alarms operation not supported in '%s' schema"):format(args.schema))
       end
       return { purged_alarms = alarms.purge_alarms(args) }
    end
@@ -317,8 +315,7 @@ end
 function Manager:rpc_compress_alarms (args)
    local function compress()
       if args.schema ~= self.schema_name then
-         return false, ("Compress-alarms operation not supported in"..
-                        "'%s' schema"):format(args.schema)
+         error(("Compress-alarms operation not supported in '%s' schema"):format(args.schema))
       end
       return { compressed_alarms = alarms.compress_alarms(args) }
    end

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -202,7 +202,7 @@ function alarm_list:set_defaults_if_any (key)
    k = alarm_type_keys:normalize(key)
    local default = self.defaults[k]
    if default then
-      for k,v in pairs(defaults) do
+      for k,v in pairs(default) do
          self.list[key][k] = v
       end
    end

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -587,13 +587,11 @@ local function compute_worker_configs(conf)
 end
 
 function ptree_manager(f, conf, manager_opts)
-   -- Always enabled in reconfigurable mode.
-   alarm_notification = true
-
    local function setup_fn(conf)
       local worker_app_graphs = {}
       for worker_id, worker_config in pairs(compute_worker_configs(conf)) do
          local app_graph = config.new()
+         worker_config.alarm_notification = true
          f(app_graph, worker_config)
          worker_app_graphs[worker_id] = app_graph
       end


### PR DESCRIPTION
After the latest changes in ptree, alarm notification was no longer enabled. These patches reenable alarm notification by default and fixes other issues.
