### PR TITLE
Prepare v3.1.10 release

### DIFF
--- a/lib/luajit/src/lj_record.c
+++ b/lib/luajit/src/lj_record.c
@@ -2332,8 +2332,6 @@ void lj_record_ins(jit_State *J)
   case BC_IFORL:
   case BC_IITERL:
   case BC_ILOOP:
-  case BC_IFUNCF:
-  case BC_IFUNCV:
     lj_trace_err(J, LJ_TRERR_BLACKL);
     break;
 
@@ -2345,6 +2343,7 @@ void lj_record_ins(jit_State *J)
   /* -- Function headers -------------------------------------------------- */
 
   case BC_FUNCF:
+  case BC_IFUNCF:
     rec_func_lua(J);
     break;
   case BC_JFUNCF:
@@ -2352,6 +2351,7 @@ void lj_record_ins(jit_State *J)
     break;
 
   case BC_FUNCV:
+  case BC_IFUNCV:
     rec_func_vararg(J);
     rec_func_lua(J);
     break;

--- a/src/program/lwaftr/doc/CHANGELOG.md
+++ b/src/program/lwaftr/doc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [3.1.10] - 2018-05-14
+
+* Apply hot-fix to LuaJIT to prevent blacklisted functions from
+  permanently preventing optimization, even after a JIT flush.  For more
+  details, see:
+
+    https://github.com/snabbco/snabb/pull/1244
+
 ## [3.1.9] - 2017-05-18
 
 * Add "snabb --version" command-line argument.


### PR DESCRIPTION
Applying https://github.com/snabbco/snabb/pull/1244 to the 3.1 release series to fix a deployment issue while the deployment migrates to the newer YANG schema.