### PR TITLE
Add ability to "snabb top" to skim back through time

### DIFF
--- a/src/lib/rrd.lua
+++ b/src/lib/rrd.lua
@@ -356,6 +356,11 @@ function ref(rrd, t)
          end
       end
    end
+   for name,source in pairs(ret) do
+      for cf,readings in pairs(source.cf) do
+         table.sort(readings, function(a,b) return a.interval<b.interval end)
+      end
+   end
    return ret
 end
 


### PR DESCRIPTION
When "snabb top" is paused, the user can use the `[` and `]` keys to go back and forward by a second.  Going to a time other than the last sample time uses the RRD file instead of the raw counters, to get the values.  You can also skim by a minute using `{` and `}`.  It seems to be fast enough; I can get through an hour in about a second or two, then precisely go by seconds likewise.

Next up will be documentation.