### PR TITLE
Ptree manager record historical counter data into RRD files

### DIFF
--- a/src/lib/README.rrd.md
+++ b/src/lib/README.rrd.md
@@ -108,13 +108,13 @@ following keys defined:
    to be marked as known.  Defaults to `0.5`, indicating that at least
    half of corresponding PDPs must be marked as known.
 
-— Function **rrd.create_file** *arg* *filename*
+— Function **rrd.create_file** *filename* *arg*
 
 Create a new round-robin database as if calling `rrd.new` on *arg*, and
 then arrange for it to be mapped directly to *filename*.  Any subsequent
 update to the returned RRD database will be written to the file.
 
-— Function **rrd.create_shm** *arg* *name*
+— Function **rrd.create_shm** *name* *arg*
 
 Like **rrd.create_file**, but determining the file name by passing
 *name* to the `resolve` function of `core.shm`.

--- a/src/lib/README.rrd.md
+++ b/src/lib/README.rrd.md
@@ -27,9 +27,9 @@ primary data points per source.
 Primary data points are just the start, however; the actual long-term
 storage is made up of *consolidated data points* (CDPs).  A CDP is
 constructed from one or more PDPs via a *consolidation function* (CF).
-Snabb supports four consolidation functions: `average`, `minimum`,
-`maximum`, and `last`.  Average takes the average of the PDPs within
-range, minimum and maximum take the lowest or highest values
+Snabb supports four consolidation functions: `average`, `min`,
+`max`, and `last`.  Average takes the average of the PDPs within
+range, min and max take the lowest or highest values
 respectively, and last takes the last one.  An archive also specifies
 its own parameters for how many unknown PDPs should cause the CDP to be
 considered unknown as well.
@@ -94,8 +94,8 @@ are defined in a source definition:
 An archive definition is also a table of key/value pairs, with the
 following keys defined:
 
- * `cf`: The consolidation function; either `average`, `minimum`,
-   `maximum`, or `last`.  The default is `average`.  See the discussion
+ * `cf`: The consolidation function; either `average`, `min`,
+   `max`, or `last`.  The default is `average`.  See the discussion
    above for more on consolidation functions.
  * `duration`: How much data to store, in terms of time.  Required.
    As with `base_interval`, can be expressed in terms of hours, weeks,

--- a/src/lib/rrd.lua
+++ b/src/lib/rrd.lua
@@ -274,7 +274,7 @@ function new(arg)
    return open_mem(ptr, len)
 end
 
-function create_file(arg, filename)
+function create_file(filename, arg)
    local rrd = new(arg)
    local fd = assert(S.open(filename, "creat, rdwr, excl", '0664'))
    local f = file.fdopen(fd, 'wronly', filename)
@@ -286,10 +286,10 @@ function create_file(arg, filename)
    return open_mem(ptr, rrd.size)
 end
 
-function create_shm(arg, name)
+function create_shm(name, arg)
    local path = shm.resolve(name)
    shm.mkdir(lib.dirname(path))
-   return create_file(arg, shm.root..'/'..path)
+   return create_file(shm.root..'/'..path, name)
 end
 
 function dump(rrd, stream)

--- a/src/lib/rrd.lua
+++ b/src/lib/rrd.lua
@@ -7,6 +7,7 @@ module(..., package.seeall)
 local ffi = require("ffi")
 local S = require("syscall")
 local lib = require("core.lib")
+local shm = require("core.shm")
 local mem = require("lib.stream.mem")
 local file = require("lib.stream.file")
 
@@ -32,7 +33,7 @@ local fixed_header_t = ffi.typeof [[struct {
 }]]
 
 local source_types = lib.set('COUNTER', 'GAUGE')
-local consolidation_functions = lib.set('AVERAGE', 'MINIMUM', 'MAXIMUM', 'LAST')
+local consolidation_functions = lib.set('AVERAGE', 'MIN', 'MAX', 'LAST')
 
 -- The bit that's after the header, that depends on the shape of the RRD
 -- file.
@@ -289,7 +290,7 @@ end
 function create_shm(name, arg)
    local path = shm.resolve(name)
    shm.mkdir(lib.dirname(path))
-   return create_file(shm.root..'/'..path, name)
+   return create_file(shm.root..'/'..path, arg)
 end
 
 function dump(rrd, stream)
@@ -412,11 +413,11 @@ local function update_cdp(cdp, pdp_value, cf, pdp_pre, pdp_advance,
          if isnan(cdp.value) then cdp.value = 0 end
          cdp.value = cdp.value + pdp_value * pdp_advance_in_cdp
       end
-   elseif cf == 'maximum' then
+   elseif cf == 'max' then
       if isnan(cdp.value) then cdp.value = pdp_value
       elseif isnan(pdp_value) then -- pass
       else cdp.value = math.max(cdp.value, pdp_value) end
-   elseif cf == 'minimum' then
+   elseif cf == 'min' then
       if isnan(cdp.value) then cdp.value = pdp_value
       elseif isnan(pdp_value) then -- pass
       else cdp.value = math.min(cdp.value, pdp_value) end


### PR DESCRIPTION
This causes the ptree manager to create an RRD for each counter in each worker, as well as an RRD for the aggregated counter.

The overhead appears to be about 100KB in space per counter.  There are about 100 counters in a "snabb lwaftr bench" workload; I think a few more in a hardware workload.  So a system with 8 workers and one manager would have maybe 8*150 counters for the workers, and another 150 for the manager, or 1350 counters, or about 135MB.  It seems OK.  Currently these are mapped into shared memory but they could just as well go to an SSD.

In terms of time I don't have a good feeling yet.  I would expect around 100ns per counter sample + rrd update, which for our hypothetical 8-worker system would mean around 135us per update.  Since it happens in the manager process I'm not too worried about it though.

Here's a graph of the RRD created for breaths/s over the last 10 minutes, for this "snabb lwaftr bench" running on my old desktop, without dedicated CPU cores or pinning or anything like that:

![test](https://user-images.githubusercontent.com/1745903/41364013-a300870a-6f35-11e8-8da1-119b0474a381.png)

That was created by:

```
rrdtool graph -s now-10min -e now  /tmp/test.png \
   DEF:avg=/var/run/snabb/17503/engine/breaths.rrd:value:AVERAGE \
   DEF:max=/var/run/snabb/17503/engine/breaths.rrd:value:MAX \
   AREA:avg#00ff00 \
   LINE:max#00bb00 \
```

In this case the max and average are the same because we're still within the frequently-sampled space.  Anyway, cool stuff!