### PR TITLE
Aggregate counters

### DIFF
--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -322,8 +322,10 @@ local function archive_counter (name)
    local val = counter.read(c)
    counter.delete(name)
    counters.active[name] = nil
-   counters.archived[name] = counters.archived[name] and counter.set(name, val)
-                                                     or counter.create(name, val)
+   if not counters.archived[name] then
+      counters.archived[name] = ffi.new("uint64_t[1]")
+   end
+   counters.archived[name][0] = counters.archived[name][0] + val
 end
 local function create_or_update_counter (worker_pid, name)
    local aggregated = name:gsub(worker_pid, S.getpid())

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -319,9 +319,11 @@ local function create_counter (name, val)
 end
 local function archive_counter (name)
    local c = assert(counters.active[name])
-   counter.delete(c)
-   counters.archived[name] = c
+   local val = counter.read(c)
+   counter.delete(name)
    counters.active[name] = nil
+   counters.archived[name] = counters.archived[name] and counter.set(name, val)
+                                                     or counter.create(name, val)
 end
 local function create_or_update_counter (worker_pid, name)
    local aggregated = name:gsub(worker_pid, S.getpid())

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -363,14 +363,14 @@ function Manager:start_worker_for_graph(id, graph)
 
    -- Update aggregated counters.
    fiber.spawn(function ()
-      local worker = self.workers[id]
       while true do
          for cname, c in pairs(counters.active) do
-            -- TODO: Store aggregated counters in an separated table?
-            if not cname:match("/"..worker.pid) then
-               create_or_update_counter(worker.pid, cname)
+            local pid = tonumber(cname:match("/(%d+)"))
+            if pid ~= S.getpid() then
+               create_or_update_counter(pid, cname)
             end
          end
+         counter.commit()
          fiber_sleep(1)
       end
    end)

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -335,7 +335,7 @@ end
 -- accumulative sum.  Accumulative sum is initialized to aggregated counter
 -- value if any.
 local function compute_aggregated_value (k)
-   local ret = counters.archived[k] or 0
+   local ret = counters.archived[k][0] or 0
    for _,c in pairs(counters.active[k]) do
       ret = ret + counter.read(c)
    end

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -318,6 +318,7 @@ local function create_counter (name)
 end
 local function archive_counter (name)
    local c = assert(counters.active[name])
+   counter.delete(c)
    counters.archived[name] = c
    counters.active[name] = nil
 end


### PR DESCRIPTION
Working plan as discussed offline:

- When a worker starts, we start a `recursive_directory_inventory_events()` channel on it to learn about the counters.
- For any file in directory -- say we are opening `/var/run/snabb/1234/` --
- For any file like `/var/run/snabb/foo/bar`, if its basename (lib.basename()) has an extension of ".counter", then it's a counter.
- So we will receive an event on the channel like `{kind='creat', name='/var/run/snabb/1234/foo/bar.counter'}`
- On the manager when we see that, we do `counter.open()` on that counter, store away that counter somewhere and additionally, periodically we create a corresponding counter in the manager process
e.g. /var/run/snabb/5678/foo/bar.counter.
- Where the manager counter = sum of all corresponding worker counters of that name + archived value
as a 64-bit unsigned integer.
- When a counter goes away ({kind='rm', name='/var/run/snabb/1234/foo/bar.counter'}) then we add its last value to the archived counter, then remove it from the set of active worker counters
in that way when we do a "snabb top" on the manager process, we should see a sum of all counters from the workers.

So far I've created the channel and added a fiber for listening the directory events.
