### PR TITLE
intel_mp app instantiations make stats symlink counter forest

### DIFF
--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -411,7 +411,6 @@ function Intel:new (conf)
    -- Figure out if we are supposed to collect device statistics
    self.run_stats = conf.run_stats or (self.master and conf.master_stats)
    if self.run_stats then
-      self.sync_timer = lib.throttle(0.01)
       local frame = {
          -- Keep a copy of the mtu here to have all
          -- data available in a single shm frame
@@ -437,6 +436,7 @@ function Intel:new (conf)
       }
       self:init_queue_stats(frame)
       self.stats = shm.create_frame(self.shm_root.."stats", frame)
+      self.sync_timer = lib.throttle(0.01)
    end
 
    -- Expose per-device statistics from master
@@ -868,6 +868,9 @@ function Intel:stop ()
       --self.r.CTRL_EXT:clear( bits { DriverLoaded = 28 })
       pci.set_bus_master(self.pciaddress, false)
       pci.close_pci_resource(self.fd, self.base)
+   end
+   if self.run_stats then
+      shm.delete_frame(self.stats)
    end
 end
 

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -340,7 +340,13 @@ local function shared_counter(srcdir, targetdir)
    end
    function mod.create(name)
       shm.alias(source(name), target(name))
-      return counter.open(target(name))
+      local c
+      local function read_shared_counter ()
+         if not c then c = pcall(counter.open, target(name)) end
+         if not c then return 0ULL end
+         return counter.read(c)
+      end
+      return read_shared_counter
    end
    function mod.delete(name)
       S.unlink(shm.resolve(source(name)))
@@ -1258,24 +1264,22 @@ end
 
 function Intel1g:get_rxstats ()
    assert(self.rxq, "cannot retrieve rxstats without rxq")
-   local frame = self.shm
-   local rxc   = self.rxq
+   local rxc = self.rxq
    return {
       counter_id = rxc,
-      packets = counter.read(frame["q"..rxc.."_rxpackets"]),
-      dropped = counter.read(frame["q"..rxc.."_rxdrops"]),
-      bytes = counter.read(frame["q"..rxc.."_rxbytes"])
+      packets = self.shm["q"..rxc.."_rxpackets"](),
+      dropped = self.shm["q"..rxc.."_rxdrops"](),
+      bytes = self.shm["q"..rxc.."_rxbytes"]()
    }
 end
 
 function Intel1g:get_txstats ()
    assert(self.txq, "cannot retrieve rxstats without txq")
-   local frame = self.shm
-   local txc   = self.txq
+   local txc = self.txq
    return {
       counter_id = txc,
-      packets = counter.read(frame["q"..txc.."_txpackets"]),
-      bytes = counter.read(frame["q"..txc.."_txbytes"])
+      packets = self.shm["q"..txc.."_txpackets"](),
+      bytes = self.shm["q"..txc.."_txbytes"]()
    }
 end
 
@@ -1707,24 +1711,22 @@ end
 -- is in control of the counter registers (and clears them on read)
 function Intel82599:get_rxstats ()
    assert(self.rxcounter and self.rxq, "cannot retrieve rxstats")
-   local frame = self.shm
-   local rxc   = self.rxcounter
+   local rxc = self.rxcounter
    return {
       counter_id = rxc,
-      packets = counter.read(frame["q"..rxc.."_rxpackets"]),
-      dropped = counter.read(frame["q"..rxc.."_rxdrops"]),
-      bytes = counter.read(frame["q"..rxc.."_rxbytes"])
+      packets = self.shm["q"..rxc.."_rxpackets"](),
+      dropped = self.shm["q"..rxc.."_rxdrops"](),
+      bytes = self.shm["q"..rxc.."_rxbytes"]()
    }
 end
 
 function Intel82599:get_txstats ()
    assert(self.txcounter and self.txq, "cannot retrieve txstats")
-   local frame = self.shm
-   local txc   = self.txcounter
+   local txc = self.txcounter
    return {
       counter_id = txc,
-      packets = counter.read(frame["q"..txc.."_txpackets"]),
-      bytes = counter.read(frame["q"..txc.."_txbytes"])
+      packets = self.shm["q"..txc.."_txpackets"](),
+      bytes = self.shm["q"..txc.."_txbytes"]()
    }
 end
 

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -510,41 +510,6 @@ function Intel:new (conf)
    return self
 end
 
-function Intel:create_stats_symlinks ()
-   local exts = {}
-   for ext, mod in pairs(shm.types) do exts[mod] = ext end
-   local head = 'pci/'..self.pciaddress..'/'
-
-   for k, v in pairs(self.shm_frame) do
-      local mod, init = unpack(v)
-      local ext = assert(exts[mod])
-      local q, dir = k:match('^q(%d+)_([rt]x)')
-      if q and q ~= tostring(self[dir..'q']) then
-         -- Don't symlink in counters for queues not used by this app.
-      else
-         local tail = k..'.'..ext
-         -- This may fail if there are multiple apps that use this NIC,
-         -- e.g. one RX app and one TX app.
-         pcall(shm.alias, head..tail, self.shm_root.."stats/"..tail)
-      end
-   end
-end
-
-function Intel:remove_stats_symlinks ()
-   local exts = {}
-   for ext, mod in pairs(shm.types) do exts[mod] = ext end
-   local head = 'pci/'..self.pciaddress..'/'
-
-   for k, v in pairs(self.shm_frame) do
-      local mod, init = unpack(v)
-      local ext = assert(exts[mod])
-      local tail = k..'.'..ext
-      S.unlink(shm.resolve(head..tail))
-   end
-   -- Leave the empty dir; there could be other files there (e.g. RRD
-   -- files).
-end
-
 function Intel:disable_interrupts ()
    self.r.EIMC(0xffffffff)
 end

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -412,7 +412,7 @@ function Intel:new (conf)
    self.run_stats = conf.run_stats or (self.master and conf.master_stats)
    if self.run_stats then
       self.sync_timer = lib.throttle(0.01)
-      local stats_frame = {
+      local frame = {
          -- Keep a copy of the mtu here to have all
          -- data available in a single shm frame
          mtu       = {counter, self.mtu},
@@ -435,8 +435,8 @@ function Intel:new (conf)
          txdrop    = {counter},
          txerrors  = {counter},
       }
-      self:init_queue_stats(stats_frame)
-      self.stats = shm.create_frame(self.shm_root.."stats", stats_frame)
+      self:init_queue_stats(frame)
+      self.stats = shm.create_frame(self.shm_root.."stats", frame)
    end
 
    -- Expose per-device statistics from master

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -896,7 +896,6 @@ function Intel:stop ()
       self:unset_pool()
    end
    self:unset_tx_rate()
-   self:remove_stats_symlinks()
    if self.fd:flock("nb, ex") then
       -- delete shm state for this NIC
       shm.unlink(self.shm_root)

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -1488,6 +1488,7 @@ function Intel82599:check_vmdq ()
    if not self.vmdq then
       assert(not self.macaddr, "VMDq must be set to use MAC address")
       assert(not self.mirror, "VMDq must be set to specify mirroring rules")
+
       if not self.master then
          assert(vmdq_shm.enabled == 0,
                 "VMDq was set by the main process for this NIC")
@@ -1495,6 +1496,7 @@ function Intel82599:check_vmdq ()
    else
       assert(self.driver == "Intel82599", "VMDq only supported on 82599")
       assert(self.macaddr, "MAC address must be set in VMDq mode")
+
       if not self.master then
          assert(vmdq_shm.enabled == 1,
                 "VMDq not set by the main process for this NIC")

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -1485,7 +1485,6 @@ function Intel82599:check_vmdq ()
    if not self.vmdq then
       assert(not self.macaddr, "VMDq must be set to use MAC address")
       assert(not self.mirror, "VMDq must be set to specify mirroring rules")
-
       if not self.master then
          assert(vmdq_shm.enabled == 0,
                 "VMDq was set by the main process for this NIC")
@@ -1493,7 +1492,6 @@ function Intel82599:check_vmdq ()
    else
       assert(self.driver == "Intel82599", "VMDq only supported on 82599")
       assert(self.macaddr, "MAC address must be set in VMDq mode")
-
       if not self.master then
          assert(vmdq_shm.enabled == 1,
                 "VMDq not set by the main process for this NIC")

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -340,6 +340,7 @@ local function shared_counter(srcdir, targetdir)
    end
    function mod.create(name)
       shm.alias(source(name), target(name))
+      return counter.open(target(name))
    end
    function mod.delete(name)
       S.unlink(shm.resolve(source(name)))
@@ -1290,7 +1291,7 @@ end
 
 function Intel1g:get_rxstats ()
    assert(self.rxq, "cannot retrieve rxstats without rxq")
-   local frame = shm.open_frame("pci/"..self.pciaddress)
+   local frame = self.shm
    local rxc   = self.rxq
    return {
       counter_id = rxc,
@@ -1302,7 +1303,7 @@ end
 
 function Intel1g:get_txstats ()
    assert(self.txq, "cannot retrieve rxstats without txq")
-   local frame = shm.open_frame("pci/"..self.pciaddress)
+   local frame = self.shm
    local txc   = self.txq
    return {
       counter_id = txc,
@@ -1739,7 +1740,7 @@ end
 -- is in control of the counter registers (and clears them on read)
 function Intel82599:get_rxstats ()
    assert(self.rxcounter and self.rxq, "cannot retrieve rxstats")
-   local frame = shm.open_frame("pci/"..self.pciaddress)
+   local frame = self.shm
    local rxc   = self.rxcounter
    return {
       counter_id = rxc,
@@ -1751,7 +1752,7 @@ end
 
 function Intel82599:get_txstats ()
    assert(self.txcounter and self.txq, "cannot retrieve txstats")
-   local frame = shm.open_frame("pci/"..self.pciaddress)
+   local frame = self.shm
    local txc   = self.txcounter
    return {
       counter_id = txc,

--- a/src/apps/intel_mp/test_10g_counters.sh
+++ b/src/apps/intel_mp/test_10g_counters.sh
@@ -76,5 +76,5 @@ assert(pkts > 0, "get_rxstats failed")
 
 local status = worker.status()
 local pid = status.worker0.pid
-local ct = counter.open("/"..pid.."/pci/"..pciaddr1.."/q1_rxbytes.counter")
+local ct = counter.open("/"..pid.."/apps/nic/pci/"..pciaddr1.."/q1_rxbytes.counter")
 assert(counter.read(ct) > 0, "failed to read worker queue counter")

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -63,8 +63,7 @@ end
 
 function alias (name, target)
    mkdir(lib.dirname(resolve(name)))
-   assert(S.symlink(root.."/"..resolve(target), root.."/"..resolve(name)),
-          "shm alias failed")
+   assert(S.symlink(root.."/"..resolve(target), root.."/"..resolve(name)))
 end
 
 function resolve (name)

--- a/src/program/l2vpn/l2vpn.lua
+++ b/src/program/l2vpn/l2vpn.lua
@@ -251,7 +251,7 @@ local driver_helpers = {
          return 'input', 'output'
       end,
       stats_path = function (intf)
-         return 'pci/'..intf.pci_address
+         return 'apps/'..intf.app:name()..'/pci/'..intf.pci_address
       end
    },
    ['apps.tap.tap.Tap'] = {


### PR DESCRIPTION
This commit changes the intel_mp driver to make a forest of symlinks to the shared stats counters, rather than a single link to the shared counters directory.  This allows the app to indicate which queue it's on, as well as allowing ptree and top to naturally track the set of counters used by the app so they can manage associated .rrd files.

As part of this change, we remove the instance-local "pci" directory, instead using per-app "pci" directories.  This allows us to more nicely record which app is on which device.

This commit also updates "snabb top" to get PCI interfaces from within apps' SHM frames.

Fixes #1178.

WDYT @takikawa @dpino ?