### PR TITLE
[WIP] Compile large binding-table

### DIFF
--- a/src/lib/yang/parser.lua
+++ b/src/lib/yang/parser.lua
@@ -53,11 +53,17 @@ local function end_pos (str)
    if type(str) == "string" then
       return #str
    end
+   if type(str) == "table" then
+      return str:end_pos()
+   end
 end
 
 local function read_char (str, pos)
    if type(str) == "string" then
       return str:sub(pos, pos)
+   end
+   if type(str) == "table" then
+      return str:read(1)
    end
 end
 
@@ -91,6 +97,9 @@ end
 local function read_string (str, start_index, end_index)
    if type(str) == "string" then
       return str:sub(start_index, end_index)
+   end
+   if type(str) == "table" then
+      return str:read(end_index - start_index)
    end
 end
 

--- a/src/lib/yang/parser.lua
+++ b/src/lib/yang/parser.lua
@@ -32,6 +32,7 @@ local lib = require('core.lib')
 
 Parser = {}
 function Parser.new(str, filename)
+   assert(type(str) == "string" or type(str) == "table")
    local ret = {pos=1, str=str, filename=filename, line=1, column=0, line_pos=1}
    ret = setmetatable(ret, {__index = Parser})
    ret.peek_char = ret:read_char()
@@ -43,8 +44,16 @@ function Parser:loc()
                         self.column)
 end
 
+local function last_line (p)
+   if type(p.str) == "string" then
+      return p.str:match("[^\n]*", p.line_pos)
+   else
+      return p.str:substr(p.line_pos, p.str:index(p.line_pos, '\n'))
+   end
+end
+
 function Parser:error(msg, ...)
-   print(self.str:match("[^\n]*", self.line_pos))
+   print(last_line(self))
    print(string.rep(" ", self.column).."^")
    error(('%s: error: '..msg):format(self:loc(), ...))
 end

--- a/src/lib/yang/parser.lua
+++ b/src/lib/yang/parser.lua
@@ -49,9 +49,21 @@ function Parser:error(msg, ...)
    error(('%s: error: '..msg):format(self:loc(), ...))
 end
 
+local function end_pos (str)
+   if type(str) == "string" then
+      return #str
+   end
+end
+
+local function read_char (str, pos)
+   if type(str) == "string" then
+      return str:sub(pos, pos)
+   end
+end
+
 function Parser:read_char()
-   if self.pos <= #self.str then
-      local ret = self.str:sub(self.pos,self.pos)
+   if self.pos <= end_pos(self.str) then
+      local ret = read_char(self.str, self.pos)
       self.pos = self.pos + 1
       return ret
    end
@@ -76,12 +88,18 @@ function Parser:next()
    return chr
 end
 
+local function read_string (str, start_index, end_index)
+   if type(str) == "string" then
+      return str:sub(start_index, end_index)
+   end
+end
+
 function Parser:peek_n(n)
    local end_index = self.pos + n - 1
-   if end_index < #self.str then
-      return self:peek() .. self.str:sub(self.pos, (end_index - 1))
+   if end_index >= end_pos(self.str) then
+      end_index = end_pos(self.str)
    end
-   return self:peek() .. self.str:sub(self.pos)
+   return self:peek() .. read_string(self.str, self.pos, (end_index - 1))
 end
 
 function Parser:check(expected)

--- a/src/lib/yang/stream.lua
+++ b/src/lib/yang/stream.lua
@@ -4,7 +4,10 @@ local ffi = require("ffi")
 local S = require("syscall")
 local lib = require("core.lib")
 
-local function round_up(x, y) return y*math.ceil(x/y) end
+local function round_up(x, y)
+   local x, y = tonumber(x), tonumber(y)
+   return y*math.ceil(x/y)
+end
 
 function open_output_byte_stream(filename)
    local fd, err =

--- a/src/lib/yang/stream.lua
+++ b/src/lib/yang/stream.lua
@@ -140,8 +140,8 @@ function open_input_byte_stream(filename)
       return ffi.cast(ffi.typeof('$*', type),
                       ret:read(ffi.sizeof(type) * count))
    end
-   function ret:read_char()
-      return ffi.string(ret:read(1), 1)
+   function ret:read_char(n)
+      return ffi.string(ret:read(n), n)
    end
    function ret:read_string()
       local count = size - pos
@@ -155,11 +155,12 @@ function open_input_byte_stream(filename)
          mtime_sec = ret.mtime_sec,
          mtime_nsec = ret.mtime_nsec,
          read = function(self, n)
-            assert(n==1)
+            n = n or 1
             if pos == end_pos then return nil end
-            return ret:read_char()
+            return ret:read_char(n)
          end,
-         close = function() ret:close() end
+         close = function() ret:close() end,
+         end_pos = function() return end_pos end,
       }
    end
    return ret

--- a/src/lib/yang/stream.lua
+++ b/src/lib/yang/stream.lua
@@ -161,6 +161,24 @@ function open_input_byte_stream(filename)
          end,
          close = function() ret:close() end,
          end_pos = function() return end_pos end,
+         substr = function (self, i, j)
+            assert(j > i)
+            ret:seek(i)
+            local size = j - i
+            local str = ffi.string(ret:read(size), size)
+            ret:seek(pos)
+            return str
+         end,
+         index = function (self, start, needle)
+            ret:seek(start)
+            for i=start,end_pos do
+               if self:read() == needle then
+                  ret:seek(pos)
+                  return i
+               end
+            end
+            ret:seek(pos)
+         end,
       }
    end
    return ret

--- a/src/lib/yang/yang.lua
+++ b/src/lib/yang/yang.lua
@@ -117,12 +117,11 @@ function load_configuration(filename, opts)
    end
 
    -- Load and compile it.
-   local source_str = source:read_string()
-   source:close()
+   local source_str = source:as_text_stream()
    log('loading source configuration')
    local conf = load_config_for_schema_by_name(opts.schema_name, source_str,
                                                filename)
-
+   source:close()
    if use_compiled_cache then
       -- Save it, if we can.
       local success, err = pcall(binary.compile_config_for_schema_by_name,


### PR DESCRIPTION
Fixes https://github.com/Igalia/snabb/issues/948

Compile large binding tables (for instance, a binding table with 40M softwires) is not possible since the binding table is converted to a Lua string and surpasses the maximum string length (near 2Gb).

This PR adapts the parser to allow using a text stream to fetch the contents of the binding table. It works fine with the 1M binding-table. However when building a large binding table, the object file is generated but and assert is triggered at https://github.com/Igalia/snabb/blob/lwaftr/src/lib/yang/binary.lua#L72.

```bash
lwaftr-40m.conf: loading compiled configuration from lwaftr-40m.o                       
lwaftr-40m.conf: failed to load compiled configuration: lib/yang/binary.lua:72: assertion failed!                                                                               
lwaftr-40m.conf: loading source configuration               
```
I debugged the assert to check what's going on:

```
lwaftr-40m.conf: loading compiled configuration from lwaftr-40m.o                       
lwaftr-40m.conf: failed to load compiled configuration: lib/yang/binary.lua:72: 677 == 4                                                                                        
lwaftr-40m.conf: loading source configuration      
```
