### PR TITLE
Fix errors due to bad strncpy behavour.

### DIFF
--- a/src/apps/vhost/vhost_user.c
+++ b/src/apps/vhost/vhost_user.c
@@ -33,7 +33,7 @@ int vhost_user_connect(const char *path)
     }
 
     un.sun_family = AF_UNIX;
-    strncpy(un.sun_path, path, sizeof(un.sun_path));
+    strncpy(un.sun_path, path, sizeof(un.sun_path)-1);
 
     if (connect(sock, (struct sockaddr *) &un, sizeof(un)) == -1) {
         close(sock);
@@ -54,7 +54,7 @@ int vhost_user_listen(const char *path)
     }
 
     un.sun_family = AF_UNIX;
-    strncpy(un.sun_path, path, sizeof(un.sun_path));
+    strncpy(un.sun_path, path, sizeof(un.sun_path)-1);
     unlink(un.sun_path);
     if (bind(sock, (struct sockaddr *) &un, sizeof(un)) == -1) {
         close(sock);


### PR DESCRIPTION
As of GCC 8.1 a compiler error (stringop-truncation) will be raised as `strncpy` has potentially unsafe behavour, which I think is the case here (not sure if there is a limiting factor on `path`'s length?)

If `strncpy`'s source (path in our case) is longer than the destination the destination will not be null terminated. Which is what `sockaddr_un` requires of `sockaddr_un.sun_path`, from the man page unix(7):

> pathname: a UNIX domain socket can be bound to a null-terminated filesystem  pathname  using bind(2).

and
>  **Pathname sockets**
> When binding a socket to a pathname, a few rules should be observed for maximum portability and ease of coding:
>
> *  The pathname in sun_path should be null-terminated.

By reducing the copy size by one ensures as much as path as can be copied is and pads the rest of destination (the remaining one character) with null bytes, ensuring it's properly null terminated. See man page strcpy(3) for it's behavour:
> The  strncpy() function is similar, except that at most n bytes of src are copied.  Warning: If there is no null byte among the first n bytes of src, the string placed in  dest  will  not  be null-terminated.

> If  the  length of src is less than n, strncpy() writes additional null bytes to dest to ensure that a total of n bytes are written.
