### PR TITLE
Fix flaky test generate-binding-table-test

### DIFF
--- a/src/program/lwaftr/tests/subcommands/generate_binding_table_test.py
+++ b/src/program/lwaftr/tests/subcommands/generate_binding_table_test.py
@@ -5,6 +5,7 @@ just to produce a binding table config result.
 """
 
 from test_env import ENC, SNABB_CMD, BaseTestCase
+import subprocess
 
 NUM_SOFTWIRES = 10
 
@@ -24,8 +25,13 @@ class TestGenerateBindingTable(BaseTestCase):
 
         <ipv4> <num_ipv4s> <br_address> <b4> <psid_len> <shift>
         """
-        # Get generate-binding-table command output.
-        output = self.run_cmd(self.generation_args)
+        # https://stackoverflow.com/questions/1606795/catching-stdout-in-realtime-from-subprocess
+        # See 'rules of thumb for subprocess'.
+        proc = subprocess.Popen(self.generation_args,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)
+        output, err = proc.communicate()
+        assert(proc.returncode == 0)
 
         # Split it into lines.
         config = str(output, ENC).split('\n')[:-1]


### PR DESCRIPTION
Another flaky test fix.

What hangs tests some times is the inability to get the a child process output. The process gets stalled forever until it eventually times out. I followed some rules of thumb on how to use Python's Popen. One of the rules is to not redirect stderr to a Pipe.

I run this test many times after this fix and I didn't get a hang. In any case, I'm not 100% sure this will fix the test forever.