### PR TITLE
Fix error in monitor

### DIFF
--- a/src/program/lwaftr/monitor/README
+++ b/src/program/lwaftr/monitor/README
@@ -1,5 +1,5 @@
 Usage:
-    monitor IPV4_ADDRESS [PID]
+    monitor IPV4_ADDRESS PID
 
 Options:
 
@@ -23,5 +23,4 @@ IPV4_ADDRESS can take two special values:
 - 'none', which is equivalent to '0.0.0.0'.
 - 'all', which is equivalent to '255.255.255.255'.
 
-PID value is used to retrieve the lwAFTR instance.  If PID is not set, the
-most recent active lwAFTR instance for which 'v4v6_mirror' is defined is used.
+PID value is used to retrieve the lwAFTR instance.

--- a/src/program/lwaftr/monitor/monitor.lua
+++ b/src/program/lwaftr/monitor/monitor.lua
@@ -5,11 +5,9 @@ local ipv4 = require("lib.protocol.ipv4")
 local lib = require("core.lib")
 local lwutil = require("apps.lwaftr.lwutil")
 local shm = require("core.shm")
-local top = require("program.top.top")
 local engine = require("core.app")
 
 local fatal = lwutil.fatal
-local select_snabb_instance = top.select_snabb_instance
 
 local long_opts = {
    help = "h",
@@ -43,7 +41,7 @@ local function find_mirror_path (pid)
    if not shm.exists(path) then
       fatal(("lwAFTR process '%d' is not running in mirroring mode"):format(pid))
    end
-   return path, pid
+   return path
 end
 
 local function set_mirror_address (address, path)
@@ -81,7 +79,10 @@ function run (args)
          fatal(("Couldn't find process with name '%s'"):format(opts.name))
       end
    end
-   local path, pid = find_mirror_path(top.select_snabb_instance(pid))
+   if not lwutil.dir_exists(shm.root..'/'..pid) then
+      fatal("No such Snabb instance: "..pid)
+   end
+   local path = find_mirror_path(pid)
    address = set_mirror_address(address, path)
    print(("Mirror address set to '%s' in PID '%s'"):format(address, pid))
 end


### PR DESCRIPTION
The error in monitor reported by CI was due to monitor using a method from top which was removed (`select_snabb_instance`).

Instead of reintroducing this method, I simplified monitor instead. Before if the PID didn't exist a list of all available PIDs was listed. Also monitor allowed to not pass a PID and fetched the list of available PIDs using top. If a single instance was available it used that one. All this was a bit overkilling, simpler to request the user to pass a PID or a name.