### PR TITLE
Fix undefined variable

### DIFF
--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -196,7 +196,7 @@ function run(args)
          local ipv4_rx = opts.hydra and 'ipv4tx' or 'IPv4 TX'
          local ipv6_tx = opts.hydra and 'ipv6rx' or 'IPv6 RX'
          local ipv6_rx = opts.hydra and 'ipv6tx' or 'IPv6 TX'
-         if use_splitter then
+         if requires_splitter(opts, conf) then
             csv:add_app('v4v6', { 'v4', 'v4' }, { tx=ipv4_tx, rx=ipv4_rx })
             csv:add_app('v4v6', { 'v6', 'v6' }, { tx=ipv6_tx, rx=ipv6_rx })
          else


### PR DESCRIPTION
Variable `use_splitter` was undefined when running the lwaftr in on-a-stick mode and activating the verbose flag:

```
$ sudo ./snabb lwaftr run --cpu 11 --name lwaftr --conf lwaftr.conf --on-a-stick 82:00.0 -v
lwaftr.conf: loading compiled configuration from lwaftr.o
lwaftr.conf: compiled configuration is up to date.
Migrating instance 'test' to '82:00.0'
Bound main process to NUMA node:        1
program/lwaftr/run/run.lua:199: variable 'use_splitter' is not declared
```