### PR TITLE
Fix ip-prefix yang

### DIFF
--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -272,12 +272,6 @@ function rpc_output_grammar_from_schema(schema)
    return rpc_grammar_from_schema(schema).output
 end
 
-local function integer_type(min, max)
-   return function(str, k)
-      return util.tointeger(str, k, min, max)
-   end
-end
-
 local function range_predicate(range, val)
    return function(val)
       for _,part in ipairs(range) do

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -9,6 +9,8 @@ local ffi = require("ffi")
 local bit = require("bit")
 local ethernet = require("lib.protocol.ethernet")
 
+local ipv4_pton, ipv4_ntop = util.ipv4_pton, util.ipv4_ntop
+
 types = {}
 
 local function integer_type(ctype)
@@ -118,8 +120,8 @@ types.union = unimplemented('union')
 
 types['ipv4-address'] = {
    ctype = 'uint32_t',
-   parse = function(str, what) return util.ipv4_pton(str) end,
-   tostring = function(val) return util.ipv4_ntop(val) end
+   parse = function(str, what) return ipv4_pton(str) end,
+   tostring = function(val) return ipv4_ntop(val) end
 }
 
 types['legacy-ipv4-address'] = {
@@ -144,7 +146,7 @@ types['ipv4-prefix'] = {
    ctype = 'struct { uint8_t prefix[4]; uint8_t len; }',
    parse = function(str, what)
       local prefix, len = str:match('^([^/]+)/(.*)$')
-      return { ipv4_pton(prefix), util.tointeger(len, 1, 32) }
+      return { ipv4_pton(prefix), util.tointeger(len, nil, 1, 32) }
    end,
    tostring = function(val) return ipv4_ntop(val[1])..'/'..tostring(val[2]) end
 }
@@ -153,7 +155,7 @@ types['ipv6-prefix'] = {
    ctype = 'struct { uint8_t prefix[16]; uint8_t len; }',
    parse = function(str, what)
       local prefix, len = str:match('^([^/]+)/(.*)$')
-      return { assert(ipv6:pton(prefix)), util.tointeger(len, 1, 128) }
+      return { assert(ipv6:pton(prefix)), util.tointeger(len, nil, 1, 128) }
    end,
    tostring = function(val) return ipv6:ntop(val[1])..'/'..tostring(val[2]) end
 }
@@ -166,4 +168,8 @@ function selftest()
    assert(types['int8'].parse('0') == 0)
    assert(types['int8'].parse('127') == 127)
    assert(not pcall(types['int8'].parse, '128'))
+   local ip = types['ipv4-prefix'].parse('10.0.0.1/8')
+   assert(types['ipv4-prefix'].tostring(ip) == '10.0.0.1/8')
+   local ip = types['ipv6-prefix'].parse('fc00::1/64')
+   assert(types['ipv6-prefix'].tostring(ip) == 'fc00::1/64')
 end


### PR DESCRIPTION
Reported by Maz on Slack https://snabb.slack.com/files/U0HLDG75Y/FAKT51A76/-.txt

Maz:

```
(3) Lua upvalue 'err' at file 'lib/yang/data.lua:24'
        Local variables:
         msg = string: "bad member name"
         pos = number: 59
(4) Lua local 'assert_match' at file 'lib/yang/data.lua:28'
```
```
Maz: okay ^ that only happens when the ip-prefix is set as ‘key’ of a list, if i have a manual ‘index’ key it works fine.  *however* ipv4-prefix and ipv6-prefix seem to have missed some changes (e.g. ipv4_pton used by ipv4-prefix is not defined in value.lua) and there’s some issues around the ‘tostring’ method which receives a table as `val` on the first run, and receives the compiled ctype on the second and subsequent runs from the compiled config. The initial run when the relevant .o file is deleted always segfaults attempting to tostring a table :slightly_smiling_face:
It’s easy enough to fix in the `tostring()` method by detecting the type of `val`, but not sure that’s the right answer, and maybe the tostring function should always receive one or the other rather than both formats :thinking_face:
```

As pointed by Maz, the issue is that `lib/yang/value.lua` references functions defined in `lib/yang/util.lua`. Another issue is the conversion to integer using `util.tointeger`, there was one argument missing, `what`. In the fix I rearrange the parameter order of the function as it makes more sense `what` is the last argument as it can be nil.