### PR TITLE
Allow setting flow-label in ingress packets

### DIFF
--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -725,6 +725,7 @@ module snabb-softwire-v2 {
 
       leaf flow-label {
         type uint32;
+        default 0;
         description
           "IPv6 flow label";
       }

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -723,6 +723,12 @@ module snabb-softwire-v2 {
          "Maximum packet size to recieve on the IPv6 interface.";
       }
 
+      leaf flow-label {
+        type uint32;
+        description
+          "IPv6 flow label";
+      }
+
       uses traffic-filters;
       uses icmp-policy;
       uses vlan-tagging;


### PR DESCRIPTION
In an infrastructure with several lwAFTRs if something goes wrong it may be hard to figure out which lwAFTR instance is causing trouble. Allowing each lwAFTR set their own flow-label can help to identify which ingress packets where processed by which lwAFTR.