### PR TITLE
Fix bad argument #2 to 'format'

### DIFF
--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -626,7 +626,7 @@ function compute_display_tree.interface(tree, prev, dt, t)
               lchars('%.3f %sPPS', scale(pps)),
               lchars('%.3f %sbps', scale(bps)),
               lchars('%.2f%%', bps/max*100),
-              drops > 0 and rchars('%.3f %sPPS dropped', drops) or nil)
+              drops > 0 and rchars('%.3f %sPPS dropped', scale(drops)) or nil)
    end
    local function show_pci(addr, pci, prev)
       local bps, tag = scale(tonumber(pci.speed and pci.speed.value) or 0)


### PR DESCRIPTION
Some times while running `snabb top` I got this error:

```
while running fiber: program/top/top.lua:587: bad argument #2 to 'format' (no value)
```
The problem is that there's one string formatted with two placeholders, but only one argument is passed . I debugged the problem and found out the culprit string was `%.3f %sPPS dropped`. I think the issue is that the argument is meant to be filtered by `scale`.