### PR TITLE
Fix runtime error on running snabb alarms

### DIFF
--- a/src/program/alarms/README
+++ b/src/program/alarms/README
@@ -1,6 +1,7 @@
 Usage:
   snabb alarms compress
   snabb alarms get-state
+  snabb alarms listen
   snabb alarms purge
   snabb alarms set-operator-state
 

--- a/src/program/alarms/listen/listen.lua
+++ b/src/program/alarms/listen/listen.lua
@@ -19,7 +19,7 @@ local function parse_command_line(args)
    local handlers = {}
    function handlers.h() show_usage(0) end
    args = lib.dogetopt(args, handlers, "h", {help="h"})
-   if #args ~= 1 then show_usage(1, msg) end
+   if #args ~= 1 then show_usage(1) end
    return unpack(args)
 end
 


### PR DESCRIPTION
There's a runtime error when running `snabb alarms listen` with a wrong number of arguments.

The PR also shows subcommand `listen` in the list of available `alarms` programs.