### PR TITLE
Leader process apparently running on wrong NUMA node

### DIFF
--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -90,15 +90,22 @@ function unbind_cpu ()
 end
 
 function bind_to_cpu (cpu)
-   if cpu == bound_cpu then return end
+   local function contains (t, e)
+      for k,v in ipairs(t) do
+         if tonumber(v) == tonumber(e) then return true end
+      end
+      return false
+   end
    if not cpu then return unbind_cpu() end
+   if cpu == bound_cpu then return end
    assert(not bound_cpu, "already bound")
 
+   if type(cpu) ~= 'table' then cpu = {cpu} end
    assert(S.sched_setaffinity(0, cpu),
-      ("Couldn't set affinity for cpu %s"):format(cpu))
+      ("Couldn't set affinity for cpuset %s"):format(table.concat(cpu, ',')))
    local cpu_and_node = S.getcpu()
-   assert(cpu_and_node.cpu == cpu)
-   bound_cpu = cpu
+   assert(contains(cpu, cpu_and_node.cpu))
+   bound_cpu = cpu_and_node.cpu
 
    bind_to_numa_node (cpu_and_node.node)
 end

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -171,11 +171,7 @@ end
 
 function Manager:start ()
    if self.name then engine.claim_name(self.name) end
-   local cpu = self.cpuset:bind_to_first_available_cpu()
-   if cpu then
-      print(('Binding manager plane PID %s to CPU %s.'):format(
-              tonumber(S.getpid()), cpu))
-   end
+   self.cpuset:bind_to_numa_node()
    require('lib.fibers.file').install_poll_io_handler()
    self.sched = fiber.current_scheduler
    fiber.spawn(function () self:accept_rpc_peers() end)

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -171,7 +171,11 @@ end
 
 function Manager:start ()
    if self.name then engine.claim_name(self.name) end
-   self.cpuset:bind_to_numa_node()
+   local cpu = self.cpuset:bind_to_first_available_cpu()
+   if cpu then
+      print(('Binding manager plane PID %s to CPU %s.'):format(
+              tonumber(S.getpid()), cpu))
+   end
    require('lib.fibers.file').install_poll_io_handler()
    self.sched = fiber.current_scheduler
    fiber.spawn(function () self:accept_rpc_peers() end)


### PR DESCRIPTION
Fixes #731.

I triaged #731 and sometimes the manager process was bound to CPU 0 (NUMA 0) and other times to CPU 6 (NUMA 1). I think the reason why the manager process didn't get bound to a core in the same NUMA node as the lwAFTR's process was that actually the process was not bind to any CPU core. The manager simply called `numa.bind_to_numa_node` but this doesn't bind a process to a core. Thus, the OS scheduled the process to any of the cores available in both NUMA nodes (sometimes 0, sometimes 6).