### PR TITLE
Codec refactor

### DIFF
--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -417,35 +417,25 @@ function Intel:new (conf)
       self.sync_timer = lib.throttle(0.01)
    end
 
-   alarms.add_to_inventory {
-      [{alarm_type_id='ingress-bandwith'}] = {
-         resource=tostring(S.getpid()),
-         has_clear=true,
-         description='Ingress bandwith exceeds N Gbps',
-      }
-   }
-   local ingress_bandwith = alarms.declare_alarm {
-      [{resource=tostring(S.getpid()),alarm_type_id='ingress-bandwith'}] = {
-         perceived_severity='major',
-         alarm_text='Ingress bandwith exceeds 1e9 bytes/s which can cause packet drops.'
-      }
-   }
+   alarms.add_to_inventory(
+      {alarm_type_id='ingress-bandwith'},
+      {resource=tostring(S.getpid()), has_clear=true,
+       description='Ingress bandwith exceeds N Gbps'})
+   local ingress_bandwith = alarms.declare_alarm(
+      {resource=tostring(S.getpid()),alarm_type_id='ingress-bandwith'},
+      {perceived_severity='major',
+       alarm_text='Ingress bandwith exceeds 1e9 bytes/s which can cause packet drops.'})
    self.ingress_bandwith_alarm = CallbackAlarm.new(ingress_bandwith,
       1, 1e9, function() return self:rxbytes() end)
 
-   alarms.add_to_inventory {
-      [{alarm_type_id='ingress-packet-rate'}] = {
-         resource=tostring(S.getpid()),
-         has_clear=true,
-         description='Ingress packet-rate exceeds N Gbps',
-      }
-   }
-   local ingress_packet_rate = alarms.declare_alarm {
-      [{resource=tostring(S.getpid()),alarm_type_id='ingress-packet-rate'}] = {
-         perceived_severity='major',
-         alarm_text='Ingress packet-rate exceeds 2MPPS which can cause packet drops.'
-      }
-   }
+   alarms.add_to_inventory(
+      {alarm_type_id='ingress-packet-rate'},
+      {resource=tostring(S.getpid()), has_clear=true,
+       description='Ingress packet-rate exceeds N Gbps'})
+   local ingress_packet_rate = alarms.declare_alarm(
+      {resource=tostring(S.getpid()),alarm_type_id='ingress-packet-rate'},
+      {perceived_severity='major',
+       alarm_text='Ingress packet-rate exceeds 2MPPS which can cause packet drops.'})
    self.ingress_packet_rate_alarm = CallbackAlarm.new(ingress_packet_rate,
       1, 2e6, function() return self:rxpackets() end)
 

--- a/src/apps/ipv4/arp.lua
+++ b/src/apps/ipv4/arp.lua
@@ -23,19 +23,14 @@ local ipv4     = require("lib.protocol.ipv4")
 local alarms = require("lib.yang.alarms")
 local S = require("syscall")
 
-alarms.add_to_inventory {
-  [{alarm_type_id='arp-resolution'}] = {
-    resource=tostring(S.getpid()),
-    has_clear=true,
-    description='Raise up if ARP app cannot resolve IP address',
-  }
-}
-local resolve_alarm = alarms.declare_alarm {
-   [{resource=tostring(S.getpid()), alarm_type_id='arp-resolution'}] = {
-      perceived_severity = 'critical',
-      alarm_text = 'Make sure you can ARP resolve IP addresses on NIC',
-   },
-}
+alarms.add_to_inventory(
+   {alarm_type_id='arp-resolution'},
+   {resource=tostring(S.getpid()), has_clear=true,
+    description='Raise up if ARP app cannot resolve IP address'})
+local resolve_alarm = alarms.declare_alarm(
+   {resource=tostring(S.getpid()), alarm_type_id='arp-resolution'},
+   {perceived_severity = 'critical',
+    alarm_text = 'Make sure you can ARP resolve IP addresses on NIC'})
 
 local C = ffi.C
 local receive, transmit = link.receive, link.transmit

--- a/src/apps/ipv4/fragment.lua
+++ b/src/apps/ipv4/fragment.lua
@@ -93,19 +93,14 @@ function Fragmenter:new(conf)
    o.next_fragment_id = deterministic_first_fragment_id or
       math.random(0, 0xffff)
 
-   alarms.add_to_inventory {
-      [{alarm_type_id='outgoing-ipv4-fragments'}] = {
-         resource=tostring(S.getpid()),
-         has_clear=true,
-         description='Outgoing IPv4 fragments over N fragments/s',
-      }
-   }
-   local outgoing_fragments_alarm = alarms.declare_alarm {
-      [{resource=tostring(S.getpid()),alarm_type_id='outgoing-ipv4-fragments'}] = {
-         perceived_severity='warning',
-         alarm_text='More than 10,000 outgoing IPv4 fragments per second',
-      }
-   }
+   alarms.add_to_inventory(
+      {alarm_type_id='outgoing-ipv4-fragments'},
+      {resource=tostring(S.getpid()), has_clear=true,
+       description='Outgoing IPv4 fragments over N fragments/s'})
+   local outgoing_fragments_alarm = alarms.declare_alarm(
+      {resource=tostring(S.getpid()),alarm_type_id='outgoing-ipv4-fragments'},
+      {perceived_severity='warning',
+       alarm_text='More than 10,000 outgoing IPv4 fragments per second'})
    o.outgoing_ipv4_fragments_alarm = CounterAlarm.new(outgoing_fragments_alarm,
       1, 1e4, o, "out-ipv4-frag")
 

--- a/src/apps/ipv4/reassemble.lua
+++ b/src/apps/ipv4/reassemble.lua
@@ -163,19 +163,14 @@ function Reassembler:new(conf)
    o.scratch_reassembly = params.value_type()
    o.next_counter_update = -1
 
-   alarms.add_to_inventory {
-      [{alarm_type_id='incoming-ipv4-fragments'}] = {
-         resource=tostring(S.getpid()),
-         has_clear=true,
-         description='Incoming IPv4 fragments over N fragments/s',
-      }
-   }
-   local incoming_fragments_alarm = alarms.declare_alarm {
-      [{resource=tostring(S.getpid()),alarm_type_id='incoming-ipv4-fragments'}] = {
-         perceived_severity='warning',
-         alarm_text='More than 10,000 IPv4 fragments per second',
-      }
-   }
+   alarms.add_to_inventory(
+      {alarm_type_id='incoming-ipv4-fragments'},
+      {resource=tostring(S.getpid()), has_clear=true,
+       description='Incoming IPv4 fragments over N fragments/s'})
+   local incoming_fragments_alarm = alarms.declare_alarm(
+      {resource=tostring(S.getpid()),alarm_type_id='incoming-ipv4-fragments'},
+      {perceived_severity='warning',
+       alarm_text='More than 10,000 IPv4 fragments per second'})
    o.incoming_ipv4_fragments_alarm = CounterAlarm.new(incoming_fragments_alarm,
       1, 1e4, o, "in-ipv4-frag-needs-reassembly")
 

--- a/src/apps/ipv6/fragment.lua
+++ b/src/apps/ipv6/fragment.lua
@@ -99,19 +99,14 @@ function Fragmenter:new(conf)
    o.next_fragment_id = deterministic_first_fragment_id or
       math.random(0, 0xffffffff)
 
-   alarms.add_to_inventory {
-      [{alarm_type_id='outgoing-ipv6-fragments'}] = {
-         resource=tostring(S.getpid()),
-         has_clear=true,
-         description='Outgoing IPv6 fragments over N fragments/s',
-      }
-   }
-   local outgoing_fragments_alarm = alarms.declare_alarm {
-      [{resource=tostring(S.getpid()),alarm_type_id='outgoing-ipv6-fragments'}] = {
-         perceived_severity='warning',
-         alarm_text='More than 10,000 outgoing IPv6 fragments per second',
-      }
-   }
+   alarms.add_to_inventory(
+      {alarm_type_id='outgoing-ipv6-fragments'},
+      {resource=tostring(S.getpid()), has_clear=true,
+       description='Outgoing IPv6 fragments over N fragments/s'})
+   local outgoing_fragments_alarm = alarms.declare_alarm(
+      {resource=tostring(S.getpid()),alarm_type_id='outgoing-ipv6-fragments'},
+      {perceived_severity='warning',
+       alarm_text='More than 10,000 outgoing IPv6 fragments per second'})
    o.outgoing_ipv6_fragments_alarm = CounterAlarm.new(outgoing_fragments_alarm,
       1, 1e4, o, "out-ipv6-frag")
 

--- a/src/apps/ipv6/reassemble.lua
+++ b/src/apps/ipv6/reassemble.lua
@@ -165,19 +165,14 @@ function Reassembler:new(conf)
    o.scratch_reassembly = params.value_type()
    o.next_counter_update = -1
 
-   alarms.add_to_inventory {
-      [{alarm_type_id='incoming-ipv6-fragments'}] = {
-         resource=tostring(S.getpid()),
-         has_clear=true,
-         description='Incoming IPv6 fragments over N fragments/s',
-      }
-   }
-   local incoming_fragments_alarm = alarms.declare_alarm {
-      [{resource=tostring(S.getpid()),alarm_type_id='incoming-ipv6-fragments'}] = {
-         perceived_severity='warning',
-         alarm_text='More than 10,000 IPv6 fragments per second',
-      }
-   }
+   alarms.add_to_inventory(
+      {alarm_type_id='incoming-ipv6-fragments'},
+      {resource=tostring(S.getpid()), has_clear=true,
+       description='Incoming IPv6 fragments over N fragments/s'})
+   local incoming_fragments_alarm = alarms.declare_alarm(
+      {resource=tostring(S.getpid()),alarm_type_id='incoming-ipv6-fragments'},
+      {perceived_severity='warning',
+       alarm_text='More than 10,000 IPv6 fragments per second'})
    o.incoming_ipv6_fragments_alarm = CounterAlarm.new(incoming_fragments_alarm,
       1, 1e4, o, "in-ipv6-frag-needs-reassembly")
 

--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -432,38 +432,28 @@ function LwAftr:new(conf)
    o.icmpv6_error_count = 0
    o.icmpv6_error_rate_limit_start = 0
 
-   alarms.add_to_inventory {
-     [{alarm_type_id='bad-ipv4-softwires-matches'}] = {
-       resource=tostring(S.getpid()),
-       has_clear=true,
+   alarms.add_to_inventory(
+      {alarm_type_id='bad-ipv4-softwires-matches'},
+      {resource=tostring(S.getpid()), has_clear=true,
        description="lwAFTR's bad matching softwires due to not found destination "..
-         "address for IPv4 packets",
-     }
-   }
-   alarms.add_to_inventory {
-     [{alarm_type_id='bad-ipv6-softwires-matches'}] = {
-       resource=tostring(S.getpid()),
-       has_clear=true,
+          "address for IPv4 packets"})
+   alarms.add_to_inventory(
+      {alarm_type_id='bad-ipv6-softwires-matches'},
+      {resource=tostring(S.getpid()), has_clear=true,
        description="lwAFTR's bad matching softwires due to not found source"..
-         "address for IPv6 packets",
-     }
-   }
-   local bad_ipv4_softwire_matches = alarms.declare_alarm {
-      [{resource=tostring(S.getpid()), alarm_type_id='bad-ipv4-softwires-matches'}] = {
-         perceived_severity = 'major',
-         alarm_text = "lwAFTR's bad softwires matches due to non matching destination"..
-            "address for incoming packets (IPv4) has reached over 100,000 softwires "..
-            "binding-table.  Please review your lwAFTR's configuration binding-table."
-      },
-   }
-   local bad_ipv6_softwire_matches = alarms.declare_alarm {
-      [{resource=tostring(S.getpid()), alarm_type_id='bad-ipv6-softwires-matches'}] = {
-         perceived_severity = 'major',
-         alarm_text = "lwAFTR's bad softwires matches due to non matching source "..
-            "address for outgoing packets (IPv6) has reached over 100,000 softwires "..
-            "binding-table.  Please review your lwAFTR's configuration binding-table."
-      },
-   }
+          "address for IPv6 packets"})
+   local bad_ipv4_softwire_matches = alarms.declare_alarm(
+      {resource=tostring(S.getpid()), alarm_type_id='bad-ipv4-softwires-matches'},
+      {perceived_severity = 'major',
+       alarm_text = "lwAFTR's bad softwires matches due to non matching destination"..
+         "address for incoming packets (IPv4) has reached over 100,000 softwires "..
+         "binding-table.  Please review your lwAFTR's configuration binding-table."})
+   local bad_ipv6_softwire_matches = alarms.declare_alarm(
+      {resource=tostring(S.getpid()), alarm_type_id='bad-ipv6-softwires-matches'},
+      {perceived_severity = 'major',
+       alarm_text = "lwAFTR's bad softwires matches due to non matching source "..
+         "address for outgoing packets (IPv6) has reached over 100,000 softwires "..
+         "binding-table.  Please review your lwAFTR's configuration binding-table."})
    o.bad_ipv4_softwire_matches_alarm = CounterAlarm.new(bad_ipv4_softwire_matches,
       5, 1e5, o, 'drop-no-dest-softwire-ipv4-packets')
    o.bad_ipv6_softwire_matches_alarm = CounterAlarm.new(bad_ipv6_softwire_matches,

--- a/src/apps/lwaftr/ndp.lua
+++ b/src/apps/lwaftr/ndp.lua
@@ -31,19 +31,14 @@ local ipv6     = require("lib.protocol.ipv6")
 local alarms = require("lib.yang.alarms")
 local S = require("syscall")
 
-alarms.add_to_inventory {
-   [{alarm_type_id='ndp-resolution'}] = {
-      resource=tostring(S.getpid()),
-      has_clear=true,
-      description='Raise up if NDP app cannot resolve IPv6 address'
-   }
-}
-local resolve_alarm = alarms.declare_alarm {
-   [{resource=tostring(S.getpid()), alarm_type_id='ndp-resolution'}] = {
-      perceived_severity = 'critical',
-      alarm_text = 'Make sure you can NDP resolve IP addresses on NIC',
-   },
-}
+alarms.add_to_inventory(
+   {alarm_type_id='ndp-resolution'},
+   {resource=tostring(S.getpid()), has_clear=true,
+    description='Raise up if NDP app cannot resolve IPv6 address'})
+local resolve_alarm = alarms.declare_alarm(
+   {resource=tostring(S.getpid()), alarm_type_id='ndp-resolution'},
+   {perceived_severity = 'critical',
+    alarm_text = 'Make sure you can NDP resolve IP addresses on NIC'})
 
 local htons, ntohs = lib.htons, lib.ntohs
 local htonl, ntohl = lib.htonl, lib.ntohl

--- a/src/apps/packet_filter/pcap_filter.lua
+++ b/src/apps/packet_filter/pcap_filter.lua
@@ -42,24 +42,15 @@ function PcapFilter:new (conf)
    }
    if conf.state_table then conntrack.define(conf.state_table) end
 
-   alarms.add_to_inventory {
-      [{alarm_type_id='filtered-packets', alarm_type_qualifier=conf.alarm_type_qualifier}] = {
-         resource=tostring(S.getpid()),
-         has_clear=true,
-         description="Total number of filtered packets"
-      }
-   }
-   local alarm_key = {
-      resource=tostring(S.getpid()),
-      alarm_type_id='filtered-packets',
-      alarm_type_qualifier=conf.alarm_type_qualifier
-   }
-   local filtered_packets_alarm = alarms.declare_alarm {
-      [alarm_key] = {
-         perceived_severity = 'warning',
-         alarm_text = "More than 1,000,000 packets filtered per second",
-      }
-   }
+   alarms.add_to_inventory(
+      {alarm_type_id='filtered-packets', alarm_type_qualifier=conf.alarm_type_qualifier},
+      {resource=tostring(S.getpid()), has_clear=true,
+       description="Total number of filtered packets"})
+   local filtered_packets_alarm = alarms.declare_alarm(
+      { resource=tostring(S.getpid()), alarm_type_id='filtered-packets',
+        alarm_type_qualifier=conf.alarm_type_qualifier },
+      { perceived_severity = 'warning',
+        alarm_text = "More than 1,000,000 packets filtered per second" })
    o.filtered_packets_alarm = CounterAlarm.new(filtered_packets_alarm,
       1, 1e6, o, 'rxerrors')
    return setmetatable(o, { __index = PcapFilter })

--- a/src/lib/ptree/alarm_codec.lua
+++ b/src/lib/ptree/alarm_codec.lua
@@ -107,36 +107,43 @@ function Encoder:finish()
 end
 
 local encoder = Encoder.new()
-function encode_raise_alarm (resource, alarm_type_id, alarm_type_qualifier,
-                             perceived_severity, alarm_text, alt_resource)
+local encoders = {}
+function encoders.raise_alarm (key, args)
    encoder:reset()
    encoder:uint32(alarm_codes.raise_alarm)
-   return alarms.raise_alarm(encoder, resource, alarm_type_id, alarm_type_qualifier,
-                             perceived_severity, alarm_text, alt_resource)
+   return alarms.raise_alarm(
+      encoder,
+      key.resource, key.alarm_type_id, key.alarm_type_qualifier,
+      args.perceived_severity, args.alarm_text, args.alt_resource)
 end
 
-function encode_clear_alarm (resource, alarm_type_id, alarm_type_qualifier)
+function encoders.clear_alarm (key)
    encoder:reset()
    encoder:uint32(alarm_codes.clear_alarm)
-   return alarms.clear_alarm(encoder, resource, alarm_type_id,
-                             alarm_type_qualifier)
+   return alarms.clear_alarm(encoder, key.resource, key.alarm_type_id,
+                             key.alarm_type_qualifier)
 end
 
-function encode_add_to_inventory (alarm_type_id, alarm_type_qualifier,
-                                  resource, has_clear, description, alt_resource)
+function encoders.add_to_inventory (key, args)
    encoder:reset()
    encoder:uint32(alarm_codes.add_to_inventory)
-   return alarms.add_to_inventory(encoder, alarm_type_id, alarm_type_qualifier,
-                                  resource, has_clear, description, alt_resource)
+   return alarms.add_to_inventory(
+      encoder,
+      key.alarm_type_id, key.alarm_type_qualifier,
+      args.resource, args.has_clear, args.description, args.alt_resource)
 end
 
-function encode_declare_alarm (resource, alarm_type_id, alarm_type_qualifier,
-                               perceived_severity, alarm_text, alt_resource)
+function encoders.declare_alarm (key, args)
    encoder:reset()
    encoder:uint32(alarm_codes.declare_alarm)
-   return alarms.declare_alarm(encoder, resource, alarm_type_id,
-                               alarm_type_qualifier, perceived_severity,
-                               alarm_text, alt_resource)
+   return alarms.declare_alarm(
+      encoder,
+      key.resource, key.alarm_type_id, key.alarm_type_qualifier,
+      args.perceived_severity, args.alarm_text, args.alt_resource)
+end
+
+function encode(name, key, args)
+   return assert(encoders[name])(key, args)
 end
 
 local function decoder(buf, len)
@@ -168,10 +175,44 @@ local function decoder(buf, len)
    return decoder
 end
 
+local function to_alarm (args)
+   local key = {
+      resource = args[1],
+      alarm_type_id = args[2],
+      alarm_type_qualifier = args[3],
+   }
+   local args = {
+      perceived_severity = args[4],
+      alarm_text = args[5],
+      alt_resource = args[6],
+   }
+   return key, args
+end
+local function to_alarm_type (args)
+   local key = {
+      alarm_type_id = args[1],
+      alarm_type_qualifier = args[2],
+   }
+   local args = {
+      resource = args[3],
+      has_clear = args[4],
+      description = args[5],
+      alt_resource = args[6],
+   }
+   return key, args
+end
+
+local decoders = {
+   raise_alarm = to_alarm,
+   clear_alarm = to_alarm,
+   add_to_inventory = to_alarm_type,
+   declare_alarm = to_alarm
+}
+
 function decode(buf, len)
    local codec = decoder(buf, len)
    local name = assert(alarm_names[codec:uint32()])
-   return { name, assert(alarms[name], name)(codec) }
+   return name, decoders[name](alarms[name](codec))
 end
 
 ---
@@ -190,59 +231,10 @@ function get_channel()
    return alarms_channel
 end
 
-local function alarm_key (t)
-   return t.resource, t.alarm_type_id, t.alarm_type_qualifier
-end
-local function alarm_args (t)
-   return t.perceived_severity, t.alarm_text, t.alt_resource
-end
-
--- To be used by the manager to group args into key and args.
-function to_alarm (args)
-   local key = {
-      resource = args[1],
-      alarm_type_id = args[2],
-      alarm_type_qualifier = args[3],
-   }
-   local args = {
-      perceived_severity = args[4],
-      alarm_text = args[5],
-      alt_resource = args[6],
-   }
-   return key, args
-end
-
-local function alarm_type_key (t)
-   return t.alarm_type_id, t.alarm_type_qualifier
-end
-local function alarm_type_args (t)
-   return t.resource, t.has_clear, t.description, t.alt_resource
-end
-
-function to_alarm_type (args)
-   local alarm_type_id, alarm_type_qualifier, resource, has_clear, description, alt_resource = unpack(args)
-   local key = {
-      alarm_type_id = args[1],
-      alarm_type_qualifier = args[2],
-   }
-   local args = {
-      resource = args[3],
-      has_clear = args[4],
-      description = args[5],
-      alt_resource = args[6],
-   }
-   return key, args
-end
-
 function raise_alarm (key, args)
    local channel = get_channel()
    if channel then
-      local resource, alarm_type_id, alarm_type_qualifier = alarm_key(key)
-      local perceived_severity, alarm_text, alt_resource = alarm_args(args)
-      local buf, len = encode_raise_alarm(
-         resource, alarm_type_id, alarm_type_qualifier,
-         perceived_severity, alarm_text, alt_resource
-      )
+      local buf, len = encoders.raise_alarm(key, args)
       channel:put_message(buf, len)
    end
 end
@@ -250,8 +242,7 @@ end
 function clear_alarm (key)
    local channel = get_channel()
    if channel then
-      local resource, alarm_type_id, alarm_type_qualifier = alarm_key(key)
-      local buf, len = encode_clear_alarm(resource, alarm_type_id, alarm_type_qualifier)
+      local buf, len = encoders.raise_alarm(key)
       channel:put_message(buf, len)
    end
 end
@@ -259,12 +250,7 @@ end
 function add_to_inventory (key, args)
    local channel = get_channel()
    if channel then
-      local alarm_type_id, alarm_type_qualifier = alarm_type_key(key)
-      local resource, has_clear, description, alt_resource = alarm_type_args(args)
-      local buf, len = encode_add_to_inventory(
-         alarm_type_id, alarm_type_qualifier,
-         resource, has_clear, description, alt_resource
-      )
+      local buf, len = encoders.add_to_inventory(key, args)
       channel:put_message(buf, len)
    end
 end
@@ -272,12 +258,7 @@ end
 function declare_alarm (key, args)
    local channel = get_channel()
    if channel then
-      local resource, alarm_type_id, alarm_type_qualifier = alarm_key(key)
-      local perceived_severity, alarm_text, alt_resource = alarm_args(args)
-      local buf, len = encode_declare_alarm(
-         resource, alarm_type_id, alarm_type_qualifier,
-         perceived_severity, alarm_text, alt_resource
-      )
+      local buf, len = encoders.declare_alarm(key, args)
       channel:put_message(buf, len)
    end
 end
@@ -285,39 +266,21 @@ end
 function selftest ()
    print('selftest: lib.ptree.alarm_codec')
    local lib = require("core.lib")
-   local function test_alarm (name, args)
-      local encoded, len
-      if name == 'raise_alarm' then
-         encoded, len = encode_raise_alarm(unpack(args))
-      elseif name == 'clear_alarm' then
-         encoded, len = encode_clear_alarm(unpack(args))
-      else
-         error('not valid alarm name: '..alarm)
-      end
-      local decoded = decode(encoded, len)
-      assert(lib.equal({name, args}, decoded))
-   end
-   local function test_raise_alarm ()
-      local key = {resource='res1', alarm_type_id='type1', alarm_type_qualifier=''}
-      local args = {perceived_severity='critical',
-                    alarm_text='whoa', alt_resource={'res2a','res2b'}}
-
-      local resource, alarm_type_id, alarm_type_qualifier = alarm_key(key)
-      local perceived_severity, alarm_text, alt_resource = alarm_args(args)
-      local alarm = {resource, alarm_type_id, alarm_type_qualifier,
-                     perceived_severity, alarm_text, alt_resource}
-
-      test_alarm('raise_alarm', alarm)
-   end
-   local function test_clear_alarm ()
-      local key = {resource='res1', alarm_type_id='type1', alarm_type_qualifier=''}
-      local resource, alarm_type_id, alarm_type_qualifier = alarm_key(key)
-      local alarm = {resource, alarm_type_id, alarm_type_qualifier}
-      test_alarm('clear_alarm', alarm)
+   local function test_alarm (name, key, args)
+      local encoded, len = encode(name, key, args)
+      local dname, dkey, dargs = decode(encoded, len)
+      assert(name == dname)
+      assert(lib.equal(key, dkey))
+      assert(lib.equal(args or {}, dargs))
    end
 
-   test_raise_alarm()
-   test_clear_alarm()
+   test_alarm('raise_alarm',
+              {resource='res1', alarm_type_id='type1', alarm_type_qualifier=''},
+              {perceived_severity='critical',
+               alarm_text='whoa', alt_resource={'res2a','res2b'}})
+
+   test_alarm('clear_alarm',
+              {resource='res1', alarm_type_id='type1', alarm_type_qualifier=''})
 
    print('selftest: ok')
 end

--- a/src/lib/ptree/alarm_codec.lua
+++ b/src/lib/ptree/alarm_codec.lua
@@ -242,7 +242,7 @@ end
 function clear_alarm (key)
    local channel = get_channel()
    if channel then
-      local buf, len = encoders.raise_alarm(key)
+      local buf, len = encoders.clear_alarm(key)
       channel:put_message(buf, len)
    end
 end

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -759,30 +759,15 @@ function Manager:receive_alarms_from_worker (worker)
    while true do
       local buf, len = channel:peek_message()
       if not buf then break end
-      local alarm = alarm_codec.decode(buf, len)
-      self:handle_alarm(worker, alarm)
+      local name, key, args = alarm_codec.decode(buf, len)
+      local ok, err = pcall(self.handle_alarm, self, worker, name, key, args)
+      if not ok then self:warn('failed to handle alarm op %s', name) end
       channel:discard_message(len)
    end
 end
 
-function Manager:handle_alarm (worker, alarm)
-   local fn, args = unpack(alarm)
-   if fn == 'raise_alarm' then
-      local key, args = alarm_codec.to_alarm(args)
-      alarms.raise_alarm(key, args)
-   end
-   if fn == 'clear_alarm' then
-      local key = alarm_codec.to_alarm(args)
-      alarms.clear_alarm(key)
-   end
-   if fn == 'add_to_inventory' then
-      local key, args = alarm_codec.to_alarm_type(args)
-      alarms.do_add_to_inventory(key, args)
-   end
-   if fn == 'declare_alarm' then
-      local key, args = alarm_codec.to_alarm(args)
-      alarms.do_declare_alarm(key, args)
-   end
+function Manager:handle_alarm (worker, name, key, args)
+   alarms[name](key, args)
 end
 
 function Manager:stop ()

--- a/src/lib/timers/ingress_drop_monitor.lua
+++ b/src/lib/timers/ingress_drop_monitor.lua
@@ -40,18 +40,13 @@ function new(args)
       end
    end
 
-   alarms.add_to_inventory {
-      [{alarm_type_id='ingress-packet-drop'}] = {
-         resource=tostring(S.getpid()),
-         has_clear=true,
-         description="Ingress packet drops exceeds threshold",
-      }
-   }
-   ret.ingress_packet_drop_alarm = alarms.declare_alarm {
-      [{resource=tostring(S.getpid()),alarm_type_id='ingress-packet-drop'}] = {
-         perceived_severity='major',
-      }
-   }
+   alarms.add_to_inventory(
+      {alarm_type_id='ingress-packet-drop'},
+      {resource=tostring(S.getpid()), has_clear=true,
+       description="Ingress packet drops exceeds threshold"})
+   ret.ingress_packet_drop_alarm = alarms.declare_alarm(
+      {resource=tostring(S.getpid()),alarm_type_id='ingress-packet-drop'},
+      {perceived_severity='major'})
 
    return setmetatable(ret, {__index=IngressDropMonitor})
 end

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -181,11 +181,9 @@ function alarm_type_keys:normalize (key)
    return self:fetch(alarm_type_id, alarm_type_qualifier)
 end
 
-function add_to_inventory (alarm_types)
-   assert(type(alarm_types) == 'table')
-   for key,args in pairs(alarm_types) do
-      alarm_codec.add_to_inventory(key, args)
-   end
+function add_to_inventory (key, args)
+   local key = alarm_type_keys:normalize(key)
+   alarm_codec.add_to_inventory(key, args)
 end
 
 function do_add_to_inventory (k, v)
@@ -290,8 +288,7 @@ function default_alarms (alarms)
    end
 end
 
-function declare_alarm (alarms)
-   local k, v = next(alarms)
+function declare_alarm (k, v)
    alarm_codec.declare_alarm(k, v)
    local key = alarm_keys:normalize(k)
    local alarm = {}


### PR DESCRIPTION
The first commit changes the "add_to_inventory" and "declare_alarm" APIs to take separate key and args, and updates all callers.  A mechanical change.

The second refactors so that alarm_codec handles any needed packing and upacking of args from its interfaces.  This changes things so that e.g. "decode" returns the name, the key, and the args, already packed appropriately.  Likewise there's less shuffling when encoding.

The manager can just dispatch received events directly to the alarms module.  In the future we'll remove the include of alarm_codec by lib.yang.alarms.