### PR TITLE
Fix notification_peers is nil error in ptree

### DIFF
--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -229,7 +229,7 @@ end
 function Manager:handle_notification_peer(peer)
    local q = queue.new()
    self.notification_peers[q] = true
-   function q:close()
+   function q.close()
       self.notification_peers[q] = nil
       peer:close()
    end


### PR DESCRIPTION
Fixes `attempt to index field 'notification_peers' (a nil value)` when a notifications peer socket is closed. `self` inside the the `q:close` function was referring to `q` rather than `Manager` due to use of `:` rather than `.`