### PR TITLE
Show nexthop MAC in top and yang model

### DIFF
--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -414,7 +414,9 @@ LwAftr.shm = {
    ["out-ipv4-bytes"]                                  = {counter},
    ["out-ipv4-packets"]                                = {counter},
    ["out-ipv6-bytes"]                                  = {counter},
-   ["out-ipv6-packets"]                                = {counter}
+   ["out-ipv6-packets"]                                = {counter},
+   ["next-hop-macaddr-v4"]                             = {counter},
+   ["next-hop-macaddr-v6"]                             = {counter},
 }
 
 function LwAftr:new(conf)
@@ -1069,6 +1071,10 @@ function LwAftr:from_b4(pkt)
    return self:enqueue_decapsulation(pkt, ipv4, port)
 end
 
+local macaddr_t = ffi.typeof('union { uint64_t u64; uint8_t bytes[6]; }')
+local next_hop_macaddr_v6 = ffi.new(macaddr_t)
+local next_hop_macaddr_v4 = ffi.new(macaddr_t)
+
 function LwAftr:push ()
    local i4, i6, ih = self.input.v4, self.input.v6, self.input.hairpin_in
    local o4, o6 = self.output.v4, self.output.v6
@@ -1076,6 +1082,15 @@ function LwAftr:push ()
 
    self.bad_ipv4_softwire_matches_alarm:check()
    self.bad_ipv6_softwire_matches_alarm:check()
+
+   if next_hop_macaddr_v6.u64 == 0 and self.conf.internal_interface.next_hop.mac then
+      next_hop_macaddr_v6.bytes = self.conf.internal_interface.next_hop.mac
+      counter.set(self.shm["next-hop-macaddr-v6"], next_hop_macaddr_v6.u64)
+   end
+   if next_hop_macaddr_v4.u64 == 0 and self.conf.external_interface.next_hop.mac then
+      next_hop_macaddr_v4.bytes = self.conf.external_interface.next_hop.mac
+      counter.set(self.shm["next-hop-macaddr-v4"], next_hop_macaddr_v4.u64)
+   end
 
    for _ = 1, link.nreadable(i6) do
       -- Decapsulate incoming IPv6 packets from the B4 interface and

--- a/src/lib/ptree/support/snabb-softwire-v2.lua
+++ b/src/lib/ptree/support/snabb-softwire-v2.lua
@@ -656,6 +656,8 @@ local function compute_state_reader(schema_name)
          local instance_state = instance_state_reader(counters)
          ret.softwire_config.instance[device] = {}
          ret.softwire_config.instance[device].softwire_state = instance_state
+         -- TODO: Copy queue[id].external_interface.next_hop.ip.resolved_mac.
+         -- TODO: Copy queue[id].internal_interface.next_hop.ip.resolved_mac.
       end
 
       return ret

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -554,7 +554,7 @@ function compute_display_tree.tree(tree, prev, dt, t)
                   local rate = compute_rate(v, prev, rrd, t, dt)
                   local v, tag = scale(rate)
                   out = lchars("%s: %.3f %s%s", k, v, tag, units or "/sec")
-               elseif k == 'macaddr' then
+               elseif k:match('macaddr') then
                   out = lchars("%s: %s", k, macaddr_string(v))
                else
                   out = lchars("%s: %s", k, lib.comma_value(v))


### PR DESCRIPTION
This PR adds two extra fields to `snabb-softwire-v2.yang`: `next-hop-macaddr-v4` and `next-hop-macaddr-v6`. Both values can be queried using `snabb config get-state` and using `snabb top`.

Some thoughts about the PR:
- Perhaps is worth to set an interval of time for updating the next hop mac address values. 
- Counters are always of `uint64_t` type. That's fine for MAC addresses, however in the YANG model I wanted the mac address fields to be of type `yang:mac-address`. This required me to do modify lib.yang.value's macaddr type and handle the case in `tostring` where `val` might be an `uint64_t` value (`uint8_t` is expected). I didn't find a more elegant way of implementing this. 

Some examples:

- Snabb top:

```bash
  workers:
    24764:
      pid: 24764
      apps:
        lwaftr:
          next-hop-macaddr-v4: 02:99:99:99:99:99                                        next-hop-macaddr-v6: 02:99:99:99:99:99
```

- Snabb config:

```bash
$ sudo ./snabb config get-state --schema=snabb-softwire-v2 diego / | grep mac
      next-hop-macaddr-v4 02:99:99:99:99:99;
      next-hop-macaddr-v6 02:99:99:99:99:99;
```