### PR TITLE
Fix loadtest find-limit arguments for short form

### DIFF
--- a/src/program/loadtest/find-limit/find-limit.lua
+++ b/src/program/loadtest/find-limit/find-limit.lua
@@ -85,9 +85,9 @@ local function parse_args(args)
 
    if #args == 2 then
       args = {
-         args[1],
+         args[2],
          'NIC', 'NIC',
-         args[2]
+         args[1]
       }
    end
    if #args == 0 or #args % 4 ~= 0 then show_usage(1) end


### PR DESCRIPTION
The loadtest command can take the (legacy) short form when sending traffic to one PCAP file. Here's what the docs say:

```
Usage: find-limit [OPTIONS] <PCAP-FILE> <TX-NAME> <RX-NAME> <PCI> [<PCAP-FILE> <TX-NAME> <RX-NAME> <PCI>]...
       find-limit [OPTIONS] <PCAP-FILE> <PCI>
...
Examples:
  find-limit 01:00.0 cap1.pcap
```

When tested with:
```
[jtallon@snabb1:~/snabb/src]$ sudo ./snabb loadtest find-limit 02:00.0 configs/dataset/from-inet-and-b4-test.pcap 
core/main.lua:26: No such device: configs/dataset/from-inet-and-b4-test.pcap
```

This fixes that