### PR TITLE
Run consistency checker on ietf alarms

### DIFF
--- a/src/lib/yang/path_data.lua
+++ b/src/lib/yang/path_data.lua
@@ -491,8 +491,10 @@ function consistency_checker_from_grammar(grammar)
    for path, node in visit_leafref_paths(grammar) do
       if require_instance(node) then
          local leafref = to_absolute_path(leafref(node), path)
-         local getter = resolver(grammar, lib.dirname(leafref))
-         table.insert(leafrefs, {path=path, leafref=leafref, getter=getter})
+         local success, getter = pcall(resolver, grammar, lib.dirname(leafref))
+         if success then
+            table.insert(leafrefs, {path=path, leafref=leafref, getter=getter})
+         end
       end
    end
    if #leafrefs == 0 then return function(data) end end

--- a/src/lib/yang/path_data.lua
+++ b/src/lib/yang/path_data.lua
@@ -434,6 +434,7 @@ remover_for_schema_by_name = util.memoize(remover_for_schema_by_name)
 function consistency_checker_from_grammar(grammar)
    -- Converts a relative path to an absolute path.
    local function to_absolute_path (leafref, path)
+      if leafref:sub(1, 1) == '/' then return leafref end
       if leafref:sub(1, 2) == './' then
          leafref = leafref:sub(3)
          return path..'/'..leafref

--- a/src/lib/yang/path_data.lua
+++ b/src/lib/yang/path_data.lua
@@ -667,5 +667,8 @@ function selftest()
    local checker = consistency_checker_from_schema(my_schema, true)
    checker(loaded_data)
 
+   local checker = consistency_checker_from_schema_by_name('ietf-alarms', false)
+   assert(checker)
+
    print("selftest: ok")
 end

--- a/src/lib/yang/path_data.lua
+++ b/src/lib/yang/path_data.lua
@@ -433,18 +433,19 @@ remover_for_schema_by_name = util.memoize(remover_for_schema_by_name)
 
 function consistency_checker_from_grammar(grammar)
    -- Converts a relative path to an absolute path.
-   local function to_absolute_path (leafref, path)
-      leafref = leafref:gsub("current%(%)", path)
-      if leafref:sub(1, 1) == '/' then return leafref end
-      if leafref:sub(1, 2) == './' then
-         leafref = leafref:sub(3)
-         return path..'/'..leafref
+   -- TODO: Consider moving it to /lib/yang/path.lua.
+   local function to_absolute_path (path, node_path)
+      path = path:gsub("current%(%)", node_path)
+      if path:sub(1, 1) == '/' then return path end
+      if path:sub(1, 2) == './' then
+         path = path:sub(3)
+         return node_path..'/'..path
       end
-      while leafref:sub(1, 3) == '../' do
-         leafref = leafref:sub(4)
-         path = lib.dirname(path)
+      while path:sub(1, 3) == '../' do
+         path = path:sub(4)
+         node_path = lib.dirname(node_path)
       end
-      return path..'/'..leafref
+      return node_path..'/'..path
    end
    local function leafref (node)
       return node.argument_type and node.argument_type.leafref

--- a/src/lib/yang/path_data.lua
+++ b/src/lib/yang/path_data.lua
@@ -488,7 +488,7 @@ function consistency_checker_from_grammar(grammar)
    for path, node in visit_leafref_paths(grammar) do
       if require_instance(node) then
          local leafref = to_absolute_path(leafref(node), path)
-         local getter = resolver(grammar, leafref)
+         local getter = resolver(grammar, lib.dirname(leafref))
          table.insert(leafrefs, {path=path, leafref=leafref, getter=getter})
       end
    end
@@ -641,7 +641,7 @@ function selftest()
          }
          leaf mgmt {
             type leafref {
-               path "../interface";
+               path "../interface/name";
             }
          }
       }

--- a/src/lib/yang/path_data.lua
+++ b/src/lib/yang/path_data.lua
@@ -434,6 +434,7 @@ remover_for_schema_by_name = util.memoize(remover_for_schema_by_name)
 function consistency_checker_from_grammar(grammar)
    -- Converts a relative path to an absolute path.
    local function to_absolute_path (leafref, path)
+      leafref = leafref:gsub("current%(%)", path)
       if leafref:sub(1, 1) == '/' then return leafref end
       if leafref:sub(1, 2) == './' then
          leafref = leafref:sub(3)


### PR DESCRIPTION
Only added as test for now.

It was necessary to fix several things:
* When retrieving a getter in the consistency check, the getter should actually be in the parent path so when the property is checked is done on the parent.
* Several improvements in `to_absolute_path`.
* Function `parse_patg` split a path by '/'. If the path contained nested paths, as it happens in several leafref paths of ietf-alarms, the parse function returned an error. Now nested paths are taken into account, but the resolution of a path of this kind is not working yet. For instance: `/alarms/alarm-list/alarm[resource=alarms/alarm-list/alarm/related-alarm/resource]`.
* Since nested paths are not working yet, only successfully getters are added to the list of leafrefs to verify.