### PR TITLE
Fix PCI affinity check for --preferred NUMA binding

### DIFF
--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -78,8 +78,9 @@ function check_affinity_for_pci_addresses (addrs)
          print('Warning: No NUMA memory affinity.')
          print('Pass --cpu to bind to a CPU and its NUMA node.')
       end
-   elseif policy.mode ~= S.c.MPOL_MODE['bind'] then
-      print("Warning: NUMA memory policy already in effect, but it's not --membind.")
+   elseif (policy.mode ~= S.c.MPOL_MODE['bind'] and
+           policy.mode ~= S.c.MPOL_MODE['preferred']) then
+      print("Warning: NUMA memory policy already in effect, but it's not --membind or --preferred.")
    else
       local node = S.getcpu().node
       local node_for_pci = choose_numa_node_for_pci_addresses(addrs)


### PR DESCRIPTION
Since we switched to the "preferred" NUMA memory binding policy in #1071, the check that PCI devices had affinity with their bound NUMA node wasn't working.  Fixes an error in the loadtester of the form:

```
Warning: NUMA memory policy already in effect, but it's not --membind.
```