### PR TITLE
Add test for hardware VLAN tagging/untagging

### DIFF
--- a/src/program/lwaftr/tests/hw/selftest.sh
+++ b/src/program/lwaftr/tests/hw/selftest.sh
@@ -1,0 +1,1 @@
+test_ping_on_a_stick.sh

--- a/src/program/lwaftr/tests/hw/test_ping_on_a_stick.sh
+++ b/src/program/lwaftr/tests/hw/test_ping_on_a_stick.sh
@@ -19,6 +19,11 @@ if [[ -z "$SNABB_PCI1" ]]; then
     exit $SKIPPED_CODE
 fi
 
+which lshw &> /dev/null
+if [[ $? == 1 ]]; then
+    exit $SKIPPED_CODE
+fi
+
 ping6=$(which ping6 2> /dev/null)
 if [[ $? == 0 ]]; then
     ping6="ping6"


### PR DESCRIPTION
Fixes #251.

Adding this test requires that the Docker container uses the host network stack (so it's possible to attach devices to OS interfaces). I don't know if that's desirable for all tests.

It would be better to enable this feature only for certain tests. For example, by making the use of the `--net=host` conditional based on the script name (if the name is `host-selftest.sh`, then enable this flag).