### PR TITLE
Simplify alarm notifications listener

### DIFF
--- a/src/lib/ptree/README.md
+++ b/src/lib/ptree/README.md
@@ -74,12 +74,17 @@ is a table of key/value pairs.  The following keys are required:
 
 Optional entries that may be present in the *parameters* table include:
 
- * `socket_file_name`: The name of the socket on which to listen for
+ * `rpc_socket_file_name`: The name of the socket on which to listen for
    incoming connections from `snabb config` clients.  See [the `snabb
    config` documentation](../../program/config/README.md) for more
    information.  Default is `$SNABB_SHM_ROOT/PID/config-leader-socket`,
    where the `$SNABB_SHM_ROOT` environment variable defaults to
    `/var/run/snabb`.
+ * `notification_socket_file_name`: The name of the socket on which to
+   listen for incoming connections from `snabb alarms` clients.  See
+   [the `snabb alarms` documentation](../../program/alarms/README.md)
+   for more information.  Default is
+   `$SNABB_SHM_ROOT/PID/notifications`.
  * `name`: A name to claim for this process tree.  `snabb config` can
    address network functions by name in addition to PID.  If the name is
    already claimed on the local machine, an error will be signalled.

--- a/src/lib/stream/socket.lua
+++ b/src/lib/stream/socket.lua
@@ -61,9 +61,16 @@ function Socket:connect_unix(file, stype)
    return self:connect(sa)
 end
 
-function listen_unix(file, stype, protocol)
-   local s = socket('unix', stype or 'stream', protocol)
+function listen_unix(file, args)
+   local s = socket('unix', args.stype or "stream", args.protocol)
    s:listen_unix(file)
+   if args.ephemeral then
+      local parent_close = s.close
+      function s:close()
+         parent_close(s)
+         S.unlink(file)
+      end
+   end
    return s
 end
 

--- a/src/lib/stream/socket.lua
+++ b/src/lib/stream/socket.lua
@@ -62,6 +62,7 @@ function Socket:connect_unix(file, stype)
 end
 
 function listen_unix(file, args)
+   args = args or {}
    local s = socket('unix', args.stype or "stream", args.protocol)
    s:listen_unix(file)
    if args.ephemeral then


### PR DESCRIPTION
Instead of having to RPC and then turn the socket into a listening
state, we should just have a separate socket for notifications.  It's
stateless anyway.  No need for the special length-prefixed message
protocol either -- we can just write JSON and trust fibers to allow
concurrency.  The listen program likewise simplifies to a glorified
socat.