### PR TITLE
[WIP] Attempt to fix NaN values

### DIFF
--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -492,8 +492,11 @@ local function compute_rate(v, prev, rrd, t, dt)
    end
 end
 
+local function isnan (n) return n ~= n end
+
 local function scale(x)
-   x=tonumber(x)
+   if isnan(x) then return 8888, '' end
+   x = tonumber(x)
    for _,scale in ipairs {{'T', 1e12}, {'G', 1e9}, {'M', 1e6}, {'k', 1e3}} do
       local tag, base = unpack(scale)
       if x > base then return x/base, tag end
@@ -647,10 +650,10 @@ function compute_display_tree.interface(tree, prev, dt, t)
          latency_str = string.format('latency: %.2f min, %.2f avg, %.2f max',
                                      summarize_histogram(latency, prev))
       end
+      local breaths, tag = scale(rate('breaths', engine, prev_engine))
       gridrow(label,
               lchars('PID %s:', instance.pid),
-              lchars('%.2f %sbreaths/s',
-                     scale(rate('breaths', engine, prev_engine))),
+              lchars('%.2f %sbreaths/s', breaths, tag),
               lchars('%s', latency_str))
       if instance.workers then
          for pid, instance in sortedpairs(instance.workers) do


### PR DESCRIPTION
Sometimes `snabb top` prints out NaN values. I dig into that and it seems that sometimes function `rate` returns NaN, likely because a counter is not defined or perhaps because `prev` is not defined.

In this patch I modified `scale` to return 8888 is input number is NaN. Here's the screenshot I got:

![screenshot](https://user-images.githubusercontent.com/11567/41970303-9c48ef6c-7a0a-11e8-9f7f-631be34caac1.png)

It's tricky to reproduce the issue, but it happens often. I think one case to trigger NaN values is to run find-limit before a lwAFTR instance is running. If not several attempts at run one before the other will eventually trigger the issue. Whenever stopping `find-limit` or `run`, `snabb top` should be run and stopped as well (at least that's what I do). 