### PR TITLE
Fix ipv4-prefix ctype

### DIFF
--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -1271,6 +1271,12 @@ function selftest()
          description "internet of fruit";
          type inet:ipv4-address;
       }
+
+      leaf-list address {
+         type inet:ip-prefix;
+         description
+         "Address prefixes bound to this interface.";
+      }
    }]])
 
    local data = load_config_for_schema(test_schema,
@@ -1282,6 +1288,7 @@ function selftest()
        contents { name baz; score 9; tree-grown true; }
      }
      addr 1.2.3.4;
+     address 1.2.3.4/24;
    ]])
    for i =1,2 do
       assert(data.fruit_bowl.description == 'ohai')

--- a/src/lib/yang/value.lua
+++ b/src/lib/yang/value.lua
@@ -143,12 +143,12 @@ types['mac-address'] = {
 }
 
 types['ipv4-prefix'] = {
-   ctype = 'struct { uint8_t prefix[4]; uint8_t len; }',
+   ctype = 'struct { uint32_t prefix; uint8_t len; }',
    parse = function(str, what)
       local prefix, len = str:match('^([^/]+)/(.*)$')
-      return { ipv4_pton(prefix), util.tointeger(len, nil, 1, 32) }
+      return { prefix=ipv4_pton(prefix), len=util.tointeger(len, nil, 1, 32) }
    end,
-   tostring = function(val) return ipv4_ntop(val[1])..'/'..tostring(val[2]) end
+   tostring = function(val) return ipv4_ntop(val.prefix)..'/'..tostring(val.len) end
 }
 
 types['ipv6-prefix'] = {


### PR DESCRIPTION
IPv4 address in ipv4-prefix was uint8_t[4], whereas IPv4 address in yang are uint32_t numbers.