### PR TITLE
Generic support of influxdb format

### DIFF
--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -1047,7 +1047,13 @@ function influxdb_printer_from_grammar(production, print_default, root)
       local path, keyword = entry.path, entry.keyword
       local value = entry.value
       if not file.is_tag then value = escape_value(entry.primitive_type, value) end
-      file:write(entry.is_unique and keyword or path..keyword)
+      if entry.is_unique then
+         file:write(keyword)
+      else
+         path = path..keyword
+         if not file.is_tag then path = '/'..path end
+         file:write(path)
+      end
       if entry.tags then file:write(','..entry.tags) end
       file:write(file.is_tag and value or ' value='..value)
       file:write('\n')
@@ -1595,7 +1601,7 @@ local function influxdb_printer_tests ()
             bar {baz "baz"; y "y"; z "z";}
          }
       ]], [[
-         foo/bar/y,baz=baz value="y"
+         /foo/bar/y,baz=baz value="y"
          z,baz=baz value="z"
          x value="x"
          y value="y"
@@ -1621,12 +1627,12 @@ local function influxdb_printer_tests ()
             }
          }
       ]], [[
-         continents/asia/country/capital,continents/asia/country/name=japan value="tokyo"
-         continents/europe/country/capital,continents/europe/country/name=uk value="london"
-         continents/europe/country/eu-member,continents/europe/country/name=uk value=true
-         continents/europe/country/gdp,continents/europe/country/name=uk value=2914000000
-         continents/europe/country/main-cities,continents/europe/country/name=uk value="\"Manchester\", \"Bristol\", \"Liverpool\""
-         continents/europe/country/population,continents/europe/country/name=uk value=65000000i
+         /continents/asia/country/capital,continents/asia/country/name=japan value="tokyo"
+         /continents/europe/country/capital,continents/europe/country/name=uk value="london"
+         /continents/europe/country/eu-member,continents/europe/country/name=uk value=true
+         /continents/europe/country/gdp,continents/europe/country/name=uk value=2914000000
+         /continents/europe/country/main-cities,continents/europe/country/name=uk value="\"Manchester\", \"Bristol\", \"Liverpool\""
+         /continents/europe/country/population,continents/europe/country/name=uk value=65000000i
       ]]},
       {test_schema,
       [[
@@ -1634,7 +1640,7 @@ local function influxdb_printer_tests ()
             allow-user "jane";
          }
       ]], [[
-         users/allow-user,%position=1 value=jane
+         /users/allow-user,%position=1 value=jane
       ]]},
       {test_schema,
       [[
@@ -1645,8 +1651,8 @@ local function influxdb_printer_tests ()
             }
          }
       ]], [[
-         nested-list/bar/foo,%position=1 value=john
-         nested-list/foo,%position=1 value=jane
+         /nested-list/bar/foo,%position=1 value=john
+         /nested-list/foo,%position=1 value=jane
       ]]},
    }
    for _, each in ipairs(tests) do

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -1627,7 +1627,7 @@ local function influxdb_printer_tests ()
             }
          }
       ]], [[
-         /continents/asia/country/capital,continents/asia/country/name=japan value="tokyo"
+         capital,name=japan value="tokyo"
          /continents/europe/country/capital,continents/europe/country/name=uk value="london"
          /continents/europe/country/eu-member,continents/europe/country/name=uk value=true
          /continents/europe/country/gdp,continents/europe/country/name=uk value=2914000000

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -1012,6 +1012,227 @@ function xpath_printer_from_grammar(production, print_default, root)
 end
 xpath_printer_from_grammar = util.memoize(xpath_printer_from_grammar)
 
+function influxdb_printer_from_grammar(production, print_default, root)
+   if #root == 1 and root:sub(1, 1) == '/' then
+      root = ''
+   end
+   local handlers = {}
+   local translators = {}
+   local function printer(keyword, production, printers)
+      return assert(handlers[production.type])(keyword, production, printers)
+   end
+   local function print_keyword(k, file, path)
+      path = path:sub(1, 1) ~= '[' and root..'/'..path or root..path
+      file:write(path)
+      print_yang_string(k, file)
+      file:write(' ')
+   end
+   local function body_printer(productions, order)
+      -- Iterate over productions trying to translate to other statements. This
+      -- is used for example in choice statements raising the lower statements
+      -- in case blocks up to the level of the choice, in place of the choice.
+      local translated = {}
+      for keyword,production in pairs(productions) do
+         local translator = translators[production.type]
+         if translator ~= nil then
+            local statements = translator(keyword, production)
+            for k,v in pairs(statements) do translated[k] = v end
+         else
+            translated[keyword] = production
+         end
+      end
+      productions = translated
+      if not order then
+         order = {}
+         for k,_ in pairs(productions) do table.insert(order, k) end
+         table.sort(order)
+      end
+      local printers = {}
+      for keyword,production in pairs(productions) do
+         local printer = printer(keyword, production, printers)
+         if printer ~= nil then
+            printers[keyword] = printer
+         end
+      end
+      return function(data, file, indent)
+         for _,k in ipairs(order) do
+            local v = data[normalize_id(k)]
+            if v ~= nil then printers[k](v, file, indent) end
+         end
+      end
+   end
+   local function key_composer (productions, order)
+      local printer = body_printer(productions, order)
+      local file = {t={}}
+      function file:write (str)
+         str = str:match("([^%s]+)")
+         if str and #str > 0 and str ~= ";" and str ~= root..'/' then
+            table.insert(self.t, str)
+         end
+      end
+      function file:flush ()
+         local ret = {}
+         for i=1,#self.t,2 do
+            local key, value = self.t[i], self.t[i+1]
+            table.insert(ret, '['..key.."="..value..']')
+         end
+         self.t = {}
+         return table.concat(ret, '')
+      end
+      return function (data, path)
+         path = path or ''
+         printer(data, file, path)
+         return file:flush()
+      end
+   end
+   function translators.choice(keyword, production)
+      local rtn = {}
+      for case, body in pairs(production.choices) do
+         for name, statement in pairs(body) do
+            rtn[name] = statement
+         end
+      end
+      return rtn
+   end
+   function handlers.struct(keyword, production)
+      local print_body = body_printer(production.members)
+      return function(data, file, path)
+         print_body(data, file, path..keyword..'/')
+      end
+   end
+   function handlers.array(keyword, production)
+      local serialize = value_serializer(production.element_type)
+      return function(data, file, indent)
+         local count = 1
+         for _,v in ipairs(data) do
+            print_keyword(keyword.."[position()="..count.."]", file, '')
+            print_yang_string(serialize(v), file)
+            file:write('\n')
+            count = count + 1
+         end
+      end
+   end
+   -- As a special case, the table handler allows the keyword to be nil,
+   -- for printing tables at the top level without keywords.
+   function handlers.table(keyword, production)
+      local key_order, value_order = {}, {}
+      for k,_ in pairs(production.keys) do table.insert(key_order, k) end
+      for k,_ in pairs(production.values) do table.insert(value_order, k) end
+      table.sort(key_order)
+      table.sort(value_order)
+      local compose_key = key_composer(production.keys, key_order)
+      local print_value = body_printer(production.values, value_order)
+      if production.key_ctype and production.value_ctype then
+         return function(data, file, path)
+            path = path or ''
+            for entry in data:iterate() do
+               local key = compose_key(entry.key)
+               local path = path..(keyword or '')..key..'/'
+               print_value(entry.value, file, path)
+            end
+         end
+      elseif production.string_key then
+         local id = normalize_id(production.string_key)
+         return function(data, file, path)
+            path = path or ''
+            for key, value in pairs(data) do
+               local key = compose_key({[id]=key})
+               local path = path..(keyword or '')..key..'/'
+               print_value(value, file, path)
+            end
+         end
+      elseif production.key_ctype then
+         return function(data, file, path)
+            path = path or ''
+            for key, value in cltable.pairs(data) do
+               local key = compose_key(key)
+               local path = path..(keyword or '')..key..'/'
+               print_value(value, file, path)
+            end
+         end
+      else
+         return function(data, file, path)
+            path = path or ''
+            for key, value in pairs(data) do
+               local key = compose_key(key)
+               local path = path..(keyword or '')..key..'/'
+               print_value(value, file, path)
+            end
+         end
+      end
+   end
+   function handlers.scalar(keyword, production)
+      local serialize = value_serializer(production.argument_type)
+      return function(data, file, path)
+         local str = serialize(data)
+         if print_default or str ~= production.default then
+            print_keyword(keyword, file, path)
+            print_yang_string(str, file)
+            file:write('\n')
+         end
+      end
+   end
+
+   local top_printers = {}
+   function top_printers.struct(production)
+      local printer = body_printer(production.members)
+      return function(data, file)
+         printer(data, file, '')
+         return file:flush()
+      end
+   end
+   function top_printers.sequence(production)
+      local printers = {}
+      for k,v in pairs(production.members) do
+         printers[k] = printer(k, v)
+      end
+      return function(data, file)
+         for _,elt in ipairs(data) do
+            local id = assert(elt.id)
+            assert(printers[id])(elt.data, file, '')
+         end
+         return file:flush()
+      end
+   end
+   function top_printers.table(production)
+      local printer = handlers.table(nil, production)
+      return function(data, file)
+         printer(data, file, '')
+         return file:flush()
+      end
+   end
+   function top_printers.array(production)
+      local serialize = value_serializer(production.element_type)
+      return function(data, file, indent)
+         local count = 1
+         for _,v in ipairs(data) do
+            file:write(root.."[position()="..count.."]")
+            file:write(' ')
+            print_yang_string(serialize(v), file)
+            file:write('\n')
+            count = count + 1
+         end
+         return file:flush()
+      end
+   end
+   function top_printers.scalar(production)
+      local serialize = value_serializer(production.argument_type)
+      return function(data, file)
+         local str = serialize(data)
+         if print_default or str ~= production.default then
+            file:write(root)
+            file:write(' ')
+            print_yang_string(str, file)
+            file:write('\n')
+            return file:flush()
+         end
+      end
+   end
+
+   return assert(top_printers[production.type])(production)
+end
+influxdb_printer_from_grammar = util.memoize(influxdb_printer_from_grammar)
+
 function data_printer_from_grammar(production, print_default)
    local handlers = {}
    local translators = {}

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -1545,15 +1545,21 @@ local function influxdb_printer_tests ()
             }
          }
          container continents {
-            list europe {
-               key country;
-               leaf country { type string; }
-               leaf capital { type string; }
+            grouping country {
+               list country {
+                  key name;
+                  leaf name { type string; mandatory true; }
+                  leaf capital { type string; }
+                  leaf gdp { type decimal64; }
+                  leaf eu-member { type boolean; }
+                  leaf main-cities { type string; }
+               }
             }
-            list asia {
-               key country;
-               leaf country { type string; }
-               leaf capital { type string; }
+            container europe {
+               uses country;
+            }
+            container asia {
+               uses country;
             }
          }
          container users {
@@ -1591,12 +1597,28 @@ local function influxdb_printer_tests ()
       {test_schema,
       [[
          continents {
-            europe {country "uk"; capital "london";}
-            asia   {country "japan"; capital "tokyo";}
+            europe {
+               country {
+                  name "uk";
+                  capital "london";
+                  eu-member true;
+                  main-cities "\"Manchester\", \"Bristol\", \"Liverpool\"";
+                  gdp 2.914e9;
+               }
+            }
+            asia {
+               country {
+                  name "japan";
+                  capital "tokyo";
+               }
+            }
          }
       ]], [[
-         continents/asia/capital,continents/asia/country=japan value="tokyo"
-         continents/europe/capital,continents/europe/country=uk value="london"
+         continents/asia/country/capital,continents/asia/country/name=japan value="tokyo"
+         continents/europe/country/capital,continents/europe/country/name=uk value="london"
+         continents/europe/country/eu-member,continents/europe/country/name=uk value=true
+         continents/europe/country/gdp,continents/europe/country/name=uk value=2914000000.00
+         continents/europe/country/main-cities,continents/europe/country/name=uk value="\"Manchester\", \"Bristol\", \"Liverpool\""
       ]]},
       {test_schema,
       [[

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -1074,7 +1074,9 @@ function influxdb_printer_from_grammar(production, print_default, root)
          local ret = {}
          for i=1,#self.t,2 do
             local key, value = self.t[i], self.t[i+1]
-            table.insert(ret, '['..key.."="..value..']')
+            if key and value then
+               table.insert(ret, '['..key.."="..value..']')
+            end
          end
          self.t = {}
          return table.concat(ret, '')

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -792,6 +792,7 @@ local function print_yang_string(str, file)
 end
 
 function xpath_printer_from_grammar(production, print_default, root)
+   if not root then root = '' end
    if #root == 1 and root:sub(1, 1) == '/' then
       root = ''
    end
@@ -1013,7 +1014,8 @@ end
 xpath_printer_from_grammar = util.memoize(xpath_printer_from_grammar)
 
 function influxdb_printer_from_grammar(production, print_default, root)
-   if #root == 1 and root:sub(1, 1) == '/' then
+   if not root then root = '' end
+   if root and #root == 1 and root:sub(1, 1) == '/' then
       root = ''
    end
    local handlers = {}

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -1132,7 +1132,7 @@ function influxdb_printer_from_grammar(production, print_default, root)
       return function(data, file, path, tags)
          local count = 1
          for _,v in ipairs(data) do
-            local tag, value = 'position='..count, serialize(v)
+            local tag, value = '%position='..count, serialize(v)
             local tags = tags and tags..','..tag or tag
             print_entry(file, {keyword=keyword, tags=tags, value=value,
                                path=path, is_unique=production.is_unique,
@@ -1249,7 +1249,7 @@ function influxdb_printer_from_grammar(production, print_default, root)
       return function(data, file, path, tags)
          local count = 1
          for _,v in ipairs(data) do
-            local tag, value = 'position='..count, serialize(v)
+            local tag, value = '%position='..count, serialize(v)
             local tags = tags and tags..','..tag or tag
             print_entry(file, {keyword=keyword, tags=tags, value=value,
                                path=path, is_unique=production.is_unique,
@@ -1604,7 +1604,7 @@ local function influxdb_printer_tests ()
             allow-user "jane";
          }
       ]], [[
-         users/allow-user,position=1 value=jane
+         users/allow-user,%position=1 value=jane
       ]]},
       {test_schema,
       [[
@@ -1615,8 +1615,8 @@ local function influxdb_printer_tests ()
             }
          }
       ]], [[
-         nested-list/bar/foo,position=1 value=john
-         nested-list/foo,position=1 value=jane
+         nested-list/bar/foo,%position=1 value=john
+         nested-list/foo,%position=1 value=jane
       ]]},
    }
    for _, each in ipairs(tests) do

--- a/src/lib/yang/path_data.lua
+++ b/src/lib/yang/path_data.lua
@@ -152,6 +152,8 @@ local function printer_for_grammar(grammar, path, format, print_default)
    local printer
    if format == "xpath" then
       printer = data.xpath_printer_from_grammar(subgrammar, print_default, path)
+   elseif format == "influxdb" then
+      printer = data.influxdb_printer_from_grammar(subgrammar, print_default, path)
    else
       printer = data.data_printer_from_grammar(subgrammar, print_default)
    end

--- a/src/program/config/common.lua
+++ b/src/program/config/common.lua
@@ -76,7 +76,7 @@ function parse_command_line(args, opts)
    function handlers.r(arg) ret.revision_date = arg end
    function handlers.c(arg) ret.socket = arg end
    function handlers.f(arg)
-      assert(arg == "yang" or arg == "xpath", "Not valid output format")
+      assert(arg == "yang" or arg == "xpath" or arg == "influxdb", "Not valid output format")
       ret.format = arg
    end
    handlers['print-default'] = function ()


### PR DESCRIPTION
Supersedes #1037.

To recap, an influxdb entry meets the following formatting:

```
ULEAF(,K=V)* value=VALUE
```

Where ULEAF in an unique leaf in the schema. If the leaf is not unique, ULEAF is the absolute path to the leaf. The same idea is applied to keys of tags.

Leaves and keys uniqueness is a property of the schema, not the data.

Here's a WIP implementation. So far, the influxdb printer inherits the same structure as YANG and XML printers. The main difference is decorating grammar nodes with an extra function that tells whether the node is duplicated in the schema or not. Initially I wanted the method to return the full path for the node, but this is not a good idea cause due to the use of `group` and `uses` keywords in YANG there are nodes that are single instances in the schema. If I decorate the node with a function that returns the full path value, the value will be the same independently of what route was taken to reach the node. 

Example:

```
$ sudo ./snabb lwaftr run --name lwaftr --conf lwaftr.conf --on-a-stick 82:00.0
```

```
$ sudo ./snabb config get-state --schema=snabb-softwire-v2 --format=influxdb lwaftr /
softwire-config/instance/softwire-state/drop-all-ipv4-iface-bytes,device=82:00.0 value=0
softwire-config/instance/softwire-state/drop-all-ipv4-iface-packets,device=82:00.0 value=0
softwire-config/instance/softwire-state/drop-all-ipv6-iface-bytes,device=82:00.0 value=0
softwire-config/instance/softwire-state/drop-all-ipv6-iface-packets,device=82:00.0 value=0
softwire-state/drop-all-ipv4-iface-bytes value=0
softwire-state/drop-all-ipv4-iface-packets value=0
softwire-state/drop-all-ipv6-iface-bytes value=0
softwire-state/drop-all-ipv6-iface-packets value=0
```

Uniqueness of keys is pending.
