### PR TITLE
Add additional RSS test for 2 instances with 4 queues to release benchmarking script.

### DIFF
--- a/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.nix
+++ b/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.nix
@@ -4,9 +4,9 @@ let dataset = stdenv.mkDerivation {
   name = "lwaftr-dataset";
 
   dataset = (fetchTarball {
-    url = https://people.igalia.com/atakikawa/lwaftr_benchmarking_dataset.tar.gz;
+    url = https://people.igalia.com/jtallon/lwaftr_benchmarking_dataset.tar.gz;
     # not supported in old NixOS
-    #sha256 = "48b4204e656d19aa9f2b4023104f2483e66df7523e28188181fb3d052445eaba";
+    #sha256 = "feb77cade87848f3f38f35c0807ac6c34c4550256a9fa99f0e1fca1063bc96fb";
   });
 
   snabb_pci0 = builtins.getEnv "SNABB_PCI0";


### PR DESCRIPTION
The results when running it:
```
[jtallon@snabb1:~/snabb]$ sudo SNABB_LWAFTR_CPU0=1 SNABB_LWAFTR_CPU1=2 SNABB_LWAFTR_CPU2=3 SNABB_LWAFTR_CPU3=4 \
         SNABB_LOADTEST_CPU0=7 SNABB_LOADTEST_CPU1=8 \
         SNABB_PCI0=02:00.0 SNABB_PCI1=82:00.0 \
         SNABB_PCI2=02:00.1 SNABB_PCI3=82:00.1 \
         SNABB_PCI4=03:00.0 SNABB_PCI5=83:00.0 \
         SNABB_PCI6=03:00.1 SNABB_PCI7=83:00.1 \
         /home/jtallon/snabb/src/program/lwaftr/tests/release-benchmarks/release-benchmarks.sh 2>/dev/null
>> Compiling configurations (may take a while)
>> Running loadtest: 1 instance, 2 NIC interface (log: /tmp/tmp.zVvWc47ofo/tmp.OW86Ba1GNS)
>> Success: 7.303
>> Running loadtest: 1 instance, 2 NIC interfaces (from config) (log: /tmp/tmp.zVvWc47ofo/tmp.VaQNIhOIFJ)
>> Success: 7.364
>> Running loadtest: 1 instance, 1 NIC (on a stick) (log: /tmp/tmp.zVvWc47ofo/tmp.jAOexcjuob)
>> Success: 9.999
>> Running loadtest: 1 instance, 1 NIC (on-a-stick, from config file) (log: /tmp/tmp.zVvWc47ofo/tmp.o6OxEkat97)
>> Success: 9.999
>> Running loadtest: 2 instances, 2 NICs (from config) (log: /tmp/tmp.zVvWc47ofo/tmp.hfwleazlWH)
>> Running loadtest 2: 2 instances, 2 NICs (from config) (log: /tmp/tmp.zVvWc47ofo/tmp.guhZtlXkBG)
>> Success: 7.059
>> Success: 4.683
>> Running loadtest: 2 instances, 1 NIC (on a stick, from config) (log: /tmp/tmp.zVvWc47ofo/tmp.IbWGH0SlMK)
>> Running loadtest 2: 2 instances, 1 NIC (on a stick, from config) (log: /tmp/tmp.zVvWc47ofo/tmp.wxigK86p7b)
>> Success: 9.999
>> Success: 9.844
>> Running loadtest: 1 instance, 1 NIC, 2 queues (log: /tmp/tmp.zVvWc47ofo/tmp.xhHY0uMlFK)
>> Success: 9.999
>> Running loadtest: 2 instances, 2 NIC, 4 queues (log: /tmp/tmp.ZW5OPdW0t9/tmp.jN3PMjlAdE)
>> Running loadtest 2: 2 instances, 2 NIC, 4 queues (log: /tmp/tmp.ZW5OPdW0t9/tmp.ThsHATs3xv)
>> Success: 9.939
>> Success: 9.756
```