### PR TITLE
Add assert limit for stride value

### DIFF
--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -364,6 +364,7 @@ function CTable:remove(key, missing_allowed)
 end
 
 function CTable:make_lookup_streamer(stride)
+   assert(stride > 0 and stride <= 262144, "stride value out of range: "..stride)
    local res = {
       all_entries = self.entries,
       stride = stride,


### PR DESCRIPTION
Stride must be a value between 1 and 262144.  Otherwise a segfault is
launched.

Backport of #1199 to v3.1.10.