### PR TITLE
Fix function require_splitter

### DIFF
--- a/src/apps/lwaftr/lwutil.lua
+++ b/src/apps/lwaftr/lwutil.lua
@@ -36,6 +36,11 @@ function parse_instance(conf)
    return device, id, queue
 end
 
+function is_on_a_stick(device, queue)
+   if not queue.external_interface.device and device then return true end
+   return device == queue.external_interface.device
+end
+
 function get_ihl_from_offset(pkt, offset)
    local ver_and_ihl = pkt.data[offset]
    return band(ver_and_ihl, 0xf) * 4

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -18,7 +18,7 @@ local function show_usage(exit_code)
    print(require("program.lwaftr.run.README_inc"))
    if exit_code then main.exit(exit_code) end
 end
-local function migrate_device_on_config(config, v4, v6, on_a_stick)
+local function migrate_device_on_config(config, v4, v6)
    -- Validate there is only one instance, otherwise the option is ambiguous.
    local device, instance
    for k, v in pairs(config.softwire_config.instance) do
@@ -40,12 +40,6 @@ local function migrate_device_on_config(config, v4, v6, on_a_stick)
    if v6 then
       for id, queue in cltable.pairs(instance.queue) do
          queue.external_interface.device = v6
-      end
-   end
-
-   if on_a_stick then
-      for id, queue in cltable.pairs(instance.queue) do
-         queue.external_interface.device = v4
       end
    end
 end
@@ -148,7 +142,8 @@ function run(args)
 
    -- If the user passed --v4, --v6, or --on-a-stick, migrate the
    -- configuration's device.
-   if v4 or v6 then migrate_device_on_config(conf, v4, v6, opts['on-a-stick']) end
+   if opts['on-a-stick'] then assert(v4); v6 = v4 end
+   if v4 or v6 then migrate_device_on_config(conf, v4, v6) end
 
    -- If there is a name defined on the command line, it should override
    -- anything defined in the config.

--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -130,13 +130,10 @@ end
 -- Requires a V4V6 splitter if running in on-a-stick mode and VLAN tag values
 -- are the same for the internal and external interfaces.
 local function requires_splitter (opts, conf)
-   local device, id, queue = lwutil.parse_instance(conf)
-   if opts["on-a-stick"] then
-      local internal_interface = queue.internal_interface
-      local external_interface = queue.external_interface
-      return internal_interface.vlan_tag == external_interface.vlan_tag
-   end
-   return false
+   local queue = select(3, lwutil.parse_instance(conf))
+   local internal_interface = queue.internal_interface
+   local external_interface = queue.external_interface
+   return internal_interface.vlan_tag == external_interface.vlan_tag
 end
 
 function run(args)

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -324,6 +324,9 @@ function load_on_a_stick(c, conf, args)
       link_source(c, v4v6..'.v4', v4v6..'.v6')
       link_sink(c, v4v6..'.v4', v4v6..'.v6')
    else
+      assert(queue.external_interface.mac ~= queue.internal_interface.mac,
+             "When using different VLAN tags, external and internal MAC "..
+                "addresses must be different too")
       config.app(c, v4_nic_name, driver, {
          pciaddr = pciaddr,
          vmdq=true, -- Needed to enable MAC filtering/stamping.


### PR DESCRIPTION
The function returns whether a V4V6 splitter app is required.  Before it checked whether an parameter `on-a-stick` was a command line argument, but this should not be the case as an on-a-stick setup is also possible when a configuration file has only one instance and one queue.

This caused that the function returned `true` if passing an `on-a-stick` argument to the command line, but returned `false` if running a lwaftr using only a configuration file.

After this fix I'll check whether the code path that not uses a splitter is correct (using vlan tags but different vlan tags), but that's another issue IMHO.