### PR TITLE
Fix binary serialization

### DIFF
--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -68,7 +68,7 @@ local function read_string_table(stream, strtab_len)
    assert(strtab_len >= 4)
    local count = stream:read_scalar(nil, uint32_t)
    assert(strtab_len >= (4 * (count + 1)))
-   local offsets = stream:read_array(nil, ffi.typeof('uint32_t'), count)
+   local offsets = stream:read_array(nil, uint32_t, count)
    assert(strtab_len == (4 * (count + 1)) + offsets[count-1])
    local strings = {}
    local offset = 0

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -14,7 +14,7 @@ local ctable = require('lib.ctable')
 local cltable = require('lib.cltable')
 
 local MAGIC = "yangconf"
-local VERSION = 0x00009000
+local VERSION = 0x0000c000
 
 local header_t = ffi.typeof([[
 struct {
@@ -258,8 +258,10 @@ local function data_emitter(production)
       elseif type.ctype then
          local ctype = type.ctype
          local emit_value = value_emitter(ctype)
+         local serialization = 'cscalar'
+         if ctype:match('[{%[]') then serialization = 'cstruct' end
          return function(data, stream)
-            stream:write_stringref('cscalar')
+            stream:write_stringref(serialization)
             stream:write_stringref(ctype)
             emit_value(data, stream)
          end


### PR DESCRIPTION
If a leaf type is "uint32", then we want to serialize and deserialize the value as a scalar.  Reading that scalar will be by-value; LuaJIT doesn't alias an array "uint32_t arr[1]" when reading "arr[0]".

However for other leaf types, like the uint8_t[16] used for IPv6 addresses, LuaJIT will read them by-reference.  These are not appropriate for writing with write_scalar, or more specifically, they aren't appropriate for reading via read_scalar, as that read result will alias a newly allocated one-element array which will quickly become garbage.

The solution is to prevent these by-reference types from being written as scalars.