### PR TITLE
Make ptree extend alarms

### DIFF
--- a/src/apps/lwaftr/ndp.lua
+++ b/src/apps/lwaftr/ndp.lua
@@ -145,13 +145,13 @@ local ipv6_unspecified_addr = ipv6:pton("0::0") -- aka ::/128
 -- Really just the first 13 bytes of the following...
 local ipv6_solicited_multicast = ipv6:pton("ff02:0000:0000:0000:0000:0001:ff00:00")
 
+local scratch_ph = ipv6_pseudoheader_t()
 local function checksum_pseudoheader_from_header(ipv6_fixed_header)
-   local ph = ipv6_pseudoheader_t()
-   ph.src_ip = ipv6_fixed_header.src_ip
-   ph.dst_ip = ipv6_fixed_header.dst_ip
-   ph.ulp_length = htonl(ntohs(ipv6_fixed_header.payload_length))
-   ph.next_header = htonl(ipv6_fixed_header.next_header)
-   return checksum.ipsum(ffi.cast('char*', ph),
+   scratch_ph.src_ip = ipv6_fixed_header.src_ip
+   scratch_ph.dst_ip = ipv6_fixed_header.dst_ip
+   scratch_ph.ulp_length = htonl(ntohs(ipv6_fixed_header.payload_length))
+   scratch_ph.next_header = htonl(ipv6_fixed_header.next_header)
+   return checksum.ipsum(ffi.cast('char*', scratch_ph),
                          ffi.sizeof(ipv6_pseudoheader_t), 0)
 end
 

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -26,7 +26,7 @@ local state = require("lib.yang.state")
 local path_mod = require("lib.yang.path")
 local path_data = require("lib.yang.path_data")
 local action_codec = require("lib.ptree.action_codec")
-local alarm_codec = require("lib.ptree.alarm_codec")
+local ptree_alarms = require("lib.ptree.alarms")
 local support = require("lib.ptree.support")
 local channel = require("lib.ptree.channel")
 local trace = require("lib.ptree.trace")
@@ -759,7 +759,7 @@ function Manager:receive_alarms_from_worker (worker)
    while true do
       local buf, len = channel:peek_message()
       if not buf then break end
-      local name, key, args = alarm_codec.decode(buf, len)
+      local name, key, args = ptree_alarms.decode(buf, len)
       local ok, err = pcall(self.handle_alarm, self, worker, name, key, args)
       if not ok then self:warn('failed to handle alarm op %s', name) end
       channel:discard_message(len)

--- a/src/lib/ptree/worker.lua
+++ b/src/lib/ptree/worker.lua
@@ -9,9 +9,10 @@ local counter      = require("core.counter")
 local histogram    = require('core.histogram')
 local lib          = require('core.lib')
 local timer        = require('core.timer')
+local alarms       = require("lib.yang.alarms")
 local channel      = require("lib.ptree.channel")
 local action_codec = require("lib.ptree.action_codec")
-local alarm_codec  = require("lib.ptree.alarm_codec")
+local ptree_alarms = require("lib.ptree.alarms")
 
 local Worker = {}
 
@@ -30,7 +31,7 @@ function new_worker (conf)
    ret.duration = conf.duration or 1/0
    ret.no_report = conf.no_report
    ret.channel = channel.create('config-worker-channel', 1e6)
-   ret.alarms_channel = alarm_codec.get_channel()
+   alarms.install_alarm_handler(ptree_alarms:alarm_handler())
    ret.pending_actions = {}
 
    ret.breathe = engine.breathe


### PR DESCRIPTION
This commit refactors alarms handling so that ptree extends alarms, instead of alarms relying on ptree.  Based on #1126.