### PR TITLE
Revert rxbytes / txbytes intel_mp change

### DIFF
--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -401,14 +401,12 @@ function Intel:new (conf)
          promisc   = {counter},
          macaddr   = {counter, self.r.RAL64[0]:bits(0,48)},
          rxbytes   = {counter},
-         rxbits    = {counter},
          rxpackets = {counter},
          rxmcast   = {counter},
          rxbcast   = {counter},
          rxdrop    = {counter},
          rxerrors  = {counter},
          txbytes   = {counter},
-         txbits    = {counter},
          txpackets = {counter},
          txmcast   = {counter},
          txbcast   = {counter},
@@ -837,13 +835,13 @@ function Intel:sync_stats ()
    set(stats.speed, self:link_speed())
    set(stats.status, self:link_status() and 1 or 2)
    set(stats.promisc, self:promisc() and 1 or 2)
-   set(stats.rxbits, self:rxbytes()*8)
+   set(stats.rxbytes, self:rxbytes())
    set(stats.rxpackets, self:rxpackets())
    set(stats.rxmcast, self:rxmcast())
    set(stats.rxbcast, self:rxbcast())
    set(stats.rxdrop, self:rxdrop())
    set(stats.rxerrors, self:rxerrors())
-   set(stats.txbits, self:txbytes()*8)
+   set(stats.txbytes, self:txbytes())
    set(stats.txpackets, self:txpackets())
    set(stats.txmcast, self:txmcast())
    set(stats.txbcast, self:txbcast())


### PR DESCRIPTION
This reverts commit fe72a43f992e63a72d1bb28d2565f1ee6bf6cd6a.

This commit was the wrong thing for two reasons:

  * The rxbytes and txbytes counters still existed, they were
    confusingly left as 0 though

  * The bits received aren't bytes * 8; bits usually include
    overhead (interframe gap etc) which aren't counted by rxbytes.