### PR TITLE
Initialize stats queue number

### DIFF
--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -234,7 +234,8 @@ function load_phy(c, conf, v4_nic_name, v6_nic_name, ring_buffer_size)
       txq=id,
       poolnum=0,
       vlan=queue.external_interface.vlan_tag,
-      rxcounter=1,
+      rxcounter=id,
+      txcounter=id,
       ring_buffer_size=ring_buffer_size,
       macaddr=ethernet:ntop(queue.external_interface.mac)})
    config.app(c, v6_nic_name, require(v6_info.driver).driver, {
@@ -244,7 +245,8 @@ function load_phy(c, conf, v4_nic_name, v6_nic_name, ring_buffer_size)
       txq=id,
       poolnum=0,
       vlan=queue.internal_interface.vlan_tag,
-      rxcounter=1,
+      rxcounter=id,
+      txcounter=id,
       ring_buffer_size=ring_buffer_size,
       macaddr = ethernet:ntop(queue.internal_interface.mac)})
 
@@ -306,6 +308,8 @@ function load_on_a_stick(c, conf, args)
          poolnum=0,
          vlan=queue.external_interface.vlan_tag,
          ring_buffer_size=args.ring_buffer_size,
+         rxcounter = id,
+         txcounter = id,
          macaddr = ethernet:ntop(queue.external_interface.mac)})
       if mirror then
          local Tap = require("apps.tap.tap").Tap
@@ -335,6 +339,8 @@ function load_on_a_stick(c, conf, args)
          poolnum=0,
          vlan=queue.external_interface.vlan_tag,
          ring_buffer_size=args.ring_buffer_size,
+         rxcounter = id,
+         txcounter = id,
          macaddr = ethernet:ntop(queue.external_interface.mac)})
       config.app(c, v6_nic_name, driver, {
          pciaddr = pciaddr,
@@ -344,6 +350,8 @@ function load_on_a_stick(c, conf, args)
          poolnum=1,
          vlan=queue.internal_interface.vlan_tag,
          ring_buffer_size=args.ring_buffer_size,
+         rxcounter = id,
+         txcounter = id,
          macaddr = ethernet:ntop(queue.internal_interface.mac)})
 
       link_source(c, v4_nic_name..'.'..device.tx, v6_nic_name..'.'..device.tx)


### PR DESCRIPTION
Arguments `rxcounter`/`txcounter` indicate which stats queue is used to store NIC statistics such as `rxpackets`, `txpackets`, etc.  If these arguments are not initialized all the stats are stored in queue 0.  When using RSS which uses a NIC with the same PCI address, if this argument is not initialized all virtualized NICs use queue 0 for stats, making it impossible to differentiate statistic per queue.  Thus, these arguments are initialized to the queue's id.