### PR TITLE
Fix attempt to index a nil value

### DIFF
--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -335,7 +335,8 @@ end
 -- accumulative sum.  Accumulative sum is initialized to aggregated counter
 -- value if any.
 local function compute_aggregated_value (k)
-   local ret = counters.archived[k][0] or 0
+   if not counters.archived[k] then return 0 end
+   local ret = counters.archived[k][0]
    for _,c in pairs(counters.active[k]) do
       ret = ret + counter.read(c)
    end


### PR DESCRIPTION
There's an error when lwAFTR starts:

```
Error while running fiber: lib/ptree/ptree.lua:338: attempt to index a nil value
```

Function `compute_aggregated_value` is trying to dereference `counters.archived[k]` but it doesn't exist yet.