### PR TITLE
Add a release benchmarking script for the lwAFTR

### DIFF
--- a/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.nix
+++ b/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.nix
@@ -1,0 +1,42 @@
+with import <nixpkgs> {};
+
+let dataset = stdenv.mkDerivation {
+  name = "lwaftr-dataset";
+
+  dataset = (fetchTarball {
+    url = https://people.igalia.com/atakikawa/lwaftr_benchmarking_dataset.tar.gz;
+    # not supported in old NixOS
+    #sha256 = "48b4204e656d19aa9f2b4023104f2483e66df7523e28188181fb3d052445eaba";
+  });
+
+  snabb_pci0 = builtins.getEnv "SNABB_PCI0";
+  snabb_pci1 = builtins.getEnv "SNABB_PCI1";
+  snabb_pci2 = builtins.getEnv "SNABB_PCI2";
+  snabb_pci3 = builtins.getEnv "SNABB_PCI3";
+  snabb_pci4 = builtins.getEnv "SNABB_PCI4";
+  snabb_pci5 = builtins.getEnv "SNABB_PCI5";
+  snabb_pci6 = builtins.getEnv "SNABB_PCI6";
+  snabb_pci7 = builtins.getEnv "SNABB_PCI7";
+
+  # substitute placeholders in the configs with actual pci addresses
+  builder = builtins.toFile "builder.sh" "
+    source $stdenv/setup
+    mkdir $out
+    cp $dataset/*.pcap $out/
+    for conf in $dataset/lwaftr*.conf
+    do
+        target=$out/`basename $conf`
+        cp $conf $target
+        sed -i -e \"s/<SNABB_PCI0>/$snabb_pci0/; \\
+                    s/<SNABB_PCI1>/$snabb_pci1/; \\
+                    s/<SNABB_PCI2>/$snabb_pci2/; \\
+                    s/<SNABB_PCI3>/$snabb_pci3/; \\
+                    s/<SNABB_PCI4>/$snabb_pci4/; \\
+                    s/<SNABB_PCI5>/$snabb_pci5/; \\
+                    s/<SNABB_PCI6>/$snabb_pci6/; \\
+                    s/<SNABB_PCI7>/$snabb_pci7/\" \\
+            $target
+    done
+    ";
+};
+in runCommand "dummy" { dataset = dataset; } ""

--- a/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
+++ b/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
@@ -1,0 +1,134 @@
+#! /usr/bin/env nix-shell
+#! nix-shell release-benchmarks.nix -i bash
+#
+# This script runs the lwAFTR release benchmarks
+#
+# Set SNABB_PCI0 to SNABB_PCI7 when calling
+
+# directory this script lives in
+# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+DIR=$(dirname "$(readlink -f "$0")")
+
+# path to snabb executable
+SNABB=$DIR/../../../../snabb
+
+# config files & pcap dataset paths
+FROM_B4_PCAP=$dataset/from-b4-test.pcap
+FROM_INET_PCAP=$dataset/from-inet-test.pcap
+FROM_INET_AND_B4_PCAP=$dataset/from-inet-and-b4-test.pcap
+CONFIGS=$dataset/*.conf
+
+# make sure lwaftr gets shut down even on interrupt
+function teardown {
+    [[ -n $lwaftr_pid ]] && kill $lwaftr_pid
+    [[ -n $lt_pid ]] && kill $lt_pid
+    [[ -n $lt_pid2 ]] && kill $lt_pid2
+}
+
+trap teardown INT TERM
+
+TMPDIR=`mktemp -d`
+
+# called with benchmark name, config path, args for lwAFTR, args for loadtest
+# optionally args of the second loadtest
+function run_benchmark {
+    name="$1"
+    config="$2"
+    lwaftr_args="$3"
+    loadtest_args="$4"
+    loadtest2_args="$5"
+
+    $SNABB lwaftr run --cpu 11 --name lwaftr --conf \
+           $dataset/$config $lwaftr_args > /dev/null &
+    lwaftr_pid=$!
+
+    # wait briefly to let lwaftr start up
+    sleep 1
+
+    log=`mktemp -p $TMPDIR`
+    echo ">> Running loadtest: $name (log: $log)"
+    $SNABB loadtest find-limit $loadtest_args > $log &
+    lt_pid=$!
+
+    if [ ! -z "$loadtest2_args" ]; then
+        log2=`mktemp -p $TMPDIR`
+        echo ">> Running loadtest 2: $name (log: $log2)"
+        $SNABB loadtest find-limit $loadtest2_args > $log2 &
+        lt_pid2=$!
+    fi
+
+    wait $lt_pid
+    status=$?
+    if [ ! -z "$loadtest2_args" ]; then
+        wait $lt_pid2
+        status2=$?
+    fi
+
+    kill $lwaftr_pid
+
+    if [ $status -eq 0 ]; then
+        echo ">> Success: $(tail -n 1 $log)"
+    else
+        echo ">> Failed: $(tail -n 1 $log)"
+        exit $status
+    fi
+    if [ ! -z "$loadtest2_args" ]; then
+        if [ $status2 -eq 0 ]; then
+            echo ">> Success: $(tail -n 1 $log2)"
+        else
+            echo ">> Failed: $(tail -n 1 $log2)"
+            exit $status
+        fi
+    fi
+}
+
+# first ensure all configs are compiled
+echo ">> Compiling configurations (may take a while)"
+for conf in $CONFIGS
+do
+    $SNABB lwaftr compile-configuration $conf
+done
+
+run_benchmark "1 instance, 2 NIC interface" \
+              "lwaftr.conf" \
+              "--v4 $SNABB_PCI0 --v6 $SNABB_PCI2" \
+              "$FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI1 \
+               $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI3"
+
+run_benchmark "1 instance, 2 NIC interfaces (from config)" \
+              "lwaftr2.conf" \
+              "--v4 $SNABB_PCI0 --v6 $SNABB_PCI2" \
+              "$FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI1 \
+               $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI3"
+
+run_benchmark "1 instance, 1 NIC (on a stick)" \
+              "lwaftr.conf" \
+              "--on-a-stick $SNABB_PCI0" \
+              "$FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI1"
+
+run_benchmark "1 instance, 1 NIC (on-a-stick, from config file)" \
+              "lwaftr3.conf" \
+              "" \
+              "$FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI1"
+
+run_benchmark "2 instances, 2 NICs (from config)" \
+              "lwaftr4.conf" \
+              "" \
+              "--cpu 2 $FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI1 \
+               $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI3" \
+              "--cpu 3 $FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI5 \
+               $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI7"
+
+run_benchmark "2 instances, 1 NIC (on a stick, from config)" \
+              "lwaftr5.conf" \
+              "" \
+              "--cpu 2 $FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI1" \
+              "--cpu 3 $FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI5"
+
+run_benchmark "1 instance, 1 NIC, 2 queues" \
+              "lwaftr6.conf" \
+              "" \
+              "$FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI1"
+
+# cleanup
+rm -r $TMPDIR

--- a/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
+++ b/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
@@ -3,7 +3,13 @@
 #
 # This script runs the lwAFTR release benchmarks
 #
+# Set SNABB_CPU0 to pick the CPU for the lwAFTR
 # Set SNABB_PCI0 to SNABB_PCI7 when calling
+
+if [ ! $SNABB_CPU0 ]; then
+    echo ">> SNABB_CPU0 not set, defaulting to 0"
+    SNABB_CPU0=0
+fi
 
 if [ ! $SNABB_PCI0 ] || [ ! $SNABB_PCI1 ]; then
     echo ">> At least SNABB_PCI0 and SNABB_PCI1 must be set"
@@ -53,7 +59,7 @@ function run_benchmark {
     loadtest_args="$4"
     loadtest2_args="$5"
 
-    $SNABB lwaftr run --cpu 11 --name lwaftr --conf \
+    $SNABB lwaftr run --cpu $SNABB_CPU0 --name lwaftr --conf \
            $dataset/$config $lwaftr_args > /dev/null &
     lwaftr_pid=$!
 

--- a/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
+++ b/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
@@ -3,7 +3,7 @@
 #
 # This script runs the lwAFTR release benchmarks
 #
-# Set SNABB_LWAFTR_CPU0 to pick the CPU for the lwAFTR
+# Set SNABB_LWAFTR_CPU0, SNABB_LWAFTR_CPU1 to pick CPUs for the lwAFTR
 # Set SNABB_LOADTEST_CPU0, SNABB_LOADTEST_CPU1 for two instance test
 # Set SNABB_PCI0 to SNABB_PCI7 when calling
 
@@ -64,10 +64,12 @@ function run_benchmark {
     lwaftr_args="$3"
     loadtest_args="$4"
     loadtest2_args="$5"
+    cpu=${6:-$SNABB_LWAFTR_CPU0}
 
     lwaftr_log=`mktemp -p $TMPDIR`
-    $SNABB lwaftr run --cpu $SNABB_LWAFTR_CPU0 --name lwaftr --conf \
-           $dataset/$config $lwaftr_args > $lwaftr_log &
+    $SNABB lwaftr run --cpu $cpu \
+           --name lwaftr-release-benchmarks \
+           --conf $dataset/$config $lwaftr_args > $lwaftr_log &
     lwaftr_pid=$!
 
     # wait briefly to let lwaftr start up
@@ -164,10 +166,16 @@ if [ ! $ONE_INSTANCE_ONLY ]; then
 fi
 
 
-run_benchmark "1 instance, 1 NIC, 2 queues" \
-              "lwaftr6.conf" \
-              "" \
-              "$FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI1"
+if [ ! $SNABB_LWAFTR_CPU1 ]; then
+    echo ">> Not running RSS test, SNABB_LWAFTR_CPU1 not set"
+else
+    run_benchmark "1 instance, 1 NIC, 2 queues" \
+                  "lwaftr6.conf" \
+                  "" \
+                  "$FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI1" \
+                  "" \
+                  "$SNABB_LWAFTR_CPU0,$SNABB_LWAFTR_CPU1"
+fi
 
 # cleanup
 rm -r $TMPDIR

--- a/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
+++ b/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
@@ -21,7 +21,7 @@ if [ ! $SNABB_PCI2 ] || [ ! $SNABB_PCI3 ]; then
     ON_A_STICK_ONLY=1
 fi
 
-if [ ! $SNABB_PCI4 ] || [ ! $SNABB_PCI5 ] || [ ! $SNABB_PCI6 ] || [ ! $SNABB_PCI7]; then
+if [ ! $SNABB_PCI4 ] || [ ! $SNABB_PCI5 ] || [ ! $SNABB_PCI6 ] || [ ! $SNABB_PCI7 ]; then
     echo ">> SNABB_PCI4 through SNABB_PCI7 need to be set for 2 instance, 2 NIC test"
     ONE_INSTANCE_ONLY=1
 fi

--- a/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
+++ b/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
@@ -3,12 +3,13 @@
 #
 # This script runs the lwAFTR release benchmarks
 #
-# Set SNABB_CPU0 to pick the CPU for the lwAFTR
+# Set SNABB_LWAFTR_CPU0 to pick the CPU for the lwAFTR
+# Set SNABB_LOADTEST_CPU0, SNABB_LOADTEST_CPU1 for two instance test
 # Set SNABB_PCI0 to SNABB_PCI7 when calling
 
-if [ ! $SNABB_CPU0 ]; then
-    echo ">> SNABB_CPU0 not set, defaulting to 0"
-    SNABB_CPU0=0
+if [ ! $SNABB_LWAFTR_CPU0 ]; then
+    echo ">> SNABB_LWAFTR_CPU0 not set, defaulting to 0"
+    SNABB_LWAFTR_CPU0=0
 fi
 
 if [ ! $SNABB_PCI0 ] || [ ! $SNABB_PCI1 ]; then
@@ -24,6 +25,11 @@ fi
 if [ ! $SNABB_PCI4 ] || [ ! $SNABB_PCI5 ] || [ ! $SNABB_PCI6 ] || [ ! $SNABB_PCI7 ]; then
     echo ">> SNABB_PCI4 through SNABB_PCI7 need to be set for 2 instance, 2 NIC test"
     ONE_INSTANCE_ONLY=1
+else
+    if [ ! $SNABB_LOADTEST_CPU0 ] || [ ! $SNABB_LOADTEST_CPU1 ]; then
+        echo ">> SNABB_LOADTEST_CPU0 and SNABB_LOADTEST_CPU1 must be set for 2 instance tests"
+        exit 1
+    fi
 fi
 
 # directory this script lives in
@@ -60,7 +66,7 @@ function run_benchmark {
     loadtest2_args="$5"
 
     lwaftr_log=`mktemp -p $TMPDIR`
-    $SNABB lwaftr run --cpu $SNABB_CPU0 --name lwaftr --conf \
+    $SNABB lwaftr run --cpu $SNABB_LWAFTR_CPU0 --name lwaftr --conf \
            $dataset/$config $lwaftr_args > $lwaftr_log &
     lwaftr_pid=$!
 
@@ -145,16 +151,16 @@ if [ ! $ONE_INSTANCE_ONLY ]; then
     run_benchmark "2 instances, 2 NICs (from config)" \
                   "lwaftr4.conf" \
                   "" \
-                  "--cpu 2 $FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI1 \
+                  "--cpu $SNABB_LOADTEST_CPU0 $FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI1 \
                    $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI3" \
-                  "--cpu 3 $FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI5 \
+                  "--cpu $SNABB_LOADTEST_CPU1 $FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI5 \
                    $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI7"
 
     run_benchmark "2 instances, 1 NIC (on a stick, from config)" \
                   "lwaftr5.conf" \
                   "" \
-                  "--cpu 2 $FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI1" \
-                  "--cpu 3 $FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI5"
+                  "--cpu $SNABB_LOADTEST_CPU0 $FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI1" \
+                  "--cpu $SNABB_LOADTEST_CPU1 $FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI5"
 fi
 
 

--- a/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
+++ b/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
@@ -59,12 +59,19 @@ function run_benchmark {
     loadtest_args="$4"
     loadtest2_args="$5"
 
+    lwaftr_log=`mktemp -p $TMPDIR`
     $SNABB lwaftr run --cpu $SNABB_CPU0 --name lwaftr --conf \
-           $dataset/$config $lwaftr_args > /dev/null &
+           $dataset/$config $lwaftr_args > $lwaftr_log &
     lwaftr_pid=$!
 
     # wait briefly to let lwaftr start up
     sleep 1
+
+    # make sure lwAFTR has't errored out, if not then exit
+    if ! ps -p $lwaftr_pid > /dev/null; then
+        echo ">> lwAFTR terminated unexpectedly, ending test (log: $lwaftr_log)"
+        exit 1
+    fi
 
     log=`mktemp -p $TMPDIR`
     echo ">> Running loadtest: $name (log: $log)"

--- a/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
+++ b/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh
@@ -5,6 +5,21 @@
 #
 # Set SNABB_PCI0 to SNABB_PCI7 when calling
 
+if [ ! $SNABB_PCI0 ] || [ ! $SNABB_PCI1 ]; then
+    echo ">> At least SNABB_PCI0 and SNABB_PCI1 must be set"
+    exit 1
+fi
+
+if [ ! $SNABB_PCI2 ] || [ ! $SNABB_PCI3 ]; then
+    echo ">> SNABB_PCI2 or SNABB_PCI3 not set, only running on-a-stick tests"
+    ON_A_STICK_ONLY=1
+fi
+
+if [ ! $SNABB_PCI4 ] || [ ! $SNABB_PCI5 ] || [ ! $SNABB_PCI6 ] || [ ! $SNABB_PCI7]; then
+    echo ">> SNABB_PCI4 through SNABB_PCI7 need to be set for 2 instance, 2 NIC test"
+    ONE_INSTANCE_ONLY=1
+fi
+
 # directory this script lives in
 # https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
 DIR=$(dirname "$(readlink -f "$0")")
@@ -89,17 +104,19 @@ do
     $SNABB lwaftr compile-configuration $conf
 done
 
-run_benchmark "1 instance, 2 NIC interface" \
-              "lwaftr.conf" \
-              "--v4 $SNABB_PCI0 --v6 $SNABB_PCI2" \
-              "$FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI1 \
-               $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI3"
+if [ ! $ON_A_STICK_ONLY ]; then
+    run_benchmark "1 instance, 2 NIC interface" \
+                  "lwaftr.conf" \
+                  "--v4 $SNABB_PCI0 --v6 $SNABB_PCI2" \
+                  "$FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI1 \
+                   $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI3"
 
-run_benchmark "1 instance, 2 NIC interfaces (from config)" \
-              "lwaftr2.conf" \
-              "--v4 $SNABB_PCI0 --v6 $SNABB_PCI2" \
-              "$FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI1 \
-               $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI3"
+    run_benchmark "1 instance, 2 NIC interfaces (from config)" \
+                  "lwaftr2.conf" \
+                  "--v4 $SNABB_PCI0 --v6 $SNABB_PCI2" \
+                  "$FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI1 \
+                   $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI3"
+fi
 
 run_benchmark "1 instance, 1 NIC (on a stick)" \
               "lwaftr.conf" \
@@ -111,19 +128,22 @@ run_benchmark "1 instance, 1 NIC (on-a-stick, from config file)" \
               "" \
               "$FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI1"
 
-run_benchmark "2 instances, 2 NICs (from config)" \
-              "lwaftr4.conf" \
-              "" \
-              "--cpu 2 $FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI1 \
-               $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI3" \
-              "--cpu 3 $FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI5 \
-               $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI7"
+if [ ! $ONE_INSTANCE_ONLY ]; then
+    run_benchmark "2 instances, 2 NICs (from config)" \
+                  "lwaftr4.conf" \
+                  "" \
+                  "--cpu 2 $FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI1 \
+                   $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI3" \
+                  "--cpu 3 $FROM_INET_PCAP NIC0 NIC1 $SNABB_PCI5 \
+                   $FROM_B4_PCAP NIC1 NIC0 $SNABB_PCI7"
 
-run_benchmark "2 instances, 1 NIC (on a stick, from config)" \
-              "lwaftr5.conf" \
-              "" \
-              "--cpu 2 $FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI1" \
-              "--cpu 3 $FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI5"
+    run_benchmark "2 instances, 1 NIC (on a stick, from config)" \
+                  "lwaftr5.conf" \
+                  "" \
+                  "--cpu 2 $FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI1" \
+                  "--cpu 3 $FROM_INET_AND_B4_PCAP NIC0 NIC0 $SNABB_PCI5"
+fi
+
 
 run_benchmark "1 instance, 1 NIC, 2 queues" \
               "lwaftr6.conf" \


### PR DESCRIPTION
This PR adds a script that tries to automate the process of running release benchmarks.

A sample invocation looks like this:

```
sudo SNABB_PCI0=82:00.0 SNABB_PCI1=02:00.0 SNABB_PCI2=82:00.1 SNABB_PCI3=02:00.1 SNABB_PCI4=83:00.0 SNABB_PCI5=03:00.0 SNABB_PCI6=83:00.1 SNABB_PCI7=03:00.1 ./release-benchmarks.sh
```

This will download a tarball with some data, do some manipulation on the data, compile configs, and run the benchmarks.

The script is parameterized over the NIC interfaces to use (though it should check that they are set, and maybe only run a subset if not all are set). The script should also be parameterized over the CPUs to use ideally.

It's still WIP for now because there seems to be some odd variability in runs, though adding the `sleep` in between the lwaftr invocation and load-test (at line 46) may have fixed some of it.