### PR TITLE
Change instance template to id 0

### DIFF
--- a/src/program/lwaftr/generate_configuration/generate_configuration.lua
+++ b/src/program/lwaftr/generate_configuration/generate_configuration.lua
@@ -177,7 +177,7 @@ local function instance (w)
       instance {
           device test;
           queue {
-              id 1;
+              id 0;
               external-interface {
                   ip 10.0.1.1;
                   mac 02:aa:aa:aa:aa:aa;


### PR DESCRIPTION
Fix error in `generate-configuration`. First id of `instance` is 0 not 1.