### PR TITLE
Add test for shared RX counters

### DIFF
--- a/src/apps/intel_mp/test_10g_shared_rxcounter.snabb
+++ b/src/apps/intel_mp/test_10g_shared_rxcounter.snabb
@@ -1,0 +1,65 @@
+#!../../snabb snsh
+
+-- Snabb test script for shared counters
+--
+-- On 82599 NICs, there are only 16 sets of counters but
+-- the possibility for many more RX queues. It's possible
+-- to then share a counter among multiple queues, so this
+-- test exercises that capability.
+
+local basic_apps = require("apps.basic.basic_apps")
+local intel      = require("apps.intel_mp.intel_mp")
+local pcap       = require("apps.pcap.pcap")
+local lib        = require("core.lib")
+
+local pciaddr0 = lib.getenv("SNABB_PCI_INTEL0")
+local pciaddr1 = lib.getenv("SNABB_PCI_INTEL1")
+
+local c = config.new()
+
+-- send packets on nic0
+config.app(c, "nic0", intel.Intel,
+           { pciaddr = pciaddr0,
+             txq = 0,
+             wait_for_link = true })
+
+-- nic1 with two apps, sharing an rx counter
+config.app(c, "nic1p0", intel.Intel,
+           { pciaddr = pciaddr1,
+             vmdq = true,
+             poolnum = 0,
+             macaddr = "90:72:82:78:c9:7a",
+             rxq = 0,
+             rxcounter = 1,
+             wait_for_link = true })
+
+config.app(c, "nic1p1", intel.Intel,
+           { pciaddr = pciaddr1,
+             vmdq = true,
+             poolnum = 1,
+             macaddr = "12:34:56:78:9a:bc",
+             rxq = 0,
+             rxcounter = 1,
+             wait_for_link = true })
+
+config.app(c, "pcap", pcap.PcapReader, "source2.pcap")
+config.app(c, 'sink', basic_apps.Sink)
+
+config.link(c, "pcap.output -> nic0.input")
+config.link(c, "nic1p0.output -> sink.input0")
+config.link(c, "nic1p1.output -> sink.input1")
+
+engine.configure(c)
+engine.main({ duration = 1 })
+
+assert(link.stats(engine.app_table.sink.input.input0).rxpackets == 51,
+       "wrong number of packets received on pool 0")
+assert(link.stats(engine.app_table.sink.input.input1).rxpackets == 51,
+       "wrong number of packets received on pool 1")
+
+local p0_pkts = engine.app_table.nic1p0:get_rxstats().packets
+assert(p0_pkts == 102,
+       string.format("p0: expected 102 packets on RX counter 1, got %d", tonumber(p0_pkts)))
+local p1_pkts = engine.app_table.nic1p1:get_rxstats().packets
+assert(p1_pkts == 102,
+       string.format("p1: expected 102 packets on RX counter 1, got %d", tonumber(p1_pkts)))


### PR DESCRIPTION
This adds a test to demonstrate the problem in issue #1137. Removing `run_stats=true` from the apps in the test makes it pass.