### PR TITLE
Skip memory binding

### DIFF
--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -91,14 +91,52 @@ function unbind_cpu ()
 end
 
 local blacklisted_kernels = {
-   '4.15.0-36-generic',
+   '>=4.15',
 }
 local function sys_kernel ()
    return lib.readfile('/proc/sys/kernel/osrelease', '*all'):gsub('%s$', '')
 end
+local function parse_version_number (str)
+   local t = {}
+   for each in str:gmatch("([^.]+)") do
+      table.insert(t, tonumber(each) or 0)
+   end
+   return t
+end
+local function equals (v1, v2)
+   for i, p1 in ipairs(v1) do
+      local p2 = v2[i] or 0
+      if p1 ~= p2 then return false end
+   end
+   return true
+end
+local function greater_or_equals (v1, v2)
+   for i, p1 in ipairs(v1) do
+      local p2 = v2[i] or 0
+      if p2 > p1 then return false end
+   end
+   return true
+end
+local function greater (v1, v2)
+   return greater_or_equals(v1, v2) and not equals(v1, v2)
+end
 function is_blacklisted_kernel (v)
    for _, each in ipairs(blacklisted_kernels) do
-      if each == v then return true end
+      -- Greater or equal.
+      if each:sub(1, 2) == '>=' then
+         each = each:sub(3, #each)
+         local v1, v2 = parse_version_number(v), parse_version_number(each)
+         if greater_or_equals(v1, v2) then return true end
+      -- Greater than.
+      elseif each:sub(1, 1) == '>' then
+         each = each:sub(2, #each)
+         local v1, v2 = parse_version_number(v), parse_version_number(each)
+         if greater(v1, v2) then return true end
+      -- Equals.
+      else
+         local v1, v2 = parse_version_number(v), parse_version_number(each)
+         if equals(v1, v2) then return true end
+      end
    end
    return false
 end
@@ -183,5 +221,10 @@ function selftest ()
          test_cpu(cpuid)
       end
    end
+
+   assert(greater(parse_version_number('4.15'), parse_version_number('4.4.80')))
+   assert(greater_or_equals(parse_version_number('4.15'), parse_version_number('4.15')))
+   assert(not greater(parse_version_number('4.14'), parse_version_number('4.15')))
+
    print('selftest: numa: ok')
 end


### PR DESCRIPTION
Apparently there's a bug in at kernel '4.15.0-36' that cause a segmentation fault when `get_mempolicy` is used. The patch skips memory binding for affected kernels and prints out a warning message.