### PR TITLE
Print out user-friendly error message

### DIFF
--- a/src/program/config/common.lua
+++ b/src/program/config/common.lua
@@ -58,7 +58,8 @@ end
 function validate_path(schema_name, path, is_config)
    local succ, err = pcall(path_grammar, schema_name, path, is_config)
    if succ == false then
-      error_and_quit(err)
+      local filename, lineno, msg = err:match("(.+):(%d+):(.+)$")
+      error_and_quit(("Invalid path:"..msg) or err)
    end
 end
 


### PR DESCRIPTION
Fixes #707 and #759 

`snabb config` commands no longer return stack traces, but the error message contains the filename and line number where the parsing error occurred. This information is not relevant for an user. Also the user doesn't know the issue is in the path. About the error message itself, I left it as it is. Perhaps it's too fine-grained detail for an user, but useful imho. Example:

```
$ sudo ./snabb config set -s snabb-softwire-v2 lwaftr \
   "/softwire-config/internal-interface/reassembly-max-fragments-per-packet" "332167"
Invalid path: Struct has no field named 'reassembly-max-fragments-per-packet'.
```