### PR TITLE
Restrict condition for use of V4V6 splitter

### DIFF
--- a/src/program/lwaftr/run/run.lua
+++ b/src/program/lwaftr/run/run.lua
@@ -4,6 +4,7 @@ local S          = require("syscall")
 local config     = require("core.config")
 local cpuset     = require("lib.cpuset")
 local csv_stats  = require("program.lwaftr.csv_stats")
+local ethernet   = require("lib.protocol.ethernet")
 local lib        = require("core.lib")
 local setup      = require("program.lwaftr.setup")
 local cltable    = require("lib.cltable")
@@ -131,9 +132,10 @@ end
 -- are the same for the internal and external interfaces.
 local function requires_splitter (conf)
    local queue = select(3, lwutil.parse_instance(conf))
-   local internal_interface = queue.internal_interface
-   local external_interface = queue.external_interface
-   return internal_interface.vlan_tag == external_interface.vlan_tag
+   local int = queue.internal_interface
+   local ext = queue.external_interface
+   return ethernet:ntop(int.mac) == ethernet:ntop(ext.mac) and
+          int.vlan_tag == ext.vlan_tag
 end
 
 function run(args)

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -300,8 +300,16 @@ function load_on_a_stick(c, conf, args)
    local v4_nic_name, v6_nic_name, v4v6, mirror = args.v4_nic_name,
       args.v6_nic_name, args.v4v6, args.mirror
 
+   if queue.external_interface.vlan_tag ~= queue.internal_interface.vlan_tag then
+      assert(queue.external_interface.mac ~= queue.internal_interface.mac,
+             "When using different VLAN tags, external and internal MAC "..
+                "addresses must be different too")
+   end
+
    if v4v6 then
       assert(queue.external_interface.vlan_tag == queue.internal_interface.vlan_tag)
+      assert(ethernet:ntop(queue.external_interface.mac) ==
+                ethernet:ntop(queue.internal_interface.mac))
       config.app(c, 'nic', driver, {
          pciaddr = pciaddr,
          vmdq=true, -- Needed to enable MAC filtering/stamping.
@@ -331,9 +339,6 @@ function load_on_a_stick(c, conf, args)
       link_source(c, v4v6..'.v4', v4v6..'.v6')
       link_sink(c, v4v6..'.v4', v4v6..'.v6')
    else
-      assert(queue.external_interface.mac ~= queue.internal_interface.mac,
-             "When using different VLAN tags, external and internal MAC "..
-                "addresses must be different too")
       config.app(c, v4_nic_name, driver, {
          pciaddr = pciaddr,
          vmdq=true, -- Needed to enable MAC filtering/stamping.


### PR DESCRIPTION
So far a V4V6 splitter was needed if VLAN tags for external and
internal interfaces were equal.  This condition assumed an scenario
where MAC addresses for external and internal interfaces were equal too.
It is necessary to add this constraint to the condition that evaluates
whether a splitter is necessary.

Summarizing, we are only going to use a V4V6 splitter when both VLAN
tags and MAC addresses of external and internal interfaces are the same.