### PR TITLE
Fix time offset in ISO8601 dates

### DIFF
--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -850,7 +850,8 @@ function selftest ()
    -- Test toseconds.
    assert(toseconds({age_spec='weeks', value=1}) == 3600*24*7)
    local now = os.time()
-   assert(now == toseconds(format_date_as_iso_8601(now)))
+   assert(now == toseconds(format_date_as_iso_8601(now)),
+          now.." != "..toseconds(format_date_as_iso_8601(now)))
 
    -- Purge alarms by status.
    assert(table_size(state.alarm_list.alarm) == 1)

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -153,10 +153,18 @@ end
 -- by 'format_date_as_iso8601'.
 function parse_date_as_iso_8601 (date)
    assert(type(date) == 'string')
-   local gmtdate = "(%d%d%d%d)-(%d%d)-(%d%d)T(%d%d):(%d%d):(%d%d)Z"
+   local gmtdate = "(%d%d%d%d)-(%d%d)-(%d%d)T(%d%d):(%d%d):(%d%d)"
    local year, month, day, hour, min, sec = assert(date:match(gmtdate))
-   local tz_sign, tz_hour, tz_min = date:match("Z([+-]?)(%d%d):(%d%d)")
-   return {year=year, month=month, day=day, hour=hour, min=min, sec=sec, tz_sign=tz_sign, tz_hour=tz_hour, tz_min=tz_min}
+   local ret = {year=year, month=month, day=day, hour=hour, min=min, sec=sec}
+   if date:match("Z$") then
+      return ret
+   else
+      local tz_sign, tz_hour, tz_min = date:match("([+-]?)(%d%d):(%d%d)$")
+      ret.tz_sign = tz_sign
+      ret.tz_hour = tz_hour
+      ret.tz_min = tz_min
+      return ret
+   end
 end
 
 function selftest()

--- a/src/lib/yang/util.lua
+++ b/src/lib/yang/util.lua
@@ -129,6 +129,8 @@ function timezone ()
    local now = os.time()
    local utctime = os.date("!*t", now)
    local localtime = os.date("*t", now)
+   -- Synchronize daylight-saving flags.
+   utctime.isdst = localtime.isdst
    local timediff = os.difftime(os.time(localtime), os.time(utctime))
    if timediff ~= 0 then
       local sign = timediff > 0 and "+" or "-"


### PR DESCRIPTION
I noticed `lib.yang.alarms` selftest was failing in my laptop (but passing in snabb2).

The following assert didn't hold:

```
local now = os.time()
assert(now == toseconds(format_date_as_iso_8601(now)),
           now.." != "..toseconds(format_date_as_iso_8601(now)))
```
In my laptop the difference between both times was 3600 seconds (1 hour). It seems the issue was a wrong computing of the timezone, which returned +01:00 when it should be +02:00 (because of summer time). What happened was that the difference between utc time and local time was +02:00 but local time had daylight-save flag set to true, while it was false in utc time. So to correctly computing the difference between both times I set utc time dst flag to the value of local time.

I also fixed the parsing of ISO8601 dates. A letter 'Z' should only be appended if time difference is higher or lower than zero.

I run alarms selftest either in my laptop and snabb2 and passes in both.