### PR TITLE
Support >4GB binding tables

### DIFF
--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -261,9 +261,7 @@ function load(stream, params)
 
    -- Slurp the entries directly into the ctable's backing store.
    -- This ensures that the ctable is in hugepages.
-   C.memcpy(ctab.entries,
-            stream:read_array(nil, ctab.entry_type, entry_count),
-            ffi.sizeof(ctab.entry_type) * entry_count)
+   stream:read_array(ctab.entries, ctab.entry_type, entry_count)
 
    return ctab
 end

--- a/src/lib/stream.lua
+++ b/src/lib/stream.lua
@@ -247,6 +247,7 @@ end
 
 function Stream:write_scalar(type, value)
    local ptr = ffi.typeof('$[1]', type)(value)
+   assert(ptr[0] == value, "value out of range")
    self:write_array(type, ptr, 1)
 end
 

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -14,7 +14,7 @@ local ctable = require('lib.ctable')
 local cltable = require('lib.cltable')
 
 local MAGIC = "yangconf"
-local VERSION = 0x0000c000
+local VERSION = 0x0000d000
 
 local header_t = ffi.typeof([[
 struct {
@@ -24,10 +24,10 @@ struct {
    uint32_t source_mtime_nsec;
    uint32_t schema_name;
    uint32_t revision_date;
-   uint32_t data_start;
-   uint32_t data_len;
-   uint32_t strtab_start;
-   uint32_t strtab_len;
+   uint64_t data_start;
+   uint64_t data_len;
+   uint64_t strtab_start;
+   uint64_t strtab_len;
 }
 ]])
 local uint32_t = ffi.typeof('uint32_t')


### PR DESCRIPTION
This branch increases a couple of sizes and offsets in the header of compiled binary data from `uint32_t` to `uint64_t`, to allow for large files.

Doing some tests locally using LuaJIT (not even RaptorJIT yet), here are some numbers:

 * for 1M entries, compiling took 1m9s; loading took 1s, works fine
 * for 10M entries, compiling took 11m44s; loading took 3.6s, worker dies
 * for 40M entries, compiling took 42m47s; loading took 15.8s, fails to migrate NUMA affinities

The "loading" numbers include migration via --v4/--v6 arguments.  A configuration that doesn't need to be migrated could be loaded in about half the time.

For the 10M binding table, the child process gets started but it dies when loading the configuration from the location in shmfs.  Here's the end of the strace log:

```strace
mmap(NULL, 468, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7fd07c8ba000
mprotect(0x7fd07c8ba000, 468, PROT_READ|PROT_EXEC) = 0
mmap(NULL, 464549592, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_HUGETLB, -1, 0) = 0x7fcf85000000
mprotect(0x2a4f0000, 65536, PROT_READ|PROT_WRITE) = 0
mprotect(0x2a4f0000, 65536, PROT_READ|PROT_EXEC) = 0
--- SIGBUS {si_signo=SIGBUS, si_code=BUS_ADRERR, si_addr=0x7fcf9a2021b8} ---
+++ killed by SIGBUS +++
```

The `si_addr` indicates the address that caused the SIGBUS.  In this case it's within the hugetlb allocation that was just mmapped between 0x7fcf85000000 and 7fcfa0b076d8.  I am not sure why this happens; do I need to mlock() to ensure that the pages are populated when using mmap as an allocator?  An ongoing investigation.