### PR TITLE
Back off RRD version to 3

### DIFF
--- a/src/lib/rrd.lua
+++ b/src/lib/rrd.lua
@@ -18,7 +18,7 @@ end
 local RRD = {}
 
 local rrd_cookie = "RRD\0"
-local rrd_version = "0005\0"
+local rrd_version = "0003\0"
 local float_cookie = 8.642135E130
 
 local fixed_header_t = ffi.typeof [[struct {
@@ -298,7 +298,7 @@ function dump(rrd, stream)
 end
 
 function dump_file(rrd, filename)
-   local f = file:open(filename, 'w')
+   local f = file.open(filename, 'w')
    dump(rrd, f)
    f:close()
 end


### PR DESCRIPTION
This is the default in upstream rrdtool, unless the RRD needs special
features.  ALso fix a bug in the dump_file function.

With these fixes, I successfully made a graph using:

 $ rrdtool graph -s now-10m -e now test.png DEF:foo=test.rrd:foo:AVERAGE AREA:foo#00ff00