### PR TITLE
Miscellaneous fixes and speedups

### DIFF
--- a/src/lib/ptree/worker.lua
+++ b/src/lib/ptree/worker.lua
@@ -34,6 +34,8 @@ function new_worker (conf)
    alarms.install_alarm_handler(ptree_alarms:alarm_handler())
    ret.pending_actions = {}
 
+   require("jit.opt").start('sizemcode=256', 'maxmcode=2048')
+
    ret.breathe = engine.breathe
    if conf.measure_latency then
       local latency = histogram.create('engine/latency.histogram', 1e-6, 1e0)

--- a/src/lib/stream.lua
+++ b/src/lib/stream.lua
@@ -109,7 +109,11 @@ end
 -- COUNT if the stream reaches EOF beforehand.
 function Stream:read_bytes(buf, count)
    buf = ffi.cast('uint8_t*', buf)
-   local offset = 0
+   -- Unrolled fast-path to avoid nested loops.
+   local did_read = self:read_some_bytes(buf, count)
+   if did_read == count then return count end
+   if did_read == 0 then return 0 end
+   local offset = did_read
    while offset < count do
       local did_read = self:read_some_bytes(buf + offset, count - offset)
       if did_read == 0 then break end
@@ -219,24 +223,23 @@ end
 function Stream:write_bytes(buf, count)
    if self.tx:read_avail() == 0 then self:flush_input() end
    buf = ffi.cast('uint8_t*', buf)
-   while count > 0 do
-      if count >= self.tx.size then
-         -- Write directly.
-         self:flush_output()
-         local did_write = self.io:write(buf, count)
-         if did_write then
-            buf, count = buf + did_write, count - did_write
-         else
-            self.io:wait_for_writable()
-         end
+   if count >= self.tx.size then
+      -- Write directly.
+      self:flush_output()
+      local did_write = self.io:write(buf, count)
+      if did_write then
+         buf, count = buf + did_write, count - did_write
       else
-         -- Write via buffer.
-         local to_put = math.min(self.tx:write_avail(), count)
-         self.tx:write(buf, to_put)
-         buf, count = buf + to_put, count - to_put
-         if self.tx:is_full() then self:flush_some_output() end
+         self.io:wait_for_writable()
       end
+   else
+      -- Write via buffer.
+      local to_put = math.min(self.tx:write_avail(), count)
+      self.tx:write(buf, to_put)
+      buf, count = buf + to_put, count - to_put
+      if self.tx:is_full() then self:flush_some_output() end
    end
+   if count > 0 then return self:write_bytes(buf, count) end
 end
 
 function Stream:write_chars(str)

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -312,7 +312,13 @@ function declare_alarm (key, args)
       alarm_list:new(key, args)
    end
    local alarm = {}
-   function alarm:raise (args)
+   function alarm:raise (raise_args)
+      if raise_args then
+         local union = {}
+         for k,v in pairs(args) do union[k] = v end
+         for k,v in pairs(raise_args) do union[k] = v end
+         args = union
+      end
       alarm_handler.raise_alarm(key, args)
    end
    function alarm:clear ()

--- a/src/lib/yang/alarms.lua
+++ b/src/lib/yang/alarms.lua
@@ -317,9 +317,11 @@ function declare_alarm (key, args)
          local union = {}
          for k,v in pairs(args) do union[k] = v end
          for k,v in pairs(raise_args) do union[k] = v end
-         args = union
+         raise_args = union
+      else
+         raise_args = args
       end
-      alarm_handler.raise_alarm(key, args)
+      alarm_handler.raise_alarm(key, raise_args)
    end
    function alarm:clear ()
       alarm_handler.clear_alarm(key)


### PR DESCRIPTION
This branch contains miscellaneous patches to quieten the `-jv` output: fewer nested loops, mostly.  Also there's a fix to alarm:raise() to handle the case where the user passes in args, and a commit to expand the limits for JIT mcode in workers, taken from l2vpn.