### PR TITLE
Adapt alarm notifications management to new API

### DIFF
--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -201,8 +201,18 @@ function do_add_to_inventory (k, v)
    alarm_inventory_changed()
 end
 
+
+local function new_notification (event, value)
+   value = value or {}
+   assert(type(value) == "table")
+   local ret = {event=event}
+   for k,v in pairs(value) do ret[k] = v end
+   return ret
+end
+
 function alarm_inventory_changed()
-   table.insert(state.notifications.alarm_inventory_changed, {})
+   table.insert(state.notifications.alarm_inventory_changed,
+                new_notification('alarm-inventory-changed'))
 end
 
 -- Single point to access alarm keys.
@@ -328,7 +338,7 @@ end
 
 function add_alarm_notification (key, status)
    local notifications = state.notifications.alarm
-   notifications[key] = status
+   notifications[key] = new_notification('alarm-notification', status)
 end
 
 -- Creates a new alarm.
@@ -482,7 +492,7 @@ end
 
 function add_operator_action_notification (key, status)
    local operator_action = state.notifications.operator_action
-   operator_action[key] = status
+   operator_action[key] = new_notification('operator-action', status)
 end
 
 -- Purge alarms.

--- a/src/program/alarms/listen/listen.lua
+++ b/src/program/alarms/listen/listen.lua
@@ -2,12 +2,13 @@
 module(..., package.seeall)
 
 local S = require("syscall")
-local ffi = require("ffi")
-local rpc = require("lib.yang.rpc")
-local data = require("lib.yang.data")
-local path_lib = require("lib.yang.path")
-local json_lib = require("lib.ptree.json")
 local common = require("program.config.common")
+local data = require("lib.yang.data")
+local fiber = require("lib.fibers.fiber")
+local file = require("lib.stream.file")
+local mem = require("lib.stream.mem")
+local path_lib = require("lib.yang.path")
+local rpc = require("lib.yang.rpc")
 
 local function open_socket(file)
    S.signal('pipe', 'ign')
@@ -23,7 +24,7 @@ local function attach_listener(leader, caller)
    local msg, parse_reply = rpc.prepare_call(
       caller, 'attach-notification-listener', {})
    common.send_message(leader, msg)
-   return parse_reply(common.recv_message(leader))
+   return parse_reply(mem.open_input_string(common.recv_message(leader)))
 end
 
 function run(args)
@@ -32,60 +33,52 @@ function run(args)
    local leader = common.open_socket_or_die(args.instance_id)
    attach_listener(leader, caller)
    
+   local handler = require('lib.fibers.file').new_poll_io_handler()
+   file.set_blocking_handler(handler)
+   fiber.current_scheduler:add_task_source(handler)
+   -- Leader was blocking in call to attach_listener.
+   leader:nonblock()
+
    -- Check if there is a socket path specified, if so use that as method
    -- to communicate, otherwise use stdin and stdout.
-   local fd = nil
+   local client_tx
    if args.socket then
       local sockfd = open_socket(args.socket)
       local addr = S.t.sockaddr_un()
       -- Wait for a connection
-      local err
       print("Listening for clients on socket: "..args.socket)
-      fd, err = sockfd:accept(addr)
-      if fd == nil then
-         sockfd:close()
-         error(err)
-      end
+      client_tx = file.fdopen(assert(sockfd:accept(addr)))
    else
-      fd = S.stdin
+      client_tx = file.fdopen(S.stdout)
    end
       
-   local client = json_lib.buffered_input(fd)
-   local pollfds = S.types.t.pollfds({
-         {fd=leader, events="in"},
-         {fd=client, events="in"}})
-   while true do
-      if client:avail() == 0 then
-         assert(S.poll(pollfds, -1))
+   local function exit_when_finished(f)
+      return function()
+         local success, res = pcall(f)
+         if not success then io.stderr:write('error: '..tostring(res)..'\n') end
+         os.exit(success and 0 or 1)
       end
-      for _,pfd in ipairs(pollfds) do
-         if pfd.fd == leader:getfd() then
-            if pfd.ERR or pfd.HUP then
-               io.stderr:write('Leader hung up\n')
-               main.exit(1)
-            elseif pfd.IN then
-               print(common.recv_message(leader))
-            end
-            pfd.revents = 0
-         elseif pfd.fd == client:getfd() then
-            if pfd.ERR or pfd.HUP or pfd.NVAL then
-               io.stderr:write('Client hung up\n')
-               main.exit(0)
-            end
-            if pfd.IN then
-               -- The JSON objects sent to us by the client can have
-               -- whitespace between them.  Make sure we don't block
-               -- expecting a new datum when really it was just the
-               -- remote side sending whitespace.  (Calling peek()
-               -- causes the buffer to fill, which itself shouldn't
-               -- block given the IN flag in the revents.)
-               client:peek()
-               json_lib.drop_buffered_whitespace(client)
-            end
-            pfd.revents = 0
-         else
-            error('unreachable')
-         end
+   end
+   local function print_notification (output, msg)
+      output:write_chars(msg)
+      output:flush()
+   end
+   local function handle_outgoing ()
+      while true do
+         local msg = common.recv_message(leader)
+         print_notification(client_tx, msg)
+      end
+   end
+
+   fiber.spawn(exit_when_finished(handle_outgoing))
+
+   while true do
+      local sched = fiber.current_scheduler
+      sched:run()
+      -- FIXME: If we want to wait until tasks are runnable, the
+      -- scheduler should handle that.
+      if #sched.next == 0 then
+         handler:schedule_tasks(sched, sched:now(), -1)
       end
    end
 end


### PR DESCRIPTION
Command `alarms listen` and management of alarm notification in `ptree.lua` need to be update to the new fibers API.

It's not fully working yet. As soon as I receive a notification, I got an EOF error.

Here's what I have done:
* In `alarms listen` I have only one fiber that pulls messages from the leader. In `config listen` there are two fibers, one for request and another one for replies. The request fiber puts replies into a queue, which is later pulled by the reply fiber. I suspect that I need a similar mechanism, but how can I know when a notification has been written in the leader?
* In the management of notifications in ptree.lua, before notifications were queued into a peer and later pulled and sent one by one. There was tracking information of the last position written of the first item. I'm not sure if this mechanism is still needed.