### PR TITLE
[WIP] Replace nic hardcoded name for argument

### DIFF
--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -130,13 +130,10 @@ end
 -- Requires a V4V6 splitter if running in on-a-stick mode and VLAN tag values
 -- are the same for the internal and external interfaces.
 local function requires_splitter (opts, conf)
-   local device, id, queue = lwutil.parse_instance(conf)
-   if opts["on-a-stick"] then
-      local internal_interface = queue.internal_interface
-      local external_interface = queue.external_interface
-      return internal_interface.vlan_tag == external_interface.vlan_tag
-   end
-   return false
+   local queue = select(3, lwutil.parse_instance(conf))
+   local internal_interface = queue.internal_interface
+   local external_interface = queue.external_interface
+   return internal_interface.vlan_tag == external_interface.vlan_tag
 end
 
 function run(args)


### PR DESCRIPTION
Finally I figured out why run wasn't working when setting device argument directly on a configuration file (without passing `--on-a-stick` parameter). The problem was that the function that sets up the nic app had the name of the app hardcode when it should be parametrized. That resulted in a app graph that used one for the app and a different name for the links (all packets dropped).