### PR TITLE
Implement unique restrictions in lib.yang

### DIFF
--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -151,6 +151,7 @@ function Manager:state_change_event(event, ...)
 end
 
 function Manager:set_initial_configuration (configuration)
+   path_data.consistency_checker_from_schema_by_name(self.schema_name, true)(configuration)
    self.current_configuration = configuration
    self.current_in_place_dependencies = {}
 

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -14,7 +14,7 @@ local lib = require('core.lib')
 local regexp = require("lib.xsd_regexp")
 
 function normalize_id(id)
-   return id:gsub('[^%w_]', '_')
+   return (id:gsub('[^%w_]', '_'))
 end
 
 -- Helper for parsing C type declarations.

--- a/src/lib/yang/data.lua
+++ b/src/lib/yang/data.lua
@@ -223,7 +223,8 @@ function data_grammar_from_schema(schema, is_config)
       return {type='table', keys=keys, values=values,
               string_key=table_string_key(keys),
               key_ctype=struct_ctype(keys),
-              value_ctype=struct_ctype(values)}
+              value_ctype=struct_ctype(values),
+              unique = node.unique}
    end
    function handlers.leaf(node, for_key)
       if node.config ~= is_config and not for_key then return end

--- a/src/lib/yang/path_data.lua
+++ b/src/lib/yang/path_data.lua
@@ -178,7 +178,11 @@ printer_for_schema_by_name = util.memoize(printer_for_schema_by_name)
 
 local function parser_for_grammar(grammar, path)
    local getter, subgrammar = resolver(grammar, path)
-   return data.data_parser_from_grammar(subgrammar)
+   return function (production)
+      local data = data.data_parser_from_grammar(subgrammar)(production)
+      consistency_checker_from_grammar(subgrammar)(data)
+      return data
+   end
 end
 
 local function parser_for_schema(schema, path)

--- a/src/lib/yang/path_data.lua
+++ b/src/lib/yang/path_data.lua
@@ -447,7 +447,7 @@ function remover_for_schema_by_name (schema_name, path)
 end
 remover_for_schema_by_name = util.memoize(remover_for_schema_by_name)
 
-function consistency_checker_from_grammar(grammar)
+function leafref_checker_from_grammar(grammar)
    -- Converts a relative path to an absolute path.
    -- TODO: Consider moving it to /lib/yang/path.lua.
    local function to_absolute_path (path, node_path)
@@ -524,6 +524,64 @@ function consistency_checker_from_grammar(grammar)
                ("Broken leafref integrity in '%s' when referencing '%s'"):format(
                 path, leafref))
       end
+   end   
+end
+
+function uniqueness_checker_from_grammar(grammar)
+   -- Generate checker for table
+   local function unique_assertion(leaves, grammar)
+      local unique_leaves = {}
+      for leaf in leaves:split(" +") do
+         table.insert(unique_leaves, normalize_id(leaf))
+      end
+      local pairs = grammar.key_ctype and cltable.pairs or pairs
+      return function (tab)
+         -- Sad quadratic loop, again
+         for k1, v1 in pairs(tab) do
+            for k2, v2 in pairs(tab) do
+               if k1 == k2 then break end
+               local collision = true
+               for _, leaf in ipairs(unique_leaves) do
+                  if not lib.equal(v1[leaf], v2[leaf]) then
+                     collision = false
+                     break
+                  end
+               end
+               assert(not collision, "Not unique: "..leaves)
+            end
+         end
+      end
+   end
+   -- Visit tables with unique constraints in grammar and apply checker
+   local function visit_unique_and_check(grammar, data)
+      if not data then return
+      elseif grammar.type == 'table' then
+         -- visit values
+         for name, value in pairs(grammar.values) do
+            for k, datum in pairs(data) do
+               visit_unique_and_check(value, datum[name])
+            end
+         end
+         -- check unique rescrictions
+         for _, leaves in ipairs(grammar.unique) do
+            unique_assertion(leaves, grammar)(data)
+         end
+      elseif grammar.type == 'struct' then
+         -- visit members
+         for name, member in pairs(grammar.members) do
+            visit_unique_and_check(member, data[name])
+         end
+      end
+   end
+   return function (data)
+      visit_unique_and_check(grammar, data)
+   end
+end
+
+function consistency_checker_from_grammar(grammar)
+   return function (data)
+      leafref_checker_from_grammar(grammar)(data)
+      uniqueness_checker_from_grammar(grammar)(data)
    end
 end
 
@@ -691,6 +749,54 @@ function selftest()
    setter_for_grammar(grammar, "/softwire-config/instance[device=test]/"..
                                "queue[id=0]/external-interface/ip 208.118.235.148")
    remover_for_grammar(grammar, "/softwire-config/instance[device=test]/")
+
+   
+   -- Test unique restrictions:
+   local unique_schema = schema.load_schema([[module unique-schema {
+      namespace "urn:ietf:params:xml:ns:yang:unique-schema";
+      prefix "test";
+
+      list unique_test {
+        key "testkey"; unique "testleaf testleaf2";
+        leaf testkey { type string; mandatory true; }
+        leaf testleaf { type string; mandatory true; }
+        leaf testleaf2 { type string; mandatory true; }
+      }
+   }]])
+   local checker = consistency_checker_from_schema(unique_schema, true)
+
+   -- Test unique validation (should fail)
+   local success, result = pcall(
+      checker,
+      data.load_config_for_schema(unique_schema,
+                                  mem.open_input_string [[
+                                     unique_test {
+                                       testkey "foo";
+                                       testleaf "bar";
+                                       testleaf2 "baz";
+                                     }
+                                     unique_test {
+                                       testkey "foo2";
+                                       testleaf "bar";
+                                       testleaf2 "baz";
+                                     }
+   ]]))
+   assert(not success)
+
+   -- Test unique validation (should succeed)
+   checker(data.load_config_for_schema(unique_schema,
+                                       mem.open_input_string [[
+                                          unique_test {
+                                            testkey "foo";
+                                            testleaf "bar";
+                                            testleaf2 "baz";
+                                          }
+                                          unique_test {
+                                            testkey "foo2";
+                                            testleaf "bar2";
+                                            testleaf2 "baz";
+                                          }
+   ]]))
 
    print("selftest: ok")
 end

--- a/src/lib/yang/path_data.lua
+++ b/src/lib/yang/path_data.lua
@@ -562,8 +562,19 @@ function uniqueness_checker_from_grammar(grammar)
       elseif grammar.type == 'table' then
          -- visit values
          for name, value in pairs(grammar.values) do
-            for k, datum in pairs(data) do
-               visit_unique_and_check(value, datum[name])
+            local id = normalize_id(name)
+            if grammar.key_ctype and grammar.value_ctype then
+               for entry in data:iterate() do
+                  visit_unique_and_check(value, entry.value[id])
+               end
+            elseif grammar.key_ctype then
+               for _, datum in cltable.pairs(data) do
+                  visit_unique_and_check(value, datum[id])
+               end
+            else
+               for _, datum in pairs(data) do
+                  visit_unique_and_check(value, datum[id])
+               end
             end
          end
          -- check unique rescrictions
@@ -573,7 +584,7 @@ function uniqueness_checker_from_grammar(grammar)
       elseif grammar.type == 'struct' then
          -- visit members
          for name, member in pairs(grammar.members) do
-            visit_unique_and_check(member, data[name])
+            visit_unique_and_check(member, data[normalize_id(name)])
          end
       end
    end


### PR DESCRIPTION
Hey Igalians, :-)

I’m putting this up for review here since this doesn’t target upstream Snabb yet.

- 1bff543 implements unique restrictions
- 5d00ae9 makes sure the consistency checker is run `parser_for_grammar` (i.e., during ptree’s `handle_update_config_rpc`)
- c7a655e runs the consistency checker on ptree’s `initial_configuration`

