### PR TITLE
Add missing cltable include

### DIFF
--- a/src/lib/yang/path_data.lua
+++ b/src/lib/yang/path_data.lua
@@ -9,6 +9,7 @@ local value = require("lib.yang.value")
 local schema = require("lib.yang.schema")
 local parse_path = require("lib.yang.path").parse_path
 local util = require("lib.yang.util")
+local cltable = require("lib.cltable")
 local normalize_id = data.normalize_id
 
 local function table_keys(t)


### PR DESCRIPTION
When using `adder_for_schema_by_name` with a string or ctype key, an error is thrown at line 314 of `path_data.lua` as it attempts to set `pairs` to `cltable.pairs` - which is not `require`'d.
