### PR TITLE
Add assert limit for stride value

### DIFF
--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -364,6 +364,7 @@ function CTable:remove(key, missing_allowed)
 end
 
 function CTable:make_lookup_streamer(stride)
+   assert(stride > 0 and stride <= 262144, "Stride value out of range: "..stride)
    local res = {
       all_entries = self.entries,
       stride = stride,


### PR DESCRIPTION
When calling `lib/ctable.lua:make_lookup_streamer` with a stride value higher than 262144 (2^18), produces a segmentation fault (TABOV, table overflow error in LuaJIT). (https://stackoverflow.com/questions/25944489/luajit-table-overflow-error-when-loading-cdefs-using-ffi-cdef). To prevent this situation I added an assert limit.

One use case that can produce this situation is when packet drop monitor is called in a row 18 times. On each step the stride is increased, until a segfault is launched. I wonder whether it would be worthy to set a high limit for the stride value and print out a warning instead. Thoughts?