### PR TITLE
Show queue counters per app

### DIFF
--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -1288,21 +1288,30 @@ function Intel82599:rxdmapackets ()
 end
 
 function Intel82599:init_queue_stats (frame)
-   local perqregs = {
-      rxdrops = "QPRDC",
-      rxpackets = "QPRC",
-      txpackets = "QPTC",
-      rxbytes = "QBRC64",
-      txbytes = "QBTC64",
-   }
    self.queue_stats = {}
-   for i=0,15 do
-      for k,v in pairs(perqregs) do
+   function init_queue_regs (qregs, i)
+      for k,v in pairs(qregs) do
          local name = "q" .. i .. "_" .. k
          table.insert(self.queue_stats, name)
          table.insert(self.queue_stats, self.r[v][i])
          frame[name] = {counter}
       end
+   end
+   local perq_rx_regs = {
+      rxbytes = "QBRC64",
+      rxdrops = "QPRDC",
+      rxpackets = "QPRC",
+   }
+   local perq_tx_regs = {
+      txbytes = "QBTC64",
+      txpackets = "QPTC",
+   }
+   local rx, tx = self.rxcounter, self.txcounter
+   for i=rx or 0,rx or 15 do
+      init_queue_regs(perq_rx_regs, i)
+   end
+   for i=tx or 0,tx or 15 do
+      init_queue_regs(perq_tx_regs, i)
    end
 end
 

--- a/src/apps/intel_mp/test_10g_vmdq_mirror.snabb
+++ b/src/apps/intel_mp/test_10g_vmdq_mirror.snabb
@@ -38,6 +38,7 @@ config.app(c, "nic1p1", intel.Intel,
              macaddr = "12:34:56:78:9a:bc",
              rxq = 0,
              rxcounter = 2,
+             run_stats = true,
              wait_for_link = true })
 
 config.app(c, "nic1p2", intel.Intel,
@@ -48,6 +49,7 @@ config.app(c, "nic1p2", intel.Intel,
              macaddr = "aa:aa:aa:aa:aa:aa",
              rxq = 0,
              rxcounter = 3,
+             run_stats = true,
              wait_for_link = true })
 
 config.app(c, "pcap", pcap.PcapReader, "source2.pcap")

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -236,6 +236,7 @@ function load_phy(c, conf, v4_nic_name, v6_nic_name, ring_buffer_size)
       vlan=queue.external_interface.vlan_tag,
       rxcounter=id,
       txcounter=id,
+      run_stats = true,
       ring_buffer_size=ring_buffer_size,
       macaddr=ethernet:ntop(queue.external_interface.mac)})
    config.app(c, v6_nic_name, require(v6_info.driver).driver, {
@@ -247,6 +248,7 @@ function load_phy(c, conf, v4_nic_name, v6_nic_name, ring_buffer_size)
       vlan=queue.internal_interface.vlan_tag,
       rxcounter=id,
       txcounter=id,
+      run_stats = true,
       ring_buffer_size=ring_buffer_size,
       macaddr = ethernet:ntop(queue.internal_interface.mac)})
 
@@ -310,6 +312,7 @@ function load_on_a_stick(c, conf, args)
          ring_buffer_size=args.ring_buffer_size,
          rxcounter = id,
          txcounter = id,
+         run_stats = true,
          macaddr = ethernet:ntop(queue.external_interface.mac)})
       if mirror then
          local Tap = require("apps.tap.tap").Tap
@@ -341,6 +344,7 @@ function load_on_a_stick(c, conf, args)
          ring_buffer_size=args.ring_buffer_size,
          rxcounter = id,
          txcounter = id,
+         run_stats = true,
          macaddr = ethernet:ntop(queue.external_interface.mac)})
       config.app(c, v6_nic_name, driver, {
          pciaddr = pciaddr,
@@ -352,6 +356,7 @@ function load_on_a_stick(c, conf, args)
          ring_buffer_size=args.ring_buffer_size,
          rxcounter = id,
          txcounter = id,
+         run_stats = true,
          macaddr = ethernet:ntop(queue.internal_interface.mac)})
 
       link_source(c, v4_nic_name..'.'..device.tx, v6_nic_name..'.'..device.tx)


### PR DESCRIPTION
Instead of initializing all the stats queue, what it's done now is if an rxcounter or txcounter is passed only the corresponding stat queue is initialized. That combined with setting `run_stats=true` in all setup configurations, makes that each app prints out its device in snabb top and only shows statistics corresponding to its relevant queue.