### PR TITLE
Improve CPUSet:acquire warning message

### DIFF
--- a/src/lib/cpuset.lua
+++ b/src/lib/cpuset.lua
@@ -3,6 +3,7 @@
 module(...,package.seeall)
 
 local numa = require('lib.numa')
+local S = require('syscall')
 
 local CPUSet = {}
 
@@ -86,12 +87,12 @@ function CPUSet:acquire(on_node)
       end
    end
    for node, cpus in pairs(self.by_node) do
-      print("Warning: All assignable CPUs in use; "
-               .."leaving data-plane process without assigned CPU.")
+      print(("Warning: All assignable CPUs in use; "..
+             "leaving data-plane PID %d without assigned CPU."):format(S.getpid()))
       return
    end
-   print("Warning: No assignable CPUs declared; "
-            .."leaving data-plane process without assigned CPU.")
+   print(("Warning: No assignable CPUs declared; "..
+         "leaving data-plane PID %d without assigned CPU."):format(S.getpid()))
 end
 
 function CPUSet:release(cpu)

--- a/src/lib/scheduling.lua
+++ b/src/lib/scheduling.lua
@@ -24,7 +24,7 @@ local scheduling_opts = {
 local sched_apply = {}
 
 function sched_apply.cpu (cpu)
-   print(string.format('Binding data plane PID %s to CPU %s.',
+   print(string.format('Binding data-plane PID %s to CPU %s.',
                        tonumber(S.getpid()), cpu))
    numa.bind_to_cpu(cpu)
 end


### PR DESCRIPTION
When launching a lwAFTR instance with two queues but only one CPU, the `lwaftr run` command returns a message that the data-plane process was assigned to a cpu but at the same time that all cpus were occupied and could not assign a data-plane process to a cpu.

```bash
$ sudo ./snabb lwaftr run --cpu 8 --conf lwaftr.conf --on-a-stick 82:00.0
lwaftr.conf: loading compiled configuration from lwaftr.o
lwaftr.conf: compiled configuration is up to date.
Binding data plane PID 4131 to CPU 8.
Warning: All assignable CPUs in use; leaving data-plane process without assigned CPU.
Bound main process to NUMA node:        1
```

This message is apparently contradictory. In fact the warning message is correct because it refers to a different process. Thus I changed the warning message to print out something like:

```bash
$ sudo ./snabb lwaftr run --cpu 8 --conf lwaftr.conf --on-a-stick 82:00.0
lwaftr.conf: loading compiled configuration from lwaftr.o
lwaftr.conf: compiled configuration is up to date.
Binding data-plane PID 4253 to CPU 8.
Warning: All assignable CPUs in use; leaving data-plane PID 4247 without assigned CPU.
Bound main process to NUMA node:        1
```