### PR TITLE
Share queue stats among all apps on a NIC

### DIFF
--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -401,12 +401,14 @@ function Intel:new (conf)
          promisc   = {counter},
          macaddr   = {counter, self.r.RAL64[0]:bits(0,48)},
          rxbytes   = {counter},
+         rxbits    = {counter},
          rxpackets = {counter},
          rxmcast   = {counter},
          rxbcast   = {counter},
          rxdrop    = {counter},
          rxerrors  = {counter},
          txbytes   = {counter},
+         txbits    = {counter},
          txpackets = {counter},
          txmcast   = {counter},
          txbcast   = {counter},
@@ -835,13 +837,13 @@ function Intel:sync_stats ()
    set(stats.speed, self:link_speed())
    set(stats.status, self:link_status() and 1 or 2)
    set(stats.promisc, self:promisc() and 1 or 2)
-   set(stats.rxbytes, self:rxbytes())
+   set(stats.rxbits, self:rxbytes()*8)
    set(stats.rxpackets, self:rxpackets())
    set(stats.rxmcast, self:rxmcast())
    set(stats.rxbcast, self:rxbcast())
    set(stats.rxdrop, self:rxdrop())
    set(stats.rxerrors, self:rxerrors())
-   set(stats.txbytes, self:txbytes())
+   set(stats.txbits, self:txbytes()*8)
    set(stats.txpackets, self:txpackets())
    set(stats.txmcast, self:txmcast())
    set(stats.txbcast, self:txbcast())

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -313,6 +313,15 @@ byPciID = {
   [0x10fb] = { registers = "82599ES", driver = Intel82599, max_q = 16 }
 }
 
+-- constant used in constructor below, keep synced with the actual
+-- keys used for the driver stats shm frame that should be shared between
+-- NIC processes
+local shm_frame_keys = { "dtime", "mtu", "speed", "status", "type",
+                         "promisc", "macaddr", "rxbytes", "rxpackets",
+                         "rxmcast", "rxbcast", "rxdrop", "rxerrors",
+                         "txbytes", "txpackets", "txmcast", "txbcast",
+                         "txdrop", "txerrors", "rxdmapackets" }
+
 -- The `driver' variable is used as a reference to the driver class in
 -- order to interchangeably use NIC drivers.
 driver = Intel
@@ -415,24 +424,32 @@ function Intel:new (conf)
       self:init_queue_stats(frame)
       self.stats = shm.create_frame(self.shm_root.."stats", frame)
       self.sync_timer = lib.throttle(0.01)
+   else
+      -- use a dummy frame, this is just used to populate shm_frame_keys
+      self:init_queue_stats({})
    end
 
-   -- Alias to the shared stats frame in each process's pci dir
-   -- The conditional checks if the symlink exists with lstat since
-   -- shm.exists requires the target exist, and the run_stats process
-   -- could go down and make the target cease to exist
-   if not S.lstat(shm.root.."/"..S.getpid().."/pci/"..self.pciaddress) then
-      shm.alias("pci/"..self.pciaddress, self.shm_root.."stats")
+   -- Alias each counter in the shared stats frame in each process's pci dir
+   -- Not all counters in pci/ are shared, some are process specific
+   for _, name in ipairs(shm_frame_keys) do
+      -- The conditional checks if the symlink exists with lstat since
+      -- shm.exists requires the target exist, and the run_stats process
+      -- could go down and make the target cease to exist
+      if not S.lstat(shm.root.."/"..S.getpid().."/pci/"..
+                     self.pciaddress.."/"..name..".counter") then
+         shm.alias("pci/"..self.pciaddress.."/"..name..".counter",
+                   self.shm_root.."stats".."/"..name..".counter")
+      end
    end
 
    -- Expose per-instance queue counter assignment, which allows a program like
    -- `snabb top` to associate PIDs to queue counters
    if self.rxcounter then
-      local rxcs = counter.create("pci/" .. self.pciaddress .. "/rxcounters")
+      local rxcs = counter.create("pci/"..self.pciaddress.."/rxcounters.counter")
       counter.set(rxcs, lib.bits({rxc=self.rxcounter}, counter.read(rxcs)))
    end
    if self.txcounter then
-      local txcs = counter.create("pci/" .. self.pciaddress .. "/txcounters")
+      local txcs = counter.create("pci/"..self.pciaddress.."/txcounters.counter")
       counter.set(txcs, lib.bits({rxc=self.txcounter}, counter.read(txcs)))
    end
 
@@ -1202,6 +1219,7 @@ function Intel1g:init_queue_stats (frame)
          local name = "q" .. i .. "_" .. k
          table.insert(self.queue_stats, name)
          table.insert(self.queue_stats, self.r[v][i])
+         table.insert(shm_frame_keys, name)
          frame[name] = {counter}
       end
    end
@@ -1309,6 +1327,7 @@ function Intel82599:init_queue_stats (frame)
          local name = "q" .. i .. "_" .. k
          table.insert(self.queue_stats, name)
          table.insert(self.queue_stats, self.r[v][i])
+         table.insert(shm_frame_keys, name)
          frame[name] = {counter}
       end
    end

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -413,8 +413,27 @@ function Intel:new (conf)
          rxdmapackets = {counter}
       }
       self:init_queue_stats(frame)
-      self.stats = shm.create_frame("pci/"..self.pciaddress, frame)
+      self.stats = shm.create_frame(self.shm_root.."stats", frame)
       self.sync_timer = lib.throttle(0.01)
+   end
+
+   -- Alias to the shared stats frame in each process's pci dir
+   -- The conditional checks if the symlink exists with lstat since
+   -- shm.exists requires the target exist, and the run_stats process
+   -- could go down and make the target cease to exist
+   if not S.lstat(shm.root.."/"..S.getpid().."/pci/"..self.pciaddress) then
+      shm.alias("pci/"..self.pciaddress, self.shm_root.."stats")
+   end
+
+   -- Expose per-instance queue counter assignment, which allows a program like
+   -- `snabb top` to associate PIDs to queue counters
+   if self.rxcounter then
+      local rxcs = counter.create("pci/" .. self.pciaddress .. "/rxcounters")
+      counter.set(rxcs, lib.bits({rxc=self.rxcounter}, counter.read(rxcs)))
+   end
+   if self.txcounter then
+      local txcs = counter.create("pci/" .. self.pciaddress .. "/txcounters")
+      counter.set(txcs, lib.bits({rxc=self.txcounter}, counter.read(txcs)))
    end
 
    alarms.add_to_inventory(
@@ -654,7 +673,7 @@ function Intel:push ()
    if self.rxq and self.output.output then return end
 
    -- Sync device statistics.
-   if self.sync_timer and self.sync_timer() then self:sync_stats() end
+   if self.run_stats and self.sync_timer() then self:sync_stats() end
 end
 
 function Intel:pull ()
@@ -680,7 +699,7 @@ function Intel:pull ()
    self.r.RDT(band(self.rdt - 1, self.ndesc-1))
 
    -- Sync device statistics.
-   if self.sync_timer and self.sync_timer() then self:sync_stats() end
+   if self.run_stats and self.sync_timer() then self:sync_stats() end
 end
 
 function Intel:unlock_sw_sem()
@@ -822,45 +841,25 @@ end
 
 function Intel:sync_stats ()
    local set, stats = counter.set, self.stats
-   local function update_queue_stats (start, last)
-      for idx = start, last, 2 do
-         local name, register = self.queue_stats[idx], self.queue_stats[idx+1]
-         set(stats[name], register())
-      end
-   end
-   local function update_rx_queue_stats (idx)
-      update_queue_stats(idx*10+1, idx*10+6)
-   end
-   local function update_tx_queue_stats (idx)
-      update_queue_stats(idx*10+7, idx*10+10)
-   end
    set(stats.speed, self:link_speed())
    set(stats.status, self:link_status() and 1 or 2)
    set(stats.promisc, self:promisc() and 1 or 2)
-   -- Values only updated by master.
-   if self.master then
-      set(stats.rxbytes, self:rxbytes())
-      set(stats.rxpackets, self:rxpackets())
-      set(stats.rxmcast, self:rxmcast())
-      set(stats.rxbcast, self:rxbcast())
-      set(stats.rxdrop, self:rxdrop())
-      set(stats.rxerrors, self:rxerrors())
-      set(stats.txbytes, self:txbytes())
-      set(stats.txpackets, self:txpackets())
-      set(stats.txmcast, self:txmcast())
-      set(stats.txbcast, self:txbcast())
-      set(stats.txdrop, self:txdrop())
-      set(stats.txerrors, self:txerrors())
-      set(stats.rxdmapackets, self:rxdmapackets())
-   end
-   if self.rxcounter or self.txcounter then
-      update_rx_queue_stats(self.rxcounter or self.txcounter)
-      update_tx_queue_stats(self.txcounter or self.rxcounter)
-   else
-      for idx = 1, #self.queue_stats, 2 do
-         local name, register = self.queue_stats[idx], self.queue_stats[idx+1]
-         set(stats[name], register())
-      end
+   set(stats.rxbytes, self:rxbytes())
+   set(stats.rxpackets, self:rxpackets())
+   set(stats.rxmcast, self:rxmcast())
+   set(stats.rxbcast, self:rxbcast())
+   set(stats.rxdrop, self:rxdrop())
+   set(stats.rxerrors, self:rxerrors())
+   set(stats.txbytes, self:txbytes())
+   set(stats.txpackets, self:txpackets())
+   set(stats.txmcast, self:txmcast())
+   set(stats.txbcast, self:txbcast())
+   set(stats.txdrop, self:txdrop())
+   set(stats.txerrors, self:txerrors())
+   set(stats.rxdmapackets, self:rxdmapackets())
+   for idx = 1, #self.queue_stats, 2 do
+      local name, register = self.queue_stats[idx], self.queue_stats[idx+1]
+      set(stats[name], register())
    end
 end
 
@@ -1296,12 +1295,6 @@ function Intel82599:rxdmapackets ()
 end
 
 function Intel82599:init_queue_stats (frame)
-   local function keys(t)
-      local ret = {}
-      for k,_ in pairs(t) do table.insert(ret, k) end
-      table.sort(ret)
-      return ret
-   end
    local perqregs = {
       rxdrops = "QPRDC",
       rxpackets = "QPRC",
@@ -1311,7 +1304,7 @@ function Intel82599:init_queue_stats (frame)
    }
    self.queue_stats = {}
    for i=0,15 do
-      for _,k in ipairs(keys(perqregs)) do
+      for k,v in pairs(perqregs) do
          local v = perqregs[k]
          local name = "q" .. i .. "_" .. k
          table.insert(self.queue_stats, name)

--- a/src/apps/intel_mp/test_10g_4q_vmdq.snabb
+++ b/src/apps/intel_mp/test_10g_4q_vmdq.snabb
@@ -22,7 +22,9 @@ config.app(c, "nic0", intel.Intel,
              rxq = false,
              txq = 0,
              wait_for_link = true })
-config.link(c, "source.output -> nic0.input")
+config.app(c, "repeat", basic_apps.Repeater)
+config.link(c, "source.output -> repeat.input")
+config.link(c, "repeat.output -> nic0.input")
 
 -- nic1 with 4-way RSS
 for i=0, 3 do
@@ -32,6 +34,7 @@ for i=0, 3 do
                 vmdq_queuing_mode = "rss-32-4",
                 macaddr = "90:72:82:78:c9:7a",
                 poolnum = 0,
+                rxcounter = i+1,
                 rxq = i,
                 txq = i,
                 wait_for_link = true })

--- a/src/apps/intel_mp/test_10g_counters.sh
+++ b/src/apps/intel_mp/test_10g_counters.sh
@@ -1,0 +1,80 @@
+#!../../snabb snsh
+
+-- Snabb test script for testing that retrieving queue stats on
+-- a process that isn't the stats-syncing process works
+
+local basic_apps = require("apps.basic.basic_apps")
+local intel      = require("apps.intel_mp.intel_mp")
+local pcap       = require("apps.pcap.pcap")
+local counter    = require("core.counter")
+local lib        = require("core.lib")
+local shm        = require("core.shm")
+local worker     = require("core.worker")
+local pci        = require("lib.hardware.pci")
+
+local pciaddr0 = pci.canonical(lib.getenv("SNABB_PCI_INTEL0"))
+local pciaddr1 = pci.canonical(lib.getenv("SNABB_PCI_INTEL1"))
+
+local function make_worker(pci, rxq, rxc)
+   local code = string.format([[
+      local basic_apps = require("apps.basic.basic_apps")
+      local intel      = require("apps.intel_mp.intel_mp")
+
+      local c = config.new()
+      config.app(c, "sink", basic_apps.Sink)
+      config.app(c, "nic", intel.Intel,
+                 { pciaddr = "%s",
+                   master_stats = false,
+                   run_stats = true,
+                   rxq = %d,
+                   rxcounter = %d,
+                   wait_for_link = true })
+      config.link(c, "nic.output -> sink.input")
+      engine.configure(c)
+      engine.main({ duration = 2 })
+      ]], pci, rxq, rxc)
+
+   worker.start("worker"..rxq, code)
+end
+
+-- Make a worker that syncs stats and uses queue 0, counter 1
+make_worker(pciaddr1, 0, 1)
+
+local c = config.new()
+
+-- send packets on nic0
+config.app(c, "nic0", intel.Intel,
+           { pciaddr = pciaddr0,
+             -- disable rxq
+             rxq = false,
+             txq = 0,
+             wait_for_link = true })
+
+-- The test process makes its own RSS app too
+config.app(c, "nic1", intel.Intel,
+           { pciaddr = pciaddr1,
+             master_stats = false,
+             run_stats = false,
+             rxq = 1,
+             rxcounter = 2,
+             wait_for_link = true })
+
+config.app(c, "source", pcap.PcapReader, "source.pcap")
+config.app(c, 'sink', basic_apps.Sink)
+config.app(c, "repeat", basic_apps.Repeater)
+config.link(c, "source.output -> repeat.input")
+config.link(c, "repeat.output -> nic0.input")
+config.link(c, "nic1.output -> sink.input")
+
+engine.configure(c)
+engine.main({ duration = 1 })
+
+-- make sure this process can read its own queue stats synced by the worker
+-- and that the worker's queue counter can be read via shm
+local pkts = engine.app_table.nic1:get_rxstats().packets
+assert(pkts > 0, "get_rxstats failed")
+
+local status = worker.status()
+local pid = status.worker0.pid
+local ct = counter.open("/"..pid.."/pci/"..pciaddr1.."/q1_rxbytes.counter")
+assert(counter.read(ct) > 0, "failed to read worker queue counter")

--- a/src/apps/intel_mp/test_10g_vmdq_mirror.snabb
+++ b/src/apps/intel_mp/test_10g_vmdq_mirror.snabb
@@ -38,7 +38,6 @@ config.app(c, "nic1p1", intel.Intel,
              macaddr = "12:34:56:78:9a:bc",
              rxq = 0,
              rxcounter = 2,
-             run_stats = true,
              wait_for_link = true })
 
 config.app(c, "nic1p2", intel.Intel,
@@ -49,7 +48,6 @@ config.app(c, "nic1p2", intel.Intel,
              macaddr = "aa:aa:aa:aa:aa:aa",
              rxq = 0,
              rxcounter = 3,
-             run_stats = true,
              wait_for_link = true })
 
 config.app(c, "pcap", pcap.PcapReader, "source2.pcap")

--- a/src/apps/intel_mp/testrecv.lua
+++ b/src/apps/intel_mp/testrecv.lua
@@ -17,11 +17,13 @@ function test(pciaddr, qno, vmdq, poolno, macaddr, vlan)
                    vmdq=true,
                    poolnum=poolno,
                    rxq = qno,
+                   rxcounter = qno+1,
                    wait_for_link=true })
    else
       config.app(c, "nic", intel.Intel,
                  { pciaddr=pciaddr,
                    rxq = qno,
+                   rxcounter = qno+1,
                    wait_for_link=true })
    end
    config.app(c, "sink", basic.Sink)

--- a/src/lib/ptree/inotify.lua
+++ b/src/lib/ptree/inotify.lua
@@ -157,9 +157,6 @@ end
 
 local function is_dir(name)
    local stat = S.lstat(name)
-   if stat and stat.islnk then
-      stat = S.lstat(S.readlink(name))
-   end
    return stat and stat.isdir
 end
 

--- a/src/lib/ptree/inotify.lua
+++ b/src/lib/ptree/inotify.lua
@@ -157,6 +157,9 @@ end
 
 local function is_dir(name)
    local stat = S.lstat(name)
+   if stat and stat.islnk then
+      stat = S.lstat(S.readlink(name))
+   end
    return stat and stat.isdir
 end
 

--- a/src/lib/rrd.lua
+++ b/src/lib/rrd.lua
@@ -277,7 +277,11 @@ end
 
 function create_file(filename, arg)
    local rrd = new(arg)
-   local fd = assert(S.open(filename, "creat, rdwr, excl", '0664'))
+   -- File might already exists if directory is a link.
+   local _, fd = pcall(S.open, filename, "rdwr, excl", '0664')
+   if not fd then
+      fd = assert(S.open(filename, "creat, rdwr, excl", '0664'))
+   end
    local f = file.fdopen(fd, 'wronly', filename)
    f:write_bytes(rrd.ptr, rrd.size)
    f:flush_output()

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -236,7 +236,6 @@ function load_phy(c, conf, v4_nic_name, v6_nic_name, ring_buffer_size)
       vlan=queue.external_interface.vlan_tag,
       rxcounter=id,
       txcounter=id,
-      run_stats=true,
       ring_buffer_size=ring_buffer_size,
       macaddr=ethernet:ntop(queue.external_interface.mac)})
    config.app(c, v6_nic_name, require(v6_info.driver).driver, {
@@ -248,7 +247,6 @@ function load_phy(c, conf, v4_nic_name, v6_nic_name, ring_buffer_size)
       vlan=queue.internal_interface.vlan_tag,
       rxcounter=id,
       txcounter=id,
-      run_stats=true,
       ring_buffer_size=ring_buffer_size,
       macaddr = ethernet:ntop(queue.internal_interface.mac)})
 
@@ -312,7 +310,6 @@ function load_on_a_stick(c, conf, args)
          ring_buffer_size=args.ring_buffer_size,
          rxcounter = id,
          txcounter = id,
-         run_stats=true,
          macaddr = ethernet:ntop(queue.external_interface.mac)})
       if mirror then
          local Tap = require("apps.tap.tap").Tap
@@ -344,7 +341,6 @@ function load_on_a_stick(c, conf, args)
          ring_buffer_size=args.ring_buffer_size,
          rxcounter = id,
          txcounter = id,
-         run_stats=true,
          macaddr = ethernet:ntop(queue.external_interface.mac)})
       config.app(c, v6_nic_name, driver, {
          pciaddr = pciaddr,
@@ -356,7 +352,6 @@ function load_on_a_stick(c, conf, args)
          ring_buffer_size=args.ring_buffer_size,
          rxcounter = id,
          txcounter = id,
-         run_stats=true,
          macaddr = ethernet:ntop(queue.internal_interface.mac)})
 
       link_source(c, v4_nic_name..'.'..device.tx, v6_nic_name..'.'..device.tx)


### PR DESCRIPTION
This PR revises queue stats handling by providing all the queue stats in each process' `pci` shm directory. It does this by symlinking all of them to a "global" shm sub-directory in the `/intel-mp` directory.

This doesn't quite solve the `snabb top` issues yet because I think symlinks are not yet followed by some layer that `snabb top` uses. Once `snabb top` follows the symlinks it should show all the counters properly. I'm looking into fixing it, but if anyone has any ideas on where to find the cause (maybe at the inotify level?) it would be helpful.

Also, this exposes the `rxcounter` and `txcounter` values in an extra counter, which could be used to filter the queue stats shown (since there may be non-zero queue counters of no interest for a given process). This part is WIP but could be useful if `snabb top` actually looks at it.