### PR TITLE
Adjust new queue stats accounting to work with original run_stats semantics

### DIFF
--- a/src/apps/intel_mp/test_10g_vmdq_mirror.snabb
+++ b/src/apps/intel_mp/test_10g_vmdq_mirror.snabb
@@ -38,7 +38,6 @@ config.app(c, "nic1p1", intel.Intel,
              macaddr = "12:34:56:78:9a:bc",
              rxq = 0,
              rxcounter = 2,
-             run_stats = true,
              wait_for_link = true })
 
 config.app(c, "nic1p2", intel.Intel,
@@ -49,7 +48,6 @@ config.app(c, "nic1p2", intel.Intel,
              macaddr = "aa:aa:aa:aa:aa:aa",
              rxq = 0,
              rxcounter = 3,
-             run_stats = true,
              wait_for_link = true })
 
 config.app(c, "pcap", pcap.PcapReader, "source2.pcap")
@@ -65,12 +63,16 @@ engine.main({ duration = 1 })
 
 assert(link.stats(engine.app_table.sink.input.input0).rxpackets == 51,
        "wrong number of packets received on pool 0")
-assert(engine.app_table.nic1p0:get_rxstats().packets == 51,
-       "expected get_rxstats and link stats to agree")
+local n1p0_pkts = engine.app_table.nic1p0:get_rxstats().packets
+assert(n1p0_pkts == 51,
+       string.format("expected get_rxstats %d and link stats %d to agree",
+                     tonumber(n1p0_pkts), 51))
 assert(link.stats(engine.app_table.sink.input.input1).rxpackets == 102,
        "wrong number of packets received on pool 1")
-assert(engine.app_table.nic1p1:get_rxstats().packets == 102,
-       "expected get_rxstats and link stats to agree")
+local n1p1_pkts = engine.app_table.nic1p1:get_rxstats().packets
+assert(n1p1_pkts == 102,
+       string.format("expected get_rxstats %d and link stats %d to agree",
+                     tonumber(n1p1_pkts), 102))
 assert(link.stats(engine.app_table.sink.input.input2).rxpackets == 102,
        "wrong number of packets received on pool 2")
 assert(engine.app_table.nic1p2:get_rxstats().packets == 102,

--- a/src/apps/intel_mp/testrecv.lua
+++ b/src/apps/intel_mp/testrecv.lua
@@ -10,18 +10,25 @@ local C = ffi.C
 function test(pciaddr, qno, vmdq, poolno, macaddr, vlan)
    local c = config.new()
    if vmdq then
+      local rxc
+      if poolno then
+         -- only have 16 counters on 82599, so use 15 if it's too big
+         rxc = math.min(poolno * 4 + qno, 15)
+      end
       config.app(c, "nic", intel.Intel,
                  { pciaddr=pciaddr,
                    macaddr=macaddr,
                    vlan=vlan,
                    vmdq=true,
                    poolnum=poolno,
+                   rxcounter = rxc,
                    rxq = qno,
                    wait_for_link=true })
    else
       config.app(c, "nic", intel.Intel,
                  { pciaddr=pciaddr,
                    rxq = qno,
+                   rxcounter = qno,
                    wait_for_link=true })
    end
    config.app(c, "sink", basic.Sink)

--- a/src/apps/intel_mp/testsend.snabb
+++ b/src/apps/intel_mp/testsend.snabb
@@ -12,7 +12,7 @@ local C = require("ffi").C
 local c = config.new()
 config.app(c, "pcap", pcap.PcapReader, pcapfile)
 config.app(c, "nic", intel.Intel,
-           {pciaddr=pciaddr, txq=qno, wait_for_link=true})
+           {pciaddr=pciaddr, txq=qno, txcounter=qno, wait_for_link=true})
 
 if os.getenv("SNABB_SEND_BLAST") then
 	local basic = require("apps.basic.basic_apps")

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -236,7 +236,6 @@ function load_phy(c, conf, v4_nic_name, v6_nic_name, ring_buffer_size)
       vlan=queue.external_interface.vlan_tag,
       rxcounter=id,
       txcounter=id,
-      run_stats=true,
       ring_buffer_size=ring_buffer_size,
       macaddr=ethernet:ntop(queue.external_interface.mac)})
    config.app(c, v6_nic_name, require(v6_info.driver).driver, {
@@ -248,7 +247,6 @@ function load_phy(c, conf, v4_nic_name, v6_nic_name, ring_buffer_size)
       vlan=queue.internal_interface.vlan_tag,
       rxcounter=id,
       txcounter=id,
-      run_stats=true,
       ring_buffer_size=ring_buffer_size,
       macaddr = ethernet:ntop(queue.internal_interface.mac)})
 
@@ -312,7 +310,6 @@ function load_on_a_stick(c, conf, args)
          ring_buffer_size=args.ring_buffer_size,
          rxcounter = id,
          txcounter = id,
-         run_stats=true,
          macaddr = ethernet:ntop(queue.external_interface.mac)})
       if mirror then
          local Tap = require("apps.tap.tap").Tap
@@ -344,7 +341,6 @@ function load_on_a_stick(c, conf, args)
          ring_buffer_size=args.ring_buffer_size,
          rxcounter = id,
          txcounter = id,
-         run_stats=true,
          macaddr = ethernet:ntop(queue.external_interface.mac)})
       config.app(c, v6_nic_name, driver, {
          pciaddr = pciaddr,
@@ -356,7 +352,6 @@ function load_on_a_stick(c, conf, args)
          ring_buffer_size=args.ring_buffer_size,
          rxcounter = id,
          txcounter = id,
-         run_stats=true,
          macaddr = ethernet:ntop(queue.internal_interface.mac)})
 
       link_source(c, v4_nic_name..'.'..device.tx, v6_nic_name..'.'..device.tx)


### PR DESCRIPTION
This PR adjusts the queue stats syncing so that RX/TX queue counters are always synced, ignoring `run_stats`. This addresses issue #1139.

Unfortunately, I think #1137 is still broken on this PR so I don't think it should be merged as-is. I'm concerned that having queue stats synced on separate apps is not actually going to work out in the end.