### PR TITLE
Rewrite ptree handling of peers using fibers

### DIFF
--- a/src/lib/fibers/epoll.lua
+++ b/src/lib/fibers/epoll.lua
@@ -52,6 +52,11 @@ function Epoll:poll(timeout)
    return reviter, events, count
 end
 
+function Epoll:close()
+   self.fd:close()
+   self.fd = nil
+end
+
 function selftest()
    print('selftest: lib.fibers.epoll')
    local lib = require('core.lib')

--- a/src/lib/fibers/op.lua
+++ b/src/lib/fibers/op.lua
@@ -52,6 +52,14 @@ function CompleteTask:run()
    end
 end
 
+-- A complete task can also be cancelled, which makes it complete with a
+-- call to "error".
+function CompleteTask:cancel(reason)
+   if self.suspension:waiting() then
+      self.suspension:complete(error, reason or 'cancelled')
+   end
+end
+
 -- An operation represents the potential for synchronization with some
 -- external party.  An operation has to be instantiated by its "perform"
 -- method, as if it were a thunk.  Note that Concurrent ML uses the term

--- a/src/lib/fibers/sched.lua
+++ b/src/lib/fibers/sched.lua
@@ -15,6 +15,9 @@ function new()
    function timer_task_source:schedule_tasks(sched, now)
       self.wheel:advance(now, sched)
    end
+   function timer_task_source:cancel_all_tasks(sched)
+      -- Implement me!
+   end
    ret:add_task_source(timer_task_source)
    return ret
 end
@@ -50,6 +53,15 @@ function Scheduler:run(now)
       self.cur[i] = nil
       task:run()
    end
+end
+
+function Scheduler:shutdown()
+   for i=1,100 do
+      for i=1,#self.sources do self.sources[i]:cancel_all_tasks(self) end
+      if #self.next == 0 then return true end
+      self:run()
+   end
+   return false
 end
 
 function selftest ()

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -14,6 +14,9 @@ local cltable = require("lib.cltable")
 local cpuset = require("lib.cpuset")
 local scheduling = require("lib.scheduling")
 local mem = require("lib.stream.mem")
+local socket = require("lib.stream.socket")
+local fiber = require("lib.fibers.fiber")
+local sched = require("lib.fibers.sched")
 local yang = require("lib.yang.yang")
 local util = require("lib.yang.util")
 local schema = require("lib.yang.schema")
@@ -164,7 +167,54 @@ end
 function Manager:start ()
    if self.name then engine.claim_name(self.name) end
    self.cpuset:bind_to_numa_node()
-   self.socket = open_socket(self.socket_file_name)
+   require('lib.fibers.file').install_poll_io_handler()
+   self.sched = fiber.current_scheduler
+   local sockname = self.socket_file_name
+   local sock = socket.listen_unix(sockname)
+   local parent_close = sock.close
+   function sock:close()
+      parent_close(sock)
+      S.unlink(sockname)
+   end
+   fiber.spawn(function () self:accept_peers(sock) end)
+end
+
+function Manager:call_with_cleanup(closeable, f, ...)
+   local ok, err = pcall(f, ...)
+   closeable:close()
+   if not ok then self:warn('%s', tostring(err)) end
+end
+
+function Manager:accept_peers (sock)
+   self:call_with_cleanup(sock, function()
+      while true do
+         local peer = sock:accept()
+         fiber.spawn(function() self:handle_peer(peer) end)
+      end
+   end)
+end
+
+function Manager:handle_peer(peer)
+   self:call_with_cleanup(peer, function()
+      while true do
+         local prefix = peer:read_line('discard')
+         if prefix == nil then return end -- EOF.
+         local len = assert(tonumber(prefix), 'not a number: '..prefix)
+         assert(tostring(len) == prefix, 'bad number: '..prefix)
+         -- FIXME: Use a streaming parse.
+         local request = peer:read_chars(len)
+         local reply = self:handle(peer, request)
+         peer:write_chars(tostring(#reply))
+         peer:write_chars('\n')
+         peer:write_chars(reply)
+         peer:flush_output()
+      end
+   end)
+   if self.listen_peer == peer then self.listen_peer = nil end
+end
+
+function Manager:run_scheduler()
+   self.sched:run(engine.now())
 end
 
 function Manager:start_worker(sched_opts)
@@ -539,14 +589,15 @@ function Manager:rpc_get_alarms_state (args)
    if success then return response else return {status=1, error=response} end
 end
 
-function Manager:handle (payload)
+function Manager:handle (peer, payload)
    -- FIXME: Stream call and response instead of building strings.
-   return mem.call_with_output_string(
+   self.rpc_peer = peer
+   local ret = mem.call_with_output_string(
       rpc.handle_calls, self.rpc_callee, mem.open_input_string(payload),
       self.rpc_handler)
+   self.rpc_peer = nil
+   return ret
 end
-
-local dummy_unix_sockaddr = S.t.sockaddr_un()
 
 function Manager:push_notifications_to_peers()
    local notifications = alarms.notifications()
@@ -599,122 +650,6 @@ function Manager:push_notifications_to_peers()
             peer.fd:close()
             table.remove(peers, i)
          end
-      end
-   end
-end
-
-function Manager:handle_calls_from_peers()
-   local peers = self.peers
-   while true do
-      local fd, err = self.socket:accept(dummy_unix_sockaddr)
-      if not fd then
-         if err.AGAIN then break end
-         assert(nil, err)
-      end
-      fd:nonblock()
-      table.insert(peers, { state='length', len=0, fd=fd })
-   end
-   local i = 1
-   while i <= #peers do
-      local peer = peers[i]
-      local visit_peer_again = false
-      while peer.state == 'length' do
-         local ch, err = peer.fd:read(nil, 1)
-         if not ch then
-            if err.AGAIN then break end
-            peer.state = 'error'
-            peer.msg = tostring(err)
-         elseif ch == '\n' then
-            peer.pos = 0
-            peer.buf = ffi.new('uint8_t[?]', peer.len)
-            peer.state = 'payload'
-         elseif tonumber(ch) then
-            peer.len = peer.len * 10 + tonumber(ch)
-            if peer.len > 1e8 then
-               peer.state = 'error'
-               peer.msg = 'length too long: '..peer.len
-            end
-         elseif ch == '' then
-            if peer.len == 0 then
-               peer.state = 'done'
-            else
-               peer.state = 'error'
-               peer.msg = 'unexpected EOF'
-            end
-         else
-            peer.state = 'error'
-            peer.msg = 'unexpected character: '..ch
-         end
-      end
-      while peer.state == 'payload' do
-         if peer.pos == peer.len then
-            peer.state = 'ready'
-            peer.payload = ffi.string(peer.buf, peer.len)
-            peer.buf, peer.len = nil, nil
-         else
-            local count, err = peer.fd:read(peer.buf + peer.pos,
-                                            peer.len - peer.pos)
-            if not count then
-               if err.AGAIN then break end
-               peer.state = 'error'
-               peer.msg = tostring(err)
-            elseif count == 0 then
-               peer.state = 'error'
-               peer.msg = 'short read'
-            else
-               peer.pos = peer.pos + count
-               assert(peer.pos <= peer.len)
-            end
-         end
-      end
-      while peer.state == 'ready' do
-         -- Uncomment to get backtraces.
-         self.rpc_peer = peer
-         -- local success, reply = true, self:handle(peer.payload)
-         local success, reply = pcall(self.handle, self, peer.payload)
-         self.rpc_peer = nil
-         peer.payload = nil
-         if success then
-            assert(type(reply) == 'string')
-            reply = #reply..'\n'..reply
-            peer.state = 'reply'
-            peer.buf = ffi.new('uint8_t[?]', #reply+1, reply)
-            peer.pos = 0
-            peer.len = #reply
-         else
-            peer.state = 'error'
-            peer.msg = reply
-         end
-      end
-      while peer.state == 'reply' do
-         if peer.pos == peer.len then
-            visit_peer_again = true
-            peer.state = 'length'
-            peer.buf, peer.pos = nil, nil
-            peer.len = 0
-         else
-            local count, err = peer.fd:write(peer.buf + peer.pos,
-                                             peer.len - peer.pos)
-            if not count then
-               if err.AGAIN then break end
-               peer.state = 'error'
-               peer.msg = tostring(err)
-            elseif count == 0 then
-               peer.state = 'error'
-               peer.msg = 'short write'
-            else
-               peer.pos = peer.pos + count
-               assert(peer.pos <= peer.len)
-            end
-         end
-      end
-      if peer.state == 'done' or peer.state == 'error' then
-         if peer.state == 'error' then self:warn('%s', peer.msg) end
-         peer.fd:close()
-         table.remove(peers, i)
-         if self.listen_peer == peer then self.listen_peer = nil end
-      elseif not visit_peer_again then
-         i = i + 1
       end
    end
 end
@@ -789,10 +724,8 @@ function Manager:handle_alarm (worker, alarm)
 end
 
 function Manager:stop ()
-   for _,peer in ipairs(self.peers) do peer.fd:close() end
-   self.peers = {}
-   self.socket:close()
-   S.unlink(self.socket_file_name)
+   assert(self.sched:shutdown())
+   require('lib.fibers.file').uninstall_poll_io_handler()
 
    for id, worker in pairs(self.workers) do
       if not worker.shutting_down then self:stop_worker(id) end
@@ -825,7 +758,7 @@ function Manager:main (duration)
       next_time = now + self.period
       if timer.ticks then timer.run_to_time(now * 1e9) end
       self:remove_stale_workers()
-      self:handle_calls_from_peers()
+      self:run_scheduler()
       self:push_notifications_to_peers()
       self:send_messages_to_workers()
       self:receive_alarms_from_workers()

--- a/src/lib/stream/file.lua
+++ b/src/lib/stream/file.lua
@@ -39,11 +39,15 @@ end
 
 set_blocking_handler()
 
+function init_nonblocking(fd)  blocking_handler:init_nonblocking(fd) end
+function wait_for_readable(fd) blocking_handler:wait_for_readable(fd) end
+function wait_for_writable(fd) blocking_handler:wait_for_writable(fd) end
+
 local File = {}
 local File_mt = {__index = File}
 
 local function new_file_io(fd, filename)
-   blocking_handler:init_nonblocking(fd)
+   init_nonblocking(fd)
    return setmetatable({fd=fd, filename=filename}, File_mt)
 end
 
@@ -88,8 +92,8 @@ function File:seek(whence, offset)
    return self.fd:lseek(offset, whence)
 end
 
-function File:wait_for_readable() blocking_handler:wait_for_readable(self.fd) end
-function File:wait_for_writable() blocking_handler:wait_for_writable(self.fd) end
+function File:wait_for_readable() wait_for_readable(self.fd) end
+function File:wait_for_writable() wait_for_writable(self.fd) end
 
 function File:close()
    self.fd:close()

--- a/src/lib/stream/socket.lua
+++ b/src/lib/stream/socket.lua
@@ -1,0 +1,105 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+-- A stream IO implementation for sockets.
+
+module(..., package.seeall)
+
+local file = require('lib.stream.file')
+local S = require('syscall')
+
+local Socket = {}
+local Socket_mt = {__index = Socket}
+
+local sigpipe_handler
+
+function socket(domain, stype, protocol)
+   if sigpipe_handler == nil then sigpipe_handler = S.signal('pipe', 'ign') end
+   local fd = assert(S.socket(domain, stype, protocol))
+   file.init_nonblocking(fd)
+   return setmetatable({fd=fd}, Socket_mt)
+end
+
+function Socket:listen_unix(file)
+   local sa = S.t.sockaddr_un(file)
+   self.scratch_sockaddr = S.t.sockaddr_un()
+   assert(self.fd:bind(sa))
+   assert(self.fd:listen())
+end
+
+function Socket:accept()
+   while true do
+      local fd, err = self.fd:accept(self.scratch_sockaddr)
+      if fd then
+         return file.fdopen(fd)
+      elseif err.AGAIN or err.WOULDBLOCK then
+         file.wait_for_readable(self.fd)
+      else
+         error(tostring(err))
+      end
+   end
+end
+
+function Socket:connect(sa)
+   local ok, err = self.fd:connect(sa)
+   if not ok and err.INPROGRESS then
+      -- Bonkers semantics; see connect(2).
+      file.wait_for_writable(self.fd)
+      local err = assert(s:getsockopt("socket", "error"))
+      if err == 0 then ok = true
+      else err = S.t.error(err) end
+   end
+   if ok then
+      local fd = self.fd
+      self.fd = nil
+      return file.fdopen(fd)
+   end
+   error(tostring(err))
+end
+
+function Socket:connect_unix(file, stype)
+   local sa = S.t.sockaddr_un(file)
+   return self:connect(sa)
+end
+
+function listen_unix(file, stype, protocol)
+   local s = socket('unix', stype or 'stream', protocol)
+   s:listen_unix(file)
+   return s
+end
+
+function connect_unix(file, stype, protocol)
+   local s = socket('unix', stype or 'stream', protocol)
+   return s:connect_unix(file)
+end
+
+function Socket:close()
+   if self.fd then self.fd:close() end
+   self.fd = nil
+end
+
+function selftest()
+   print('selftest: lib.stream.socket')
+   local shm = require('core.shm')
+
+   local sockname = shm.root..'/'..tostring(S.getpid())..'/test-socket'
+   S.unlink(sockname)
+
+   local server = listen_unix(sockname)
+   local client = connect_unix(sockname)
+   local peer = server:accept()
+
+   local message = "hello, world\n"
+   client:write(message)
+   client:flush_output()
+   local message2 = peer:read_some_chars()
+   assert(message == message2)
+   client:close()
+   assert(peer:read_some_chars() == nil)
+   peer:close()
+
+   server:close()
+
+   S.unlink(sockname)
+
+   print('selftest: ok')
+end

--- a/src/program/config/common.lua
+++ b/src/program/config/common.lua
@@ -170,6 +170,7 @@ end
 
 local function read_length(socket)
    local line = socket:read_line()
+   if line == nil then error('unexpected EOF when reading length') end
    local len = assert(tonumber(line), 'not a number: '..line)
    assert(len >= 0 and len == math.floor(len), 'bad length: '..len)
    return len


### PR DESCRIPTION
This branch rewrites the peer-handling code in the ptree manager to use fibers.  Eventually we should rewrite the notification code as well.  The advantage is greater clarity regarding control flow, easier composability (it would have been easier to add notification support as in #1055), and the eventual ability to stream in the parsing of configurations and the printing of replies.  It also avoids an `accept` call at every loop.