### PR TITLE
dasm: Error when a 64-bit value is used as a 32-bit immediate

### DIFF
--- a/src/dasm.lua
+++ b/src/dasm.lua
@@ -106,7 +106,10 @@ local int_ct = ffi.typeof'int'
 local function convert_arg(arg)   --dasm_put() accepts only int32 varargs.
 	if type(arg) == "number" then  --but we make it accept uint32 too by normalizing the arg.
 		arg = bit.tobit(arg)        --non-number args are converted to int32 according to ffi rules.
-	end
+        elseif type(arg) == "cdata" and ffi.sizeof(arg) > 4 then
+		-- avoid truncating 64-bit FFI values
+		err("cannot coerce value to 32-bit immediate (consider 'mov64'): ", tostring(arg))
+        end
 	return ffi.cast(int_ct, arg)
 end
 local function convert_args(...) --not a tailcall but at least it doesn't make any garbage

--- a/src/dasm_x86.lua
+++ b/src/dasm_x86.lua
@@ -2114,8 +2114,8 @@ if x64 then
     local psz, sk = wputop(sz, opcode, rex, nil, vreg)
     wvreg("opcode", vreg, psz, sk)
     if luamode then
-      waction("IMM_D", format("ffi.cast(\"uintptr_t\", %s) %% 2^32", op64))
-      waction("IMM_D", format("ffi.cast(\"uintptr_t\", %s) / 2^32", op64))
+      waction("IMM_D", format("ffi.cast(\"uint32_t\", ffi.cast(\"uintptr_t\", %s) %% 2^32)", op64))
+      waction("IMM_D", format("ffi.cast(\"uint32_t\", ffi.cast(\"uintptr_t\", %s) / 2^32)", op64))
     else
       waction("IMM_D", format("(unsigned int)(%s)", op64))
       waction("IMM_D", format("(unsigned int)((%s)>>32)", op64))


### PR DESCRIPTION
If a 64-bit value is provided as a 32-bit immediate operand for a DynASM
instruction then error. The previous behavior was to automatically
truncate to 32-bit.

This is particularly significant for GC64 mode where pointers to
objects created by `ffi.new()` cannot be safely truncated to 32 bits.

The solution for referencing 64-bit immediates is to use 'mov64' and
this is suggested in the error message.