### PR TITLE
Report RX/TX stats per queue on interface view

### DIFF
--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -410,7 +410,9 @@ function Intel:new (conf)
          txbcast   = {counter},
          txdrop    = {counter},
          txerrors  = {counter},
-         rxdmapackets = {counter}
+         rxdmapackets = {counter},
+         rxcounter = {counter, self.rxcounter},
+         txcounter = {counter, self.txcounter},
       }
       self:init_queue_stats(frame)
       self.stats = shm.create_frame("pci/"..self.pciaddress, frame)

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -614,6 +614,18 @@ function compute_display_tree.interface(tree, prev, dt, t)
       return compute_rate(v, prev, rrd, t, dt)
    end
    local function show_traffic(tag, pci, prev)
+      local label = tag
+      if tag == 'rx' then
+         local rxcounter = pci.rxcounter and pci.rxcounter.value
+         if rxcounter then
+            tag = 'q'..tonumber(rxcounter)..'_'..tag
+         end
+      elseif tag == 'tx' then
+         local txcounter = pci.txcounter and pci.txcounter.value
+         if txcounter then
+            tag = 'q'..tonumber(txcounter)..'_'..tag
+         end
+      end
       local pps = rate(tag..'packets', pci, prev)
       local bytes = rate(tag..'bytes', pci, prev)
       local drops = rate(tag..'drop', pci, prev)
@@ -622,7 +634,7 @@ function compute_display_tree.interface(tree, prev, dt, t)
       local bps = (bytes + overhead) * 8
       local max = tonumber(pci.speed and pci.speed.value) or 0
       gridrow(nil,
-              rchars('%s:', tag:upper()),
+              rchars('%s:', label:upper()),
               lchars('%.3f %sPPS', scale(pps)),
               lchars('%.3f %sbps', scale(bps)),
               lchars('%.2f%%', bps/max*100),


### PR DESCRIPTION
Fixes https://github.com/Igalia/snabb/issues/1134.

When the lwAFTR is run with RSS only the master process updates the stats, except for per-queue stats which are updated per process. What happened in issue 1134 is that one of processes was showing RX/TX values as 0. The reason was that this was the non-master process and its counters are never updated. Instead of showing global rx/tx counters processes should show their per-queue stats in interface view.

If there's only one process I think its per-queue stats are equals to global rx/tx stats.