### PR TITLE
Fix hardware ping test

### DIFF
--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -298,8 +298,10 @@ function load_on_a_stick(c, conf, args)
    local v4_nic_name, v6_nic_name, v4v6, mirror = args.v4_nic_name,
       args.v6_nic_name, args.v4v6, args.mirror
 
-   if queue.external_interface.vlan_tag ~= queue.internal_interface.vlan_tag then
-      assert(queue.external_interface.mac ~= queue.internal_interface.mac,
+   local ext = queue.external_interface
+   local int = queue.internal_interface
+   if ext.vlan_tag ~= int.vlan_tag then
+      assert(ethernet:ntop(ext.mac) ~= ethernet:ntop(int.mac),
              "When using different VLAN tags, external and internal MAC "..
                 "addresses must be different too")
    end

--- a/src/program/lwaftr/tests/data/lwaftr-vlan.conf
+++ b/src/program/lwaftr/tests/data/lwaftr-vlan.conf
@@ -34,7 +34,7 @@ softwire-config {
       }
       internal-interface {
         ip fe80::100;
-        mac 02:aa:aa:aa:aa:aa;
+        mac 02:bb:bb:bb:bb:bb;
         next-hop {
           mac 02:99:99:99:99:99;
         }

--- a/src/program/lwaftr/tests/hw/test_ping_on_a_stick.sh
+++ b/src/program/lwaftr/tests/hw/test_ping_on_a_stick.sh
@@ -19,6 +19,13 @@ if [[ -z "$SNABB_PCI1" ]]; then
     exit $SKIPPED_CODE
 fi
 
+ping6=$(which ping6 2> /dev/null)
+if [[ $? == 0 ]]; then
+    ping6="ping6"
+else
+    ping6="ping -6"
+fi
+
 function fatal {
     local msg=$1
     echo "Error: $msg"
@@ -47,7 +54,7 @@ function bind_card {
 }
 
 function test_ping_to_internal_interface {
-    local out=$(ping6 -c 1 -I "$IFACE.v6" "$INTERNAL_IP")
+    local out=$($ping6 -c 1 -I "$IFACE.v6" "$INTERNAL_IP")
     local count=$(echo "$out" | grep -o -c " 0% packet loss")
     if [[ $count -eq 1 ]]; then
         echo "Success: Ping to internal interface"
@@ -62,7 +69,7 @@ function test_ping_to_external_interface {
     if [[ $count -eq 1 ]]; then
         echo "Success: Ping to external interface"
     else
-        fatal "Couldn't ping to internal interface"
+        fatal "Couldn't ping to external interface"
     fi
 
 }


### PR DESCRIPTION
Fixes #1162.

There's a test script that currently is not run being run by CI* to check if ping resolution to lwAFTR's internal and external interfaces work. I realized the script stopped working for internal interfaces. After lots of research I realized the issue was that the configuration file required that both interfaces had a different MAC address. This condition was guarded by an assert, but the assert didn't work well :)

Applying this fix, ping resolution using a physical NIC works:

```bash
$ sudo SNABB_PCI0=0000:82:00.0 SNABB_PCI1=0000:02:00.0 ./program/lwaftr/tests/hw/test_ping_on_a_stick.sh                                    
Success: Ping to internal interface         
Success: Ping to external interface       
```

* The reason why the script is not part of the selftest is that it doesn't work inside a container. I think to fix that is necessary to tweak how the container is launched. Probably in a different PR.