### PR TITLE
Detect version mismatch when loading compiled YANG configurations

### DIFF
--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -301,7 +301,7 @@ end
 function data_compiler_from_schema(schema, is_config)
    local grammar = data.data_grammar_from_schema(schema, is_config)
    return data_compiler_from_grammar(data_emitter(grammar),
-                                     schema.id, schema.revision_date)
+                                     schema.id, schema.last_revision)
 end
 
 function config_compiler_from_schema(schema)


### PR DESCRIPTION
This commit makes four changes:

  (1) On the individual revision nodes in a schema, the revision date is
      now stored under `date` instead of `value`.

  (2) Schemas now have a `last_revision` property, indicating the date
      of the most recent revision.

  (3) This revision now gets serialized into compiled configurations.

  (4) When loading compiled configurations, we check that the compiled
      file's revision date corresponds to the what we are expecting.

Fixes #1208 .