### PR TITLE
Support draft-ietf-softwire-yang-16

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -47,7 +47,7 @@ LUAJIT_A := ../lib/luajit/src/libluajit.a
 # for each module that has a top-level selftest () function.
 TESTMODS = $(shell find . -regex '[^\#]*\.\(lua\|dasl\)' -printf '%P ' | \
              xargs grep -s -l '^function selftest *[[:punct:]]' | \
-             sed -e 's_\.lua__' -e 's_\.dasl__' -e 's_/_._g')
+             sed -e 's_\.lua__' -e 's_\.dasl__' -e 's_/_._g' -e 's/-/_/g')
 
 # TESTSCRIPTS expands to:
 #   lib/watchdog/selftest.sh ...

--- a/src/lib/maxpc.lua
+++ b/src/lib/maxpc.lua
@@ -265,6 +265,17 @@ function capture.integer_number (radix)
 end
 
 
+-- string parsing
+
+function match.string (s)
+   local chars = {}
+   for i = 1, #s do
+      chars[i] = match.equal(s:sub(i,i))
+   end
+   return match.seq(unpack(chars))
+end
+
+
 -- backtracking combinators
 
 function match.plus (a, b)

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -582,7 +582,8 @@ function Manager:foreign_rpc_get_state (schema_name, path, format,
                                        print_default)
    path = path_mod.normalize_path(path)
    local translate = self:get_translator(schema_name)
-   local foreign_state = translate.get_state(self:get_native_state())
+   local foreign_state = translate.get_state(self:get_native_state(),
+                                             self.current_configuration)
    local printer = path_data.printer_for_schema_by_name(
       schema_name, path, false, format, print_default)
    return { state = call_with_output_string(printer, foreign_state) }

--- a/src/lib/ptree/support/snabb-softwire-v2.lua
+++ b/src/lib/ptree/support/snabb-softwire-v2.lua
@@ -11,7 +11,8 @@ local ctable = require('lib.ctable')
 local cltable = require('lib.cltable')
 local data = require('lib.yang.data')
 local state = require('lib.yang.state')
-local ipv4_ntop = require('lib.yang.util').ipv4_ntop
+local yang_util = require('lib.yang.util')
+local ipv4_ntop = yang_util.ipv4_ntop
 local yang = require('lib.yang.yang')
 local path_mod = require('lib.yang.path')
 local path_data = require('lib.yang.path_data')
@@ -100,12 +101,19 @@ local function remove_softwire_entry_actions(app_graph, path)
    return {{'call_app_method_with_blob', args}, {'commit', {}}}
 end
 
+-- Configuration discontinuity-time: this is set on startup and whenever the
+-- configuration changes.
+local discontinuity_time = os.time()
+
 local function compute_config_actions(old_graph, new_graph, to_restart,
                                       verb, path, arg)
    -- If the binding cable changes, remove our cached version.
    if path ~= nil and path:match("^/softwire%-config/binding%-table") then
       binding_table_instance = nil
    end
+
+   -- Set discontinuity-time.
+   discontinuity_time = os.time()
 
    if verb == 'add' and path == '/softwire-config/binding-table/softwire' then
       if to_restart == false then

--- a/src/lib/ptree/support/snabb-softwire-v2.lua
+++ b/src/lib/ptree/support/snabb-softwire-v2.lua
@@ -471,7 +471,6 @@ local function ietf_softwire_br_translator ()
       -- Two kinds of updates: setting the whole binding table, or
       -- updating one entry.
       if path_match(path, bind_instance_path, binding_entry_path) then
-         print("whole")
          -- Setting the whole binding table.
          if #path == #bind_instance_path + #binding_entry_path and
             not path_has_query(path, #path)
@@ -739,14 +738,6 @@ function selftest ()
    local path = path_mod.parse_path(
       "/br-instances/binding/bind-instance[name=test]/binding-table/binding-entry"
    )
-   print("path")
-   for i,c in pairs(path) do
-      print(i)
-      print(c.name)
-      for k,v in pairs(c.query) do
-         print(k, v)
-      end
-   end
    assert(#path == #bind_instance_path + #binding_entry_path)
    assert(path_match(path, bind_instance_path, binding_entry_path))
    assert(path_match(path, bind_instance_path))

--- a/src/lib/ptree/support/snabb-softwire-v2.lua
+++ b/src/lib/ptree/support/snabb-softwire-v2.lua
@@ -400,9 +400,9 @@ local function ietf_softwire_br_translator ()
          not path_has_query(path, #bind_instance_path,
                             {name=instance_name(native_config)})
       then
-         error("Instance name does not match this instance (%s): %s",
-               instance_name(native_config),
-               path[#bind_instance_path].query.name)
+         error(("Instance name does not match this instance (%s): %s")
+               :format(instance_name(native_config),
+                       path[#bind_instance_path].query.name))
       end
 
       -- Handle special br attributes (softwire-payload-mtu,
@@ -572,9 +572,9 @@ local function ietf_softwire_br_translator ()
       end
       if not path_has_query(path, #bind_instance_path,
                             {name=instance_name(native_config)}) then
-         error("Instance name does not match this instance (%s): %s",
-               instance_name(native_config),
-               path[#bind_instance_path].query.name)
+         error(("Instance name does not match this instance (%s): %s")
+               :format(instance_name(native_config),
+                       path[#bind_instance_path].query.name))
       end
       local config = ret.get_config(native_config)
       local ietf_bt = ietf_softwire_br_getter(path_str)(config)
@@ -624,9 +624,9 @@ local function ietf_softwire_br_translator ()
       then
          if not path_has_query(path, #bind_instance_path,
                                {name=instance_name(native_config)}) then
-            error("Instance name does not match this instance (%s): %s",
-                  instance_name(native_config),
-                  path[#bind_instance_path].query.name)
+            error(("Instance name does not match this instance (%s): %s")
+                  :format(instance_name(native_config),
+                          path[#bind_instance_path].query.name))
          end
          if not path_has_query(path, #path) then
             error('unsupported path: '..path_str)

--- a/src/lib/yang/ietf-softwire-br.yang
+++ b/src/lib/yang/ietf-softwire-br.yang
@@ -1,304 +1,493 @@
 module ietf-softwire-br {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-softwire-br";
-  prefix "softwire-br";
+  prefix softwire-br;
 
-  import ietf-inet-types {prefix inet; }
-  import ietf-yang-types {prefix yang; }
-  import ietf-softwire-common {prefix softwire-common; }
+  import ietf-inet-types {
+    prefix inet;
+    reference "Section 4 of RFC 6991";
+  }
+  import ietf-yang-types {
+    prefix yang;
+    reference "Section 3 of RFC 6991";
+  }
+  import ietf-softwire-common {
+    prefix softwire-common;
+    reference
+      "RFC XXXX: YANG Modules for IPv4-in-IPv6 Address plus Port
+                 Softwires";
+  }
 
-  organization "Softwire Working Group";
-
+  organization
+    "IETF Softwire Working Group";
   contact
-    "
-    Qi Sun <sunqi.ietf@gmail.com>
-    Hao Wang <wangh13@mails.tsinghua.edu.cn>
-    Yong Cui <yong@csnet1.cs.tsinghua.edu.cn>
-    Ian <Farrer ian.farrer@telekom.de>
-    Sladjana Zoric <sladjana.zoric@telekom.de>
-    Mohamed Boucadair <mohamed.boucadair@orange.com>
-    Rajiv <Asati rajiva@cisco.com>
-    ";
+    "WG Web:   <https://datatracker.ietf.org/wg/softwire/>
+     WG List:  <mailto:softwire@ietf.org>
+
+     Author:  Qi Sun
+              <mailto:sunqi.ietf@gmail.com>
+
+     Author:  Linhui Sun
+              <mailto:lh.sunlinh@gmail.com>
+
+     Author:  Yong Cui
+              <mailto:yong@csnet1.cs.tsinghua.edu.cn>
+
+     Editor:  Ian Farrer
+              <mailto:ian.farrer@telekom.de>
+
+     Author:  Sladjana Zoric
+              <mailto:sladjana.zoric@telekom.de>
+
+     Editor:  Mohamed Boucadair
+              <mailto:mohamed.boucadair@orange.com>
+
+     Author:  Rajiv Asati
+               <mailto:rajiva@cisco.com>";
 
   description
-    "This document defines a YANG data module for the configuration and
-    management of A+P Softwire Border Routers. It covers Lightweight 4over6,
-    MAP-E, and MAP-T mechanisms.
+    "This document defines a YANG module for the configuration and
+     management of A+P Softwire Border Routers. It covers Lightweight
+     4over6, MAP-E, and MAP-T mechanisms.
 
-    Copyright (c) 2017 IETF Trust and the persons identified
-    as authors of the code. All rights reserved.
-    This version of this YANG module is part of RFC XXX; see the RFC
-    itself for full legal notices.";
+     Copyright (c) 2019 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
 
-  revision 2017-10-19 {
-    description
-      "Update...";
-    reference "-02";
-  }
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
 
-  revision 2017-06-14 {
-    description
-      "Monolithic version of ietf-softwire divided into separate CE and BR
-      models. Added icmp handling and improved counters.";
-    reference "-06";
-  }
-  revision 2016-06-04 {
-    description
-      "Version-05: Combined MAP-E/MAP-T into a single tree. Added binding
-      table/algorthm versioning";
-    reference "-05";
-  }
+     This version of this YANG module is part of RFC XXXX; see
+     the RFC itself for full legal notices.";
 
-  revision 2015-09-30 {
-    description
-      "Version-04: Fix YANG syntax; Add flags to map-rule; Remove
-      the map-rule-type element. ";
-    reference "-04";
-  }
-
-  revision 2015-04-07 {
-    description
-      "Version-03: Integrate lw4over6; Updata state nodes; Correct
-      grammar errors; Reuse groupings; Update descriptions.
-      Simplify the model.";
-    reference "-03";
-  }
-
-  revision 2015-02-10 {
-    description
-      "Version-02: Add notifications.";
-    reference "-02";
-  }
-
-
-  revision 2015-02-06 {
-    description
-      "Version-01: Correct grammar errors; Reuse groupings; Update
-      descriptions.";
-    reference "-01";
-  }
-
-  revision 2015-02-02 {
+  revision 2019-01-11 {
     description
       "Initial revision.";
-    reference "-00";
+    reference
+      "RFC XXXX: YANG Modules for IPv4-in-IPv6 Address plus Port
+                 Softwires";
+  }
+
+  /*
+   * Groupings
+   */
+
+  grouping port-set {
+    description
+      "Describes a set of layer 4 port numbers.
+
+       This may be a simple port range, or use the Port Set
+       Identifier (PSID) algorithm to represent a range of transport
+       layer ports which will be used by a NAPT.";
+    leaf psid-offset {
+      type uint8 {
+        range "0..16";
+      }
+      description
+        "The number of offset bits. In Lightweight 4over6,
+         the default value is 0 for assigning one contiguous
+         port range. In MAP-E/T, the default value is 6,
+         which means the system ports (0-1023) are excluded by
+         default and the assigned port ranges are distributed across
+         the entire port space, depending on either psid-len or the
+         number of contiguous ports.";
+    }
+    leaf psid-len {
+      type uint8 {
+        range "0..15";
+      }
+      mandatory true;
+      description
+        "The length of PSID, representing the sharing
+         ratio for an IPv4 address. This, along with ea-len, can
+         be used to calculate the number of contiguous ports per
+         port range";
+    }
+    leaf psid {
+      type uint16;
+      mandatory true;
+      description
+        "Port Set Identifier (PSID) value, which
+         identifies a set of ports algorithmically.";
+    }
+  }
+
+  grouping binding-entry {
+    description
+      "The binding BR maintains an address binding table that
+       contains the binding between the CE's IPv6 address,
+       the allocated IPv4 address and restricted port-set.";
+    leaf binding-ipv6info {
+      type union {
+        type inet:ipv6-address;
+        type inet:ipv6-prefix;
+      }
+      description
+        "The IPv6 information for a CE binding entry.
+         When the IPv6 prefix type is used,
+         the IPv6 source address of the CE is constructed
+         according to the description in RFC7596;
+         if the IPv6 address type is used, the CE can use
+         any valid /128 address from a prefix assigned to
+         the CE.";
+      reference
+        "RFC7596: Lightweight 4over6: An Extension to the Dual-Stack
+                  Lite Architecture";
+    }
+    leaf binding-ipv4-addr {
+      type inet:ipv4-address;
+      description
+        "The IPv4 address assigned to the binding CE,
+         which is used as the IPv4 external address
+         for binding CE local NAPT44.";
+    }
+    container port-set {
+      description
+        "For Lightweight 4over6, the default value
+         for offset should be 0, to configure one contiguous
+         port range.";
+      uses port-set {
+        refine "psid-offset" {
+          default "0";
+        }
+      }
+    }
+    leaf br-ipv6-addr {
+      type inet:ipv6-address;
+      description
+        "The IPv6 address for binding BR.";
+    }
   }
 
   /*
    * Features
    */
 
-  feature binding {
+  feature binding-mode {
     description
-      "Binding is used for configuring Lightweight 4over6 mechanism.
+      "Binding is used for configuring the Lightweight 4over6 mechanism.
 
-      Binding softwire mechanisms are IPv4-over-IPv6 tunnelling transition mechanisms specifically for complete independence between IPv6 subnet prefix (and /128 IPv6 address) and IPv4 address with or without IPv4 address sharing.
+       Binding based softwire mechanisms are IPv4-over-IPv6 tunnelling
+       transition mechanisms specifically intended for complete
+       independence between the IPv6 subnet prefix (and IPv6 address)
+       and IPv4 address, with or without IPv4 address sharing.
 
-      This is accomplished by maintaining state for each softwire (per-subscriber state) in the central Border Relay (BR) and a hub-and-spoke forwarding architecture. In order to delegate the NAPT function and achieve IPv4 address sharing, port-restricted IPv4 addresses needs to be allocated to CEs.";
+       This is accomplished by maintaining state for each softwire
+       (per-subscriber state) in the central Border Relay (BR) and using
+       a hub-and-spoke forwarding architecture. In order to delegate the
+       NAPT function and achieve IPv4 address sharing, port-restricted
+       IPv4 addresses needs to be allocated to CEs.
 
+       This feature indicates that the network element can function as
+       one or more binding based softwire instances.";
     reference
-      "RFC7596, RFC7597 & RFC7599";
+      "RFC7596: Lightweight 4over6: An Extension to the Dual-Stack Lite
+                Architecture
+       RFC7597: Mapping of Address and Port with Encapsulation (MAP-E)
+       RFC7599: Mapping of Address and Port using Translation (MAP-T)";
   }
 
-  feature algorithm {
+  feature map-e {
     description
       "MAP-E is an IPv6 transition mechanism for transporting IPv4
-      packets across an IPv6 network using IP encapsulation. MAP-E
-      allows for a reduction of the amount of centralized state using
-      rules to express IPv4/IPv6 address mappings. This introduces an
-      algorithmic relationship between the IPv6 subnet and IPv4 address.
+       packets across an IPv6 network using IP encapsulation. MAP-E
+       allows for a reduction of the amount of centralized state using
+       rules to express IPv4/IPv6 address mappings. This introduces an
+       algorithmic relationship between the IPv6 subnet and IPv4
+       address.
 
-      MAP-T is an IPv6 transition mechanism for transporting IPv4 packets across an IPv6 network using IP translation. It leverages double stateless NAT64 based solution as well as the stateless algorithmic address & transport layer port mapping algorithm defined for MAP-E.
-
-      This feature indicates the instance functions as a MAP-E or
-      MAP-T instance.";
-
+       This feature indicates that the network element can function as
+       one or more MAP-E softwire instances.";
     reference
-      "RFC7597 & RFC7599";
+      "RFC7597: Mapping of Address and Port with Encapsulation (MAP-E)";
+  }
+
+  feature map-t {
+    description
+      "MAP-T is an IPv6 transition mechanism for transporting IPv4
+       packets across an IPv6 network using IP translation. It leverages
+       a double stateless NAT64 based solution as well as the stateless
+       algorithmic address & transport layer port mapping algorithm
+       defined for MAP-E.
+
+       This feature indicates that the network element can function as
+       one or more MAP-T softwire instances.";
+    reference
+      "RFC7599: Mapping of Address and Port using Translation (MAP-T)";
   }
 
   container br-instances {
     description
-      "BR Instances";
-
+      "BR instances enabled in a network element.";
     choice br-type {
       description
         "Select binding or algorithmic BR functionality.";
       case binding {
-        if-feature binding;
+        if-feature "binding-mode";
         container binding {
-          if-feature binding;
           description
-            "lw4over6 (binding table) configuration.";
-          list br-instance {
-            key "id";
+            "binding mechanism (binding table) configuration.";
+          list bind-instance {
+            key "name";
             description
-              "A set of lwAFTRs to be configured.";
+              "A set of binding instances to be configured.";
+            leaf name {
+              type string;
+              mandatory true;
+              description
+                "The name for the binding BR. It is used to uniquely
+                 distinguish a binding instance by its name.";
+            }
             container binding-table-versioning {
-              description "binding table's version";
-              leaf version{
+              description
+                "binding table's version";
+              leaf version {
                 type uint64;
-                description "Incremental version number of the binding
-                  table";
+                description
+                  "Version number for this binding table.";
               }
               leaf date {
                 type yang:date-and-time;
-                description "Timestamp of the binding
-                  table";
+                description
+                  "Timestamp when the binding table was activated.
+
+                   A binding instance may be provided with binding
+                   entries that may change in time (e.g., increase
+                   the size of the port set). When a party who is the
+                   victim of abuse presents an external IP address/port,
+                   the version of the binding table is important
+                   because depending on the version, a distinct customer
+                   may be identified.
+
+                   The timestamp is used as a key to find the
+                   appropriate binding table that was put into effect
+                   when an abuse occurred.";
+                reference
+                  "RFC7422: Deterministic Address Mapping to Reduce
+                            Logging in Carrier-Grade NAT Deployments";
               }
             }
-            leaf id {
-              type uint32;
-              mandatory true;
-              description "An instance identifier.";
-            }
-            leaf name {
-              type string;
-              description "The name for the lwaftr.";
-            }
-            leaf softwire-num-threshold {
-              type uint32;
+            leaf softwire-num-max {
+              type uint32 {
+                range "1..max";
+              }
               mandatory true;
               description
-                "The maximum number of softwires that can be created on
-                the lwAFTR.";
+                "The maximum number of softwires that can be created
+                 on the binding BR.";
             }
-            leaf softwires-payload-mtu {
+            leaf softwire-payload-mtu {
               type uint16;
-              units bytes;
+              units "bytes";
               mandatory true;
               description
-                "The payload MTU for Lightweight 4over6 softwire.";
+                "The payload IPv4 MTU for binding softwire.";
             }
             leaf softwire-path-mru {
               type uint16;
-              units bytes;
+              units "bytes";
               mandatory true;
               description
-                "The path MRU for Lightweight 4over6 softwire.";
+                "The path MRU for binding softwire.";
+              reference
+                "RFC4213: Basic Transition Mechanisms for IPv6 Hosts
+                          and Routers";
             }
             leaf enable-hairpinning {
               type boolean;
-              default true;
+              default "true";
               description
                 "Enables/disables support for locally forwarding
-                (hairpinning) traffic between two CEs (RFC7596
-                    Section 6.2)";
+                 (hairpinning) traffic between two CEs.";
+              reference "Section 6.2 of RFC7596";
             }
             container binding-table {
-              description "binding table";
+              description
+                "binding table";
               list binding-entry {
                 key "binding-ipv6info";
-                description "binding entry";
-                uses softwire-common:binding-entry;
+                description
+                  "binding entry";
+                uses binding-entry;
               }
             }
             container icmp-policy {
               description
-                "The lwAFTR can be configured to process or drop incoming ICMP
-                messages, and to generate outgoing ICMP error messages or
-                not.";
-
+                "The binding BR can be configured to process or drop
+                 incoming ICMP messages, and to generate outgoing ICMP
+                 error messages.";
               container icmpv4-errors {
                 description
                   "ICMPv4 error processing configuration";
                 leaf allow-incoming-icmpv4 {
                   type boolean;
-                  default true;
+                  default "true";
                   description
-                    "Whether to allow processing of incoming ICMPv4 packets.
-                    (RFC7596 )";
+                    "Enables the processing of incoming ICMPv4
+                     packets.";
+                  reference
+                    "RFC7596: Lightweight 4over6: An Extension to
+                              the Dual-Stack Lite Architecture";
                 }
-
+                leaf icmpv4-rate {
+                  type uint32;
+                  description
+                    "Rate limit threshold in messages per-second
+                     for processing incoming ICMPv4 errors messages";
+                }
                 leaf generate-icmpv4-errors {
                   type boolean;
-                  default true;
+                  default "true";
                   description
-                    "Whether to generate outgoing ICMP error messages on
-                    receipt of an inbound IPv4 packet with no matching
-                    binding table entry (RFC7596 Seciton 5.2).";
+                    "Enables the generation of outgoing ICMPv4 error
+                     messages on receipt of an inbound IPv4 packet
+                     with no matching binding table entry.";
+                  reference "Seciton 5.2 of RFC7596.";
                 }
               }
-
               container icmpv6-errors {
                 description
                   "ICMPv6 error processing configuration";
                 leaf generate-icmpv6-errors {
                   type boolean;
-                  default true;
+                  default "true";
                   description
-                    "Whether to generate ICMPv6 errors messages if no
-                    matching binding table entry is found (RFC7596
-                        Section 6.2)";
+                    "Enables the generation of ICMPv6 error messages if
+                     no matching binding table entry is found for a
+                     received packet.";
+                  reference "Section 6.2 of RFC7596.";
                 }
-                leaf icmpv6-errors-rate {
-                  type uint16;
+                leaf icmpv6-rate {
+                  type uint32;
                   description
                     "Rate limit threshold in messages per-second
-                    for sending ICMPv6 errors messages (RFC7596
-                        Section 9.)";
+                     for sending ICMPv6 errors messages";
+                  reference "Section 9 of RFC7596.";
                 }
               }
             }
-
             container traffic-stat {
               config false;
               description
-                "traffic-stat";
-              uses softwire-common:traffic-stat;
-
-              leaf hairpin-ipv4-bytes {
-                type yang:zero-based-counter64;
-                description "IPv4 packets locally routed between two CEs
-                  (hairpinned).";
+                "Traffic statistics information for the BR.";
+              leaf discontinuity-time {
+                type yang:date-and-time;
+                mandatory true;
+                description
+                  "The time of the most recent occasion on which the BR
+                   instance suffered a discontinuity.  This must be
+                   initialized when the BR instance is configured
+                   or rebooted.";
               }
+              uses softwire-common:traffic-stat;
+              leaf dropped-icmpv4-packets {
+                type yang:zero-based-counter64;
+                description
+                  "ICMPv4 packets that are dropped as a result
+                   of the ICMP policy. Typically, this can be any
+                   incoming ICMPv4 packets if ICMPv4 processing is
+                   disabled or incoming ICMPv4 packets that exceed
+                   the ICMPv4 rate-limit threshold.
 
+                   Discontinuities in the value of this counter can
+                   occur at re-initialization of the management
+                   system, and at other times as indicated by
+                   the value of 'discontinuity-time'.";
+              }
+              leaf dropped-icmpv4-bytes {
+                type yang:zero-based-counter64;
+                description
+                  "ICMPv4 messages, in bytes, that are dropped as
+                   a result of the ICMP policy. Typically, it
+                   can be any incoming ICMPv4 packets if ICMPv4
+                   processing is disabled or incoming ICMPv4
+                   packets that exceed the ICMPv4 rate-limit
+                   threshold.
+
+                   Discontinuities in the value of this counter can
+                   occur at re-initialization of the management
+                   system, and at other times as indicated by
+                   the value of 'discontinuity-time'.";
+              }
               leaf hairpin-ipv4-packets {
                 type yang:zero-based-counter64;
-                description "IPv4 bytes locally routed between two CEs
-                  (hairpinned).";
-              }
+                description
+                  "IPv4 packets locally routed between two CEs
+                   (hairpinned).
 
+                   Discontinuities in the value of this counter can
+                   occur at re-initialization of the management
+                   system, and at other times as indicated by
+                   the value of 'discontinuity-time'.";
+              }
+              leaf hairpin-ipv4-bytes {
+                type yang:zero-based-counter64;
+                description
+                  "IPv4 bytes locally routed between two CEs
+                   (hairpinned).
+
+                   Discontinuities in the value of this counter can
+                   occur at re-initialization of the management
+                   system, and at other times as indicated by
+                   the value of 'discontinuity-time'.";
+              }
               leaf active-softwire-num {
                 type uint32;
+                config false;
                 description
                   "The number of currently active softwires on the
-                  lw4over6 (binding) instance.";
+                   binding instance.
+
+                   Discontinuities in the value of this counter can
+                   occur at re-initialization of the management
+                   system, and at other times as indicated by
+                   the value of 'discontinuity-time'.";
               }
             }
           }
         }
       }
-      case algorithm {
-        if-feature algorithm;
+      case algo {
+        if-feature "map-e or map-t";
         container algorithm {
-          if-feature algorithm;
           description
-            "Indicate the instances support the MAP-E and MAP-T function.
-            The instances advertise the map-e/map-t feature through the
-            capability exchange mechanism when a NETCONF session is
-            established.";
+            " A set of parameters used for MAP-E/MAP-T.";
           list algo-instance {
-            key "id";
-            description "Instances of algorithm";
-            leaf id {
-              type uint32;
-              mandatory true;
-              description "id";
-            }
+            key "name";
+            description
+              "Instances of algorithm";
             leaf name {
               type string;
-              description "The MAP instance name.";
+              mandatory true;
+              description
+                "The name is used to uniquely identify an algorithm
+                 instance.
+
+                 This name can be automatically assigned
+                 or explicitly configured.";
             }
-            uses softwire-common:algorithm {
-              augment "algo-instances/algo-instance"{
-                description "Augments the port-set group for the algorithm.";
-                uses softwire-common:port-set;
-            }
+            uses softwire-common:algorithm-instance;
+            container port-set {
+              description
+                "Indicates a set of ports.";
+              uses port-set;
             }
             container traffic-stat {
+              config false;
               description
-                "traffic-stat";
+                "Traffic statistics information for the BR.";
+              leaf discontinuity-time {
+                type yang:date-and-time;
+                mandatory true;
+                description
+                  "The time of the most recent occasion on which the BR
+                   instance suffered a discontinuity.  This must be
+                   reset to the current date-and-time when the BR
+                   instance is configured or rebooted.";
+              }
               uses softwire-common:traffic-stat;
             }
           }
@@ -310,79 +499,84 @@ module ietf-softwire-br {
   /*
    * Notifications
    */
-  notification softwire-br-event {
-    if-feature binding;
-    description "Notifications for BR.";
-    leaf br-id {
+
+  notification softwire-binding-instance-event {
+    if-feature "binding-mode";
+    description
+      "Notifications for binding instance when an entry is
+       added, modified, or is not valid anymore.";
+    leaf bind-name {
       type leafref {
-        path
-          "/br-instances/binding/"
-          + "br-instance/id";
+        path "/br-instances/binding/bind-instance/name";
       }
-      description "...";
+      description
+        "The name of the binding-instance that
+         generated the notification.";
     }
     leaf-list invalid-entry {
       type leafref {
         path
           "/br-instances/binding/"
-          + "br-instance[id=current()/../br-id]/"
+          + "bind-instance[name=current()/../bind-name]/"
           + "binding-table/binding-entry/binding-ipv6info";
       }
       description
-        "Notify the client that a specific binding entry has been
-        expired/invalid. The binding-ipv6info identifies an entry.";
+        "Notify the client that a specific binding entry has
+         expired or is invalid. The binding-ipv6info identifies
+         an entry.";
     }
     leaf-list added-entry {
       type inet:ipv6-address;
       description
         "Notify the client that a binding entry has been added.
-        The ipv6 address of that entry is the index. The client
-        get other information from the lwaftr about the entry
-        indexed by that ipv6 address.
-        ";
+         The ipv6 address of that entry is the index. The client
+         gets other information from the binding BR about the entry
+         indexed by that ipv6 address.";
     }
     leaf-list modified-entry {
       type leafref {
         path
           "/br-instances/binding/"
-          + "br-instance[id=current()/../br-id]/"
+          + "bind-instance[name=current()/../bind-name]/"
           + "binding-table/binding-entry/binding-ipv6info";
       }
-      description "...";
+      description
+        "The binding-table entry that has been modified.";
     }
   }
-
   notification softwire-algorithm-instance-event {
-    if-feature algorithm;
-    description "Notifications for MAP-E or MAP-T.";
-    leaf algo-id {
+    if-feature "map-e or map-t";
+    description
+      "Notifications for algorithm instance when an entry is
+       added, modified, or is not valid anymore.";
+    leaf algo-name {
       type leafref {
-        path
-          "/br-instances/algorithm/algo-instance/id";
+        path "/br-instances/algorithm/algo-instance/name";
       }
       mandatory true;
-      description "MAP-E or MAP-T event.";
+      description
+        "algorithmic instance event.";
     }
-    leaf-list invalid-entry-id {
+    leaf-list invalid-entry {
       type leafref {
-        path
-          "/br-instances/algorithm/algo-instance/id";
+        path "/br-instances/algorithm/algo-instance/name";
       }
-      description "Invalid entry event.";
+      description
+        "Invalid entry event.";
     }
     leaf-list added-entry {
       type leafref {
-        path
-          "/br-instances/algorithm/algo-instance/id";
+        path "/br-instances/algorithm/algo-instance/name";
       }
-      description "Added entry.";
+      description
+        "Added entry.";
     }
     leaf-list modified-entry {
       type leafref {
-        path
-          "/br-instances/algorithm/algo-instance/id";
+        path "/br-instances/algorithm/algo-instance/name";
       }
-      description "Modified entry.";
+      description
+        "Modified entry.";
     }
   }
 }

--- a/src/lib/yang/ietf-softwire-br.yang
+++ b/src/lib/yang/ietf-softwire-br.yang
@@ -219,6 +219,15 @@ module ietf-softwire-br {
       "RFC7599: Mapping of Address and Port using Translation (MAP-T)";
   }
 
+  /* XXX - if-feature can be a boolean logic expression in YANG 1.1
+     https://tools.ietf.org/html/rfc7950#section-7.20.2
+   *
+   * This is not yet implemented in lib.yang yet, and since we do not support
+   * map-e or map-t this is a shortcut patch to make it accept this model.
+   */
+  feature "map-e or map-t" {
+  }
+
   container br-instances {
     description
       "BR instances enabled in a network element.";

--- a/src/lib/yang/ietf-softwire-br.yang
+++ b/src/lib/yang/ietf-softwire-br.yang
@@ -219,15 +219,6 @@ module ietf-softwire-br {
       "RFC7599: Mapping of Address and Port using Translation (MAP-T)";
   }
 
-  /* XXX - if-feature can be a boolean logic expression in YANG 1.1
-     https://tools.ietf.org/html/rfc7950#section-7.20.2
-   *
-   * This is not yet implemented in lib.yang yet, and since we do not support
-   * map-e or map-t this is a shortcut patch to make it accept this model.
-   */
-  feature "map-e or map-t" {
-  }
-
   container br-instances {
     description
       "BR instances enabled in a network element.";

--- a/src/lib/yang/ietf-softwire-common.yang
+++ b/src/lib/yang/ietf-softwire-common.yang
@@ -1,298 +1,400 @@
 module ietf-softwire-common {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-softwire-common";
-  prefix "softwire-common";
+  prefix softwire-common;
 
-  import ietf-inet-types { prefix inet; }
-  import ietf-yang-types { prefix yang; }
+  import ietf-inet-types {
+    prefix inet;
+    reference "Section 4 of RFC 6991";
+  }
+  import ietf-yang-types {
+    prefix yang;
+    reference "Section 3 of RFC 6991";
+  }
 
-  organization "Softwire Working Group";
-
+  organization
+    "IETF Softwire Working Group";
   contact
-    "
-    Qi Sun <sunqi.ietf@gmail.com>
-    Hao Wang <wangh13@mails.tsinghua.edu.cn>
-    Yong Cui <yong@csnet1.cs.tsinghua.edu.cn>
-    Ian <Farrer ian.farrer@telekom.de>
-    Sladjana Zoric <sladjana.zoric@telekom.de>
-    Mohamed Boucadair <mohamed.boucadair@orange.com>
-    Rajiv <Asati rajiva@cisco.com>
-    ";
+    "WG Web:   <https://datatracker.ietf.org/wg/softwire/>
+     WG List:  <mailto:softwire@ietf.org>
 
+     Author:  Qi Sun
+              <mailto:sunqi.ietf@gmail.com>
+
+     Author:  Linhui Sun
+              <mailto:lh.sunlinh@gmail.com>
+
+     Author:  Yong Cui
+              <mailto:yong@csnet1.cs.tsinghua.edu.cn>
+
+     Editor:  Ian Farrer
+              <mailto:ian.farrer@telekom.de>
+     Author:  Sladjana Zoric
+              <mailto:sladjana.zoric@telekom.de>
+
+     Editor:  Mohamed Boucadair
+              <mailto:mohamed.boucadair@orange.com>
+
+     Author:  Rajiv Asati
+               <mailto:rajiva@cisco.com>";
   description
-    "This document defines a YANG data model for the configuration and
-    management of A+P Softwire Customer Premises Equipment (CEs). It
-    covers Lightweight 4over6, MAP-E and MAP-T mechanisms.
+    "This document defines a YANG module defining types
+     common to all A+P modules.
 
-    Copyright (c) 2017 IETF Trust and the persons identified
-    as authors of the code. All rights reserved.
-    This version of this YANG module is part of RFC XXX; see the RFC
-    itself for full legal notices.";
+     Copyright (c) 2019 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
 
-  revision 2017-10-19 {
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX; see
+     the RFC itself for full legal notices.";
+
+  revision 2019-01-11 {
     description
-      "Initial version of containing a model for common softwire elements.";
-    reference "-02";
+      "Initial revision.";
+    reference
+      "RFC XXXX: YANG Modules for IPv4-in-IPv6 Address plus Port
+                 Softwires";
+  }
+
+  feature map-e {
+    description
+      "MAP-E is an IPv6 transition mechanism for transporting IPv4
+       packets across an IPv6 network using IP encapsulation. MAP-E
+       allows for a reduction of the amount of centralized state using
+       rules to express IPv4/IPv6 address mappings. This introduces an
+       algorithmic relationship between the IPv6 subnet and IPv4
+       address.
+
+       This feature indicates that the network element can function as
+       one or more MAP-E softwire instances.";
+    reference
+      "RFC7597: Mapping of Address and Port with Encapsulation (MAP-E)";
+  }
+
+  feature map-t {
+    description
+      "MAP-T is an IPv6 transition mechanism for transporting IPv4
+       packets across an IPv6 network using IP translation. It leverages
+       a double stateless NAT64 based solution as well as the stateless
+       algorithmic address & transport layer port mapping algorithm
+       defined for MAP-E.
+
+       This feature indicates that the network element can function as
+       one or more MAP-T softwire instances.";
+    reference
+      "RFC7599: Mapping of Address and Port using Translation (MAP-T)";
   }
 
   /*
-   * Grouping
+   * Groupings
    */
 
-  grouping port-set {
+  grouping algorithm-instance {
     description
-      "Indicates a set of ports.
-      It may be a simple port range, or use the PSID algorithm
-      to represent a range of transport layer ports which will
-      be used by a NAPT.";
-
-    leaf psid-offset {
-      type uint8 {
-        range 0..16;
+      "A collection of parameters that is used fro MAP-E/MAP-T.";
+    leaf enable {
+      type boolean;
+      description
+        "Enable/disable an individual MAP-E or MAP-T rule.";
+    }
+    container algo-versioning {
+      description
+        "Version number for this algorithm instance";
+      leaf version {
+        type uint64;
+        description
+          "A version number for the mapping algorithm
+           rules provided to the algorithm instance";
       }
-      description
-        "The number of offset bits. In Lightweight 4over6,
-        the default value is 0 for assigning one contiguous
-          port range. In MAP-E/T, the default value is 6,
-        which means the system ports (0-1023) are excluded by
-        default and assigns port ranges distributed across the
-        entire port space, depending on either psid-len or the
-        number of contiguous ports.";
-    }
+      leaf date {
+        type yang:date-and-time;
+        description
+          "Timestamp when the algorithm instance was activated.
 
-    leaf psid-len {
-      type uint8 {
-        range 0..15;
-      }
-      mandatory true;
-      description
-        "The length of PSID, representing the sharing
-        ratio for an IPv4 address. This, along with ea-len, also
-        helps to calculate the number of contiguous ports per
-        port range";
-    }
+           An algorithm instance may be provided with mapping
+           rules that may change in time (for example, increase
+           the size of the port set). When a party who is the victim
+           of abuse presents an external IP address/port, the version
+           of the algorithm is important because depending on
+           the version, a distinct customer may be identified.
 
-    leaf psid {
-      type uint16;
-      mandatory true;
-      description
-        "Port Set Identifier (PSID) value, which
-        identifies a set of ports algorithmically.";
-    }
-  }
-
-  grouping binding-entry {
-    description
-      "The lwAFTR maintains an address binding table that contains
-      the binding between the lwB4's IPv6 address, the allocated IPv4
-      address and restricted port-set.";
-    leaf binding-ipv6info {
-      type union {
-        type inet:ipv6-address;
-        type inet:ipv6-prefix;
-      }
-      description
-        "The IPv6 information for a binding entry.
-        If this is an IPv6 prefix, it indicates that
-        the IPv6 source address of the CE is constructed
-        according to the description in RFC7596;
-      if it is an IPv6 address, it means the CE uses
-        any /128 address from the assigned CE prefix.
-          ";
-    }
-    leaf binding-ipv4-addr {
-      type inet:ipv4-address;
-      description
-        "The IPv4 address assigned to the lwB4, which is
-        used as the IPv4 external address
-        for lwB4 local NAPT44.";
-    }
-    container port-set {
-      description
-        "For Lightweight 4over6, the default value
-        of offset should be 0, to configure one contiguous
-        port range.";
-      uses port-set {
-        refine "psid-offset" {
-          default "0";
-        }
+           The timestamp is used as a key to find the appropriate
+           algorithm that was put into effect when an abuse
+           occurred. ";
+        reference
+          "RFC7422: Deterministic Address Mapping to Reduce
+                    Logging in Carrier-Grade NAT Deployments";
       }
     }
-    leaf br-ipv6-addr {
-      type inet:ipv6-address;
+    choice data-plane {
       description
-        "The IPv6 address for lwaftr.";
-    }
-  }
-
-  grouping algorithm {
-    description
-      "Indicate the instances support the MAP-E and MAP-T function.
-      The instances advertise the map-e feature through the
-      capability exchange mechanism when a NETCONF session is
-      established.";
-    container algo-instances {
-      description
-        "A set of MAP-E or MAP-T instances to be configured,
-        applying to BRs and CEs. A MAP-E/T instance defines a MAP
-          domain comprising one or more MAP-CE and MAP-BR";
-      list algo-instance {
-        key "id";
-        description "MAP forwarding rule instance for MAP-E/MAP-T";
-        leaf enable {
-          type boolean;
-          description
-            "Enable/disable individual MAP-E or MAP-T rule.";
-        }
-        container algo-versioning {
-          description "algorithm's version";
-          leaf version {
-            type uint64;
-            description "Incremental version number for the algorithm";
-          }
-          leaf date {
-            type yang:date-and-time;
-            description "Timestamp to the algorithm";
-          }
-        }
-        leaf id {
-          type uint32;
-          mandatory true;
-          description "Algorithm Instance ID";
-        }
-        leaf name {
-          type string;
-          description "The name for the instance.";
-        }
-        choice data-plane {
-          description "Selects MAP-E (encapsulation) or MAP-T (translation)";
-          case encapsulation {
-            description "encapsulation for MAP-E";
-            leaf br-ipv6-addr {
-              type inet:ipv6-address;
-              mandatory true;
-              description
-                "The IPv6 address of the MAP-E BR.";
-            }
-          }
-          case translation {
-            description "translation for MAP-T";
-            leaf dmr-ipv6-prefix {
-              type inet:ipv6-prefix;
-              description
-                "The IPv6 prefix of the MAP-T BR. ";
-            }
-          }
-        }
-        leaf ea-len {
-          type uint8;
+        "Selects MAP-E (encapsulation) or MAP-T
+         (translation)";
+      case encapsulation {
+        if-feature "map-e";
+        description
+          "encapsulation for MAP-E";
+        leaf br-ipv6-addr {
+          type inet:ipv6-address;
           mandatory true;
           description
-            "Embedded Address (EA) bits are the IPv4 EA-bits in the IPv6
-            address identify an IPv4 prefix/address (or part thereof) or
-            a shared IPv4 address (or part thereof) and a port-set identifier.
-            The length of the EA-bits is defined as part of a MAP rule for a
-            MAP domain.";
+            "The IPv6 address of the MAP-E BR.";
         }
-        leaf rule-ipv6-prefix {
+      }
+      case translation {
+        if-feature "map-t";
+        description
+          "translation for MAP-T";
+        leaf dmr-ipv6-prefix {
           type inet:ipv6-prefix;
-          mandatory true;
           description
-            "The Rule IPv6 prefix defined in the mapping rule.";
-        }
-        leaf rule-ipv4-prefix {
-          type inet:ipv4-prefix;
-          mandatory true;
-          description
-            "The Rule IPv4 prefix defined in the mapping rule.";
-        }
-        leaf forwarding {
-          type boolean;
-          mandatory true;
-          description
-            "This parameter specifies whether the rule may be used for
-            forwarding (FMR). If set, this rule is used as an FMR;
-          if not set, this rule is a BMR only and must not be used
-            for forwarding.";
+            "The IPv6 prefix of the MAP-T BR.";
         }
       }
+    }
+    leaf ea-len {
+      type uint8;
+      mandatory true;
+      description
+        "Embedded Address (EA) bits are the IPv4 EA-bits in the IPv6
+         address identifying an IPv4 prefix/address (or part thereof)
+         or a shared IPv4 address (or part thereof) and a port-set
+         identifier. The length of the EA-bits is defined as part of
+         a MAP rule for a MAP domain.";
+    }
+    leaf rule-ipv6-prefix {
+      type inet:ipv6-prefix;
+      mandatory true;
+      description
+        "The Rule IPv6 prefix defined in the mapping rule.";
+    }
+    leaf rule-ipv4-prefix {
+      type inet:ipv4-prefix;
+      mandatory true;
+      description
+        "The Rule IPv4 prefix defined in the mapping rule.";
+    }
+    leaf forwarding {
+      type boolean;
+      mandatory true;
+      description
+        "This parameter specifies whether the rule may be used for
+         forwarding (FMR). If set, this rule is used as an FMR;
+         if not set, this rule is a Basic Mapping Rule (BMR) only
+         and must not be used for forwarding.";
     }
   }
 
   grouping traffic-stat {
-    description "Traffic statistics";
-    leaf sent-ipv4-packet {
+    description
+      "Traffic statistics";
+    leaf sent-ipv4-packets {
       type yang:zero-based-counter64;
-      description "Number of decapsulated/translated IPv4 packets sent.";
+      description
+        "Number of decapsulated and forwarded IPv4 packets.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
-    leaf sent-ipv4-byte {
+    leaf sent-ipv4-bytes {
       type yang:zero-based-counter64;
-      description "Decapsulated/translated IPv4 traffic sent, in bytes";
+      description
+        "Decapsulated/translated IPv4 traffic sent, in bytes
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
-    leaf sent-ipv6-packet {
+    leaf sent-ipv6-packets {
       type yang:zero-based-counter64;
-      description "Number of encapsulated/translated IPv6 packets sent.";
+      description
+        "Number of encapsulated IPv6 packets sent.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
-    leaf sent-ipv6-byte {
+    leaf sent-ipv6-bytes {
       type yang:zero-based-counter64;
-      description "Encapsulated/translated IPv6 traffic sent, in bytes";
+      description
+        "Encapsulated IPv6 traffic sent, in bytes
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
-    leaf rcvd-ipv4-packet {
+    leaf rcvd-ipv4-packets {
       type yang:zero-based-counter64;
-      description "Number of IPv4 packets received for processing.";
+      description
+        "Number of IPv4 packets received.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
-    leaf rcvd-ipv4-byte {
+    leaf rcvd-ipv4-bytes {
       type yang:zero-based-counter64;
-      description "IPv4 traffic received for processing, in bytes";
+      description
+        "IPv4 traffic received, in bytes.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
-    leaf rcvd-ipv6-packet {
+    leaf rcvd-ipv6-packets {
       type yang:zero-based-counter64;
-      description "Number of IPv6 packets received for processing.";
+      description
+        "Number of IPv4-in-IPv6 packets received.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
-    leaf rcvd-ipv6-byte {
+    leaf rcvd-ipv6-bytes {
       type yang:zero-based-counter64;
-      config false;
-      description "IPv6 traffic received for processing, in bytes";
+      description
+        "IPv4-in-IPv6 traffic received, in bytes.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
-    leaf dropped-ipv4-packet {
+    leaf dropped-ipv4-packets {
       type yang:zero-based-counter64;
-      description "Number of IPv4 packets dropped.";
-    }
-    leaf dropped-ipv4-byte {
-      type yang:zero-based-counter64;
-      description "IPv4traffic dropped, in bytes";
-    }
-    leaf dropped-ipv6-packet {
-      type yang:zero-based-counter64;
-      description "Number of IPv4 packets dropped.";
-    }
-    leaf dropped-ipv6-byte {
-      type yang:zero-based-counter64;
-      description "IPv4 traffic dropped, in bytes";
-    }
-    leaf dropped-ipv4-fragments {
-      type yang:zero-based-counter64;
-      description "Number of fragmented IPv4 packets dropped";
+      description
+        "Number of IPv4 packets dropped at the
+         Internet-facing interface.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
     leaf dropped-ipv4-bytes {
       type yang:zero-based-counter64;
-      description "Fragmented IPv4 traffic dropped, in bytes";
+      description
+        "IPv4 traffic dropped at the Internet-facing
+         interface, in bytes.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
+    }
+    leaf dropped-ipv6-packets {
+      type yang:zero-based-counter64;
+      description
+        "Number of IPv4-in-IPv6 packets dropped.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
+    }
+    leaf dropped-ipv6-bytes {
+      type yang:zero-based-counter64;
+      description
+        "IPv4-in-IPv6 traffic dropped, in bytes.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
+    }
+    leaf dropped-ipv4-fragments {
+      type yang:zero-based-counter64;
+      description
+        "Number of fragmented IPv4 packets dropped.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
+    }
+    leaf dropped-ipv4-fragment-bytes {
+      type yang:zero-based-counter64;
+      description
+        "Fragmented IPv4 traffic dropped, in bytes.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
     leaf ipv6-fragments-reassembled {
       type yang:zero-based-counter64;
-      description "Number of IPv6 fragments successfully reassembled";
+      description
+        "Number of IPv6 fragments successfully reassembled.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
     leaf ipv6-fragments-bytes-reassembled {
       type yang:zero-based-counter64;
-      description "IPv6 fragments successfully reassembled, in bytes";
+      description
+        "IPv6 fragments successfully reassembled, in bytes.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
     leaf out-icmpv4-error-packets {
       type yang:zero-based-counter64;
-      description "Internally generated ICMPv4 error packets.";
+      description
+        "Internally generated ICMPv4 error packets.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
+    }
+    leaf out-icmpv4-error-bytes {
+      type yang:zero-based-counter64;
+      description
+        "Internally generated ICMPv4 error messages, in bytes.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
     leaf out-icmpv6-error-packets {
       type yang:zero-based-counter64;
-      description "Internally generted ICMPv6 error packets.";
+      description
+        "Internally generated ICMPv6 error packets.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
+    }
+    leaf out-icmpv6-error-bytes {
+      type yang:zero-based-counter64;
+      description
+        "Internally generated ICMPv6 error messages, in bytes.
+
+         Discontinuities in the value of this counter can occur
+         at re-initialization of the management system, and at
+         other times as indicated by the value of
+         'discontinuity-time'.";
     }
   }
 }

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -5,6 +5,7 @@ local lib = require("core.lib")
 local mem = require("lib.stream.mem")
 local parser = require("lib.yang.parser")
 local util = require("lib.yang.util")
+local maxpc = require("lib.maxpc")
 
 local function error_with_loc(loc, msg, ...)
    error(string.format("%s: "..msg, loc, ...))
@@ -640,6 +641,127 @@ function set_default_capabilities(capabilities)
    end
 end
 
+-- Parse/interpret YANG 1.1 if-feature expressions
+-- https://tools.ietf.org/html/rfc7950#section-7.20.2
+local if_feature_expr_parser = (function ()
+   local match, capture, combine = maxpc.import()
+   local refs = {}
+   local function ref (s) return function (...) return refs[s](...) end end
+   local di = 0
+   local function d(n, p)
+      return function (...)
+         print((' '):rep(di)..n)
+         di = di + 3
+         local res = {p(...)}
+         di = di - 3
+         print((' '):rep(di)..(res[1] and 'match' or 'fail'))
+         return unpack(res)
+      end
+   end
+   local function wsp_lf()
+      return combine._or(match.equal(' '), match.equal('\t'),
+                         match.equal('\n'), match.equal('\r'))
+   end
+   local function sep()      return d('sep', combine.some(wsp_lf())) end
+   local function optsep()   return d('optsep',combine.any(wsp_lf()))  end
+   local function keyword(s) return d(s, match.string(s))        end
+   local function identifier()
+      -- [a-zA-Z_][a-zA-Z0-9_-.:]+
+      local alpha_ = match.satisfies(function (x)
+            return ("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_")
+               :find(x, 1, true)
+      end)
+      local digit_punct = match.satisfies(function (x)
+            return ("0123456789-."):find(x, 1, true)
+      end)
+      return d('identifier', capture.subseq(
+         match.seq(alpha_, combine.any(combine._or(alpha_, digit_punct)))
+      ))
+   end
+   local function identifier_ref()
+      local idref = capture.seq(
+         identifier(),
+         combine.maybe(match.equal(":")), combine.maybe(identifier())
+      )
+      local function ast_idref (mod_or_id, _, id)
+         return {'feature', id or mod_or_id, id and mod_or_id or nil}
+      end
+      return d('identifier_ref',
+               capture.unpack(idref, ast_idref))
+   end
+   local function if_feature_not()
+      local not_feature = capture.seq(
+         keyword'not', sep(), ref'if_feature_factor'
+      )
+      local function ast_not (_, _, fact) return {'not', fact} end
+      return d('if_feature_not',
+               capture.unpack(not_feature, ast_not))
+   end
+   local function if_feature_subexpr()
+      local subexpr = capture.seq(
+         match.equal("("), optsep(), ref'if_feature_expr', optsep(), match.equal(")")
+      )
+      local function ast_subexpr (_, _, expr) return {'subexpr', expr} end
+      return d('if_feature_subexpr',
+               capture.unpack(subexpr, ast_subexpr))
+   end
+   local function if_feature_factor ()
+      return d('if_feature_factor',
+               combine._or(if_feature_not(), if_feature_subexpr(), identifier_ref()))
+   end
+   refs.if_feature_factor = if_feature_factor()
+   local function if_feature_and()
+      local and_feature = capture.seq(
+         if_feature_factor(), sep(), keyword'and', sep(), ref'if_feature_term'
+      )
+      local function ast_and (a, _, _, _, b) return {'and', a, b} end
+      return d('if_feature_and',
+               capture.unpack(and_feature, ast_and))
+   end
+   local function if_feature_term()
+      return d('if_feature_term',
+               combine._or(if_feature_and(), if_feature_factor()))
+   end
+   refs.if_feature_term = if_feature_term()
+   local function if_feature_or()
+      local or_feature = capture.seq(
+         if_feature_term(), sep(), keyword'or', sep(), ref'if_feature_expr'
+      )
+      local function ast_or (a, _, _, _, b) return {'or', a, b} end
+      return d('if_feature_or',
+               capture.unpack(or_feature, ast_or))
+   end
+   local function if_feature_expr()
+      return d('if_feature_expr',
+               combine._or(if_feature_or(), if_feature_term()))
+   end
+   refs.if_feature_expr = if_feature_expr()
+   return refs.if_feature_expr
+end)()
+
+local function parse_if_feature_expr(expr)
+   local ast, success, eof = maxpc.parse(expr, if_feature_expr_parser)
+   assert(success and eof, "Error parsing if-feature-expression: "..expr)
+   return ast
+end
+
+local function interpret_if_feature(expr, has_feature_p)
+   local function interpret (ast)
+      local op, a, b = unpack(ast)
+      if op == 'feature' then
+         return has_feature_p(a, b)
+      elseif op == 'or' then
+         if interpret(a) then return true
+         else                 return interpret(b) end
+      elseif op == 'and' then
+         return interpret(a) and interpret(b)
+      elseif op == 'subexpr' then
+         return interpret(a)
+      end
+   end
+   return interpret(parse_if_feature_expr(expr))
+end
+
 -- Inline "grouping" into "uses".
 -- Inline "submodule" into "include".
 -- Inline "imports" into "module".
@@ -794,15 +916,22 @@ function resolve(schema, features)
             node.unavailable = true
          end
       end
-      for _,feature in ipairs(pop_prop(node, 'if_features') or {}) do
-         local feature_node = lookup_lazy(env, 'features', feature)
-         if node.kind == 'feature' then
-            -- This is a feature that depends on a feature.  These we
-            -- keep in the environment but if the feature is
-            -- unavailable, we mark it as such.
-            local mod, id = feature_node.module_id, feature_node.id
-            if not (features[mod] or {})[id] then node.unavailable = true end
-         elseif feature_node.unavailable then
+      for _,expr in ipairs(pop_prop(node, 'if_features') or {}) do
+         local function resolve_feature (feature, mod)
+            assert(not mod, "NYI: module qualified features in if-feature expression")
+            local feature_node = lookup_lazy(env, 'features', feature)
+            if node.kind == 'feature' then
+               -- This is a feature that depends on a feature.  These we
+               -- keep in the environment but if the feature is
+               -- unavailable, we mark it as such.
+               local mod, id = feature_node.module_id, feature_node.id
+               if (features[mod] or {})[id] then return true
+               else node.unavailable = true end
+            elseif not feature_node.unavailable then
+               return true
+            end
+         end
+         if not interpret_if_feature(expr, resolve_feature) then
             return nil, env
          end
       end
@@ -1178,6 +1307,8 @@ function selftest()
    assert(bt)
    local ps = bt.body['binding-entry'].body['port-set']
    assert(ps)
+   local alg = br.body['br-instances'].body['br-type'].body['algorithm']
+   assert(not alg)
    -- The binding-entry grouping is defined in ietf-softwire-common and
    -- imported by ietf-softwire-br, but with a refinement that the
    -- default is 0.  Test that the refinement was applied.
@@ -1228,6 +1359,17 @@ function selftest()
 
    -- Test Range with explicit value.
    assert(lib.equal(parse_range_or_length_arg(nil, nil, "42"), {{42, 42}}))
+
+   -- Parsing/interpreting if-feature expressions
+   local function test_features (i, m)
+      local f = { b_99 = { ["c.d"] = true },
+                  [0] = { bar = true } }
+      return f[m or 0][i]
+   end
+   local expr = "baz and foo or bar and (a or b_99:c.d)"
+   assert(interpret_if_feature(expr, test_features))
+   assert(not interpret_if_feature("boo", test_features))
+   assert(not interpret_if_feature("baz or foo", test_features))
 
    print('selftest: ok')
 end

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -795,8 +795,6 @@ function resolve(schema, features)
          end
       end
       for _,feature in ipairs(pop_prop(node, 'if_features') or {}) do
-         -- XXX - feature can be a boolean logic expression in YANG 1.1
-         -- https://tools.ietf.org/html/rfc7950#section-7.20.2
          local feature_node = lookup_lazy(env, 'features', feature)
          if node.kind == 'feature' then
             -- This is a feature that depends on a feature.  These we

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -795,6 +795,8 @@ function resolve(schema, features)
          end
       end
       for _,feature in ipairs(pop_prop(node, 'if_features') or {}) do
+         -- XXX - feature can be a boolean logic expression in YANG 1.1
+         -- https://tools.ietf.org/html/rfc7950#section-7.20.2
          local feature_node = lookup_lazy(env, 'features', feature)
          if node.kind == 'feature' then
             -- This is a feature that depends on a feature.  These we

--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -1158,7 +1158,7 @@ function selftest()
    -- capabilities, for now, assuming tests are run independently from
    -- programs.
    local caps = get_default_capabilities()
-   local new_caps = { ['ietf-softwire-br'] = {feature={'binding'}} }
+   local new_caps = { ['ietf-softwire-br'] = {feature={'binding-mode'}} }
    for mod_name, mod_caps in pairs(new_caps) do
       if not caps[mod_name] then caps[mod_name] = {feature={}} end
       for _,feature in ipairs(mod_caps.feature) do
@@ -1174,7 +1174,7 @@ function selftest()
    local br = load_schema_by_name('ietf-softwire-br')
    local binding = br.body['br-instances'].body['br-type'].body['binding']
    assert(binding)
-   local bt = binding.body['binding'].body['br-instance'].body['binding-table']
+   local bt = binding.body['binding'].body['bind-instance'].body['binding-table']
    assert(bt)
    local ps = bt.body['binding-entry'].body['port-set']
    assert(ps)

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -11,6 +11,11 @@ module snabb-softwire-v2 {
   description
    "Configuration for the Snabb Switch lwAFTR.";
 
+  revision 2019-09-17 {
+    description
+      "Add discontinuity time to softwire-state.";
+  }
+
   revision 2018-10-13 {
     description
       "Add flow-label setting.";
@@ -44,6 +49,15 @@ module snabb-softwire-v2 {
 
       description "State data about interface.";
       config false;
+
+      leaf discontinuity-time {
+        type yang:date-and-time;
+        mandatory true;
+        description
+          "The time of the most recent occasion on which the lwaftr instance
+           suffered a discontinuity. This is set to the current time whenever
+           the lwaftr instance is started or configured.";
+      }
 
       leaf drop-all-ipv4-iface-bytes {
         type yang:zero-based-counter64;

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -771,7 +771,6 @@ module snabb-softwire-v2 {
 
       list softwire {
         key "ipv4 psid";
-        unique "b4-ipv6";
 
         leaf ipv4 {
           type inet:ipv4-address;

--- a/src/lib/yang/snabb-softwire-v2.yang
+++ b/src/lib/yang/snabb-softwire-v2.yang
@@ -771,6 +771,7 @@ module snabb-softwire-v2 {
 
       list softwire {
         key "ipv4 psid";
+        unique "b4-ipv6";
 
         leaf ipv4 {
           type inet:ipv4-address;

--- a/src/program/lwaftr/setup.lua
+++ b/src/program/lwaftr/setup.lua
@@ -34,7 +34,7 @@ local alarms     = require("lib.yang.alarms")
 local alarm_notification = false
 
 local capabilities = {
-   ['ietf-softwire-br']={feature={'binding'}},
+   ['ietf-softwire-br']={feature={'binding-mode'}},
    ['ietf-alarms']={feature={'operator-actions', 'alarm-shelving', 'alarm-history'}},
 }
 require('lib.yang.schema').set_default_capabilities(capabilities)

--- a/src/program/lwaftr/tests/propbased/genyang.lua
+++ b/src/program/lwaftr/tests/propbased/genyang.lua
@@ -385,7 +385,7 @@ local function path_generator_from_grammar(production, generate_invalid)
       table.sort(members)
       return function ()
          local head = keyword or ''
-         if math.random() < 0.1 then return head end
+         if #members == 0 or math.random() < 0.1 then return head end
          if head ~= '' then head = head..'/' end
          local k = choose(members)
          return head..gen_tail[k]()

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -113,7 +113,7 @@ class TestConfigGet(BaseTestCase):
             DAEMON_PROC_NAME,
             # Implicit string concatenation, do not add commas.
             '/br-instances/binding/'
-            'br-instance[id=1]/binding-table/binding-entry'
+            'bind-instance[name=test]/binding-table/binding-entry'
             '[binding-ipv6info=127:22:33:44:55:66:77:128]/binding-ipv4-addr',
         ))
         output = self.run_cmd(cmd_args)
@@ -284,6 +284,9 @@ class TestConfigMultiproc(BaseTestCase):
                 continue
             [cname, cvalue] = line.split(" ")
             cname = os.path.basename(cname)
+            if cname == "discontinuity-time":
+                cvalue = str(cvalue)
+                continue
             cvalue = int(cvalue)
 
             if line.startswith("/softwire-config"):
@@ -501,7 +504,7 @@ class TestConfigMisc(BaseTestCase):
             DAEMON_PROC_NAME,
             # Implicit string concatenation, no summing needed.
             '/br-instances/binding/'
-            'br-instance[id=1]/binding-table/binding-entry'
+            'bind-instance[name=test]/binding-table/binding-entry'
             '[binding-ipv6info=::1]/binding-ipv4-addr',
         ))
         output = self.run_cmd(get_args)
@@ -515,7 +518,7 @@ class TestConfigMisc(BaseTestCase):
         get_args.extend((
             DAEMON_PROC_NAME,
             # Implicit string concatenation, no summing needed.
-            '/br-instances/binding/br-instance[id=1]/'
+            '/br-instances/binding/bind-instance[name=test]/'
             'binding-table/binding-entry[binding-ipv6info=::1]/port-set/psid',
         ))
         output = self.run_cmd(get_args)

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -113,7 +113,7 @@ class TestConfigGet(BaseTestCase):
             DAEMON_PROC_NAME,
             # Implicit string concatenation, do not add commas.
             '/br-instances/binding/'
-            'bind-instance[name=test]/binding-table/binding-entry'
+            'bind-instance[name=config-test-daemon]/binding-table/binding-entry'
             '[binding-ipv6info=127:22:33:44:55:66:77:128]/binding-ipv4-addr',
         ))
         output = self.run_cmd(cmd_args)
@@ -429,7 +429,7 @@ class TestConfigMisc(BaseTestCase):
         add_args.extend((
             DAEMON_PROC_NAME,
             # Implicit string concatenation, no summing needed.
-            '/br-instances/binding/bind-instance[name=test]/'
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
             'binding-table/binding-entry',
             '{ binding-ipv6info ::123; binding-ipv4-addr 8.8.8.8;'
             'br-ipv6-addr 2001:db8::; port-set { psid 8; psid-len 15; }}',
@@ -439,7 +439,7 @@ class TestConfigMisc(BaseTestCase):
         get_args[3] = '--schema=ietf-softwire-br'
         get_args.extend((
             DAEMON_PROC_NAME,
-            '/br-instances/binding/bind-instance[name=test]/'
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
             'binding-table/binding-entry[binding-ipv6info=::123]/port-set/psid',
         ))
         output = self.run_cmd(get_args)
@@ -483,6 +483,8 @@ class TestConfigMisc(BaseTestCase):
         # Verify we cannot find it anymore.
         self.run_cmd(get_args)
         # run_cmd checks the exit code and fails the test if it is not zero.
+
+    #XXX - def test_remove_ietf(self):
 
     def test_set(self):
         """
@@ -529,7 +531,7 @@ class TestConfigMisc(BaseTestCase):
             DAEMON_PROC_NAME,
             # Implicit string concatenation, no summing needed.
             '/br-instances/binding/'
-            'bind-instance[name=test]/binding-table/binding-entry'
+            'bind-instance[name=config-test-daemon]/binding-table/binding-entry'
             '[binding-ipv6info=::1]/binding-ipv4-addr',
         ))
         output = self.run_cmd(get_args)
@@ -543,7 +545,7 @@ class TestConfigMisc(BaseTestCase):
         get_args.extend((
             DAEMON_PROC_NAME,
             # Implicit string concatenation, no summing needed.
-            '/br-instances/binding/bind-instance[name=test]/'
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
             'binding-table/binding-entry[binding-ipv6info=::1]/port-set/psid',
         ))
         output = self.run_cmd(get_args)
@@ -559,7 +561,7 @@ class TestConfigMisc(BaseTestCase):
         set_args.extend((
             DAEMON_PROC_NAME,
             # Implicit string concatenation, no summing needed.
-            '/br-instances/binding/bind-instance[name=test]/'
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
             'binding-table/binding-entry',
             '{ binding-ipv6info ::124; binding-ipv4-addr 8.8.8.8;'
             'br-ipv6-addr 2001:db8::; port-set { psid 8; psid-len 15; }}',
@@ -570,7 +572,7 @@ class TestConfigMisc(BaseTestCase):
         set_args.extend((
             DAEMON_PROC_NAME,
             # Implicit string concatenation, no summing needed.
-            '/br-instances/binding/bind-instance[name=test]/'
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
             'binding-table/binding-entry[binding-ipv6info=::124]/'
             'binding-ipv4-addr',
             '9.9.9.9',
@@ -585,6 +587,7 @@ class TestConfigMisc(BaseTestCase):
         self.assertEqual(
             output.strip(), b'::124',
             '\n'.join(('OUTPUT', str(output, ENC))))
+        # XXX - test Handle special br attributes
 
 
 if __name__ == '__main__':

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -465,6 +465,20 @@ class TestConfigMisc(BaseTestCase):
         self.run_cmd(get_state_args)
         # run_cmd checks the exit code and fails the test if it is not zero.
 
+    def test_get_state_ietf(self):
+        get_args = self.get_cmd_args('get-state')[:-1]
+        get_args[3] = '--schema=ietf-softwire-br'
+        get_args.extend((
+            DAEMON_PROC_NAME,
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
+            'traffic-stat/rcvd-ipv4-bytes',
+        ))
+        output = self.run_cmd(get_args)
+        # run_cmd checks the exit code and fails the test if it is not zero.
+        self.assertNotEqual(
+            output.strip(), b'0',
+            '\n'.join(('OUTPUT', str(output, ENC))))
+
     def test_remove(self):
         # Verify that the thing we want to remove actually exists.
         get_args = self.get_cmd_args('get')
@@ -478,13 +492,31 @@ class TestConfigMisc(BaseTestCase):
         # Remove it.
         remove_args = list(get_args)
         remove_args[2] = 'remove'
-        self.run_cmd(get_args)
+        self.run_cmd(remove_args)
         # run_cmd checks the exit code and fails the test if it is not zero.
         # Verify we cannot find it anymore.
+        self.run_cmd(get_args, 1)
+        # run_cmd checks the exit code and fails the test if it is not 1.
+
+    def test_remove_ietf(self):
+        # Verify that the thing we want to remove actually exists.
+        get_args = self.get_cmd_args('get')[:-1]
+        get_args[3] = '--schema=ietf-softwire-br'
+        get_args.extend((
+            DAEMON_PROC_NAME,
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
+            'binding-table/binding-entry[binding-ipv6info=::123]',
+        ))
         self.run_cmd(get_args)
         # run_cmd checks the exit code and fails the test if it is not zero.
-
-    #XXX - def test_remove_ietf(self):
+        # Remove it.
+        remove_args = list(get_args)
+        remove_args[2] = 'remove'
+        self.run_cmd(remove_args)
+        # run_cmd checks the exit code and fails the test if it is not zero.
+        # Verify we cannot find it anymore.
+        self.run_cmd(get_args, 1)
+        # run_cmd checks the exit code and fails the test if it is not 1.
 
     def test_set(self):
         """
@@ -587,8 +619,79 @@ class TestConfigMisc(BaseTestCase):
         self.assertEqual(
             output.strip(), b'::124',
             '\n'.join(('OUTPUT', str(output, ENC))))
-        # XXX - test Handle special br attributes
 
+    def test_set_ietf_special(self):
+        """
+        Test handling of special br attributes.
+        """
+        set_args = self.get_cmd_args('set')[:-1]
+        set_args[3] = '--schema=ietf-softwire-br'
+        set_args.extend((
+            DAEMON_PROC_NAME,
+            # Implicit string concatenation, no summing needed.
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
+            'softwire-path-mru',
+            '542',
+        ))
+        self.run_cmd(set_args)
+        get_args = self.get_cmd_args('get')[:-1]
+        get_args[3] = '--schema=ietf-softwire-br'
+        get_args.extend((
+            DAEMON_PROC_NAME,
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
+            'softwire-path-mru',
+        ))
+        output = self.run_cmd(get_args)
+        # run_cmd checks the exit code and fails the test if it is not zero.
+        self.assertEqual(
+            output.strip(), b'542',
+            '\n'.join(('OUTPUT', str(output, ENC))))
+        #####
+        set_args = self.get_cmd_args('set')[:-1]
+        set_args[3] = '--schema=ietf-softwire-br'
+        set_args.extend((
+            DAEMON_PROC_NAME,
+            # Implicit string concatenation, no summing needed.
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
+            'icmp-policy/icmpv6-errors/generate-icmpv6-errors',
+            'false',
+        ))
+        self.run_cmd(set_args)
+        get_args = self.get_cmd_args('get')[:-1]
+        get_args[3] = '--schema=ietf-softwire-br'
+        get_args.extend((
+            DAEMON_PROC_NAME,
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
+            'icmp-policy/icmpv6-errors/generate-icmpv6-errors',
+        ))
+        output = self.run_cmd(get_args)
+        # run_cmd checks the exit code and fails the test if it is not zero.
+        self.assertEqual(
+            output.strip(), b'false',
+            '\n'.join(('OUTPUT', str(output, ENC))))
+        #####
+        set_args = self.get_cmd_args('set')[:-1]
+        set_args[3] = '--schema=ietf-softwire-br'
+        set_args.extend((
+            DAEMON_PROC_NAME,
+            # Implicit string concatenation, no summing needed.
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
+            'icmp-policy/icmpv4-errors/icmpv4-rate',
+            '1001',
+        ))
+        self.run_cmd(set_args)
+        get_args = self.get_cmd_args('get')[:-1]
+        get_args[3] = '--schema=ietf-softwire-br'
+        get_args.extend((
+            DAEMON_PROC_NAME,
+            '/br-instances/binding/bind-instance[name=config-test-daemon]/'
+            'icmp-policy/icmpv4-errors/icmpv4-rate',
+        ))
+        output = self.run_cmd(get_args)
+        # run_cmd checks the exit code and fails the test if it is not zero.
+        self.assertEqual(
+            output.strip(), b'1001',
+            '\n'.join(('OUTPUT', str(output, ENC))))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/program/lwaftr/tests/subcommands/config_test.py
+++ b/src/program/lwaftr/tests/subcommands/config_test.py
@@ -516,7 +516,7 @@ class TestConfigMisc(BaseTestCase):
         # run_cmd checks the exit code and fails the test if it is not zero.
         # Verify we cannot find it anymore.
         self.run_cmd(get_args, 1)
-        # run_cmd checks the exit code and fails the test if it is not 1.
+        # run_cmd checks the exit code and fails the test if it is not 1.x
 
     def test_set(self):
         """
@@ -692,6 +692,62 @@ class TestConfigMisc(BaseTestCase):
         self.assertEqual(
             output.strip(), b'1001',
             '\n'.join(('OUTPUT', str(output, ENC))))
+
+    def test_wrong_instance_ietf(self):
+        # Check for failure when querying wrong instance
+        remove_args = self.get_cmd_args('remove')[:-1]
+        remove_args[3] = '--schema=ietf-softwire-br'
+        remove_args.extend((
+            DAEMON_PROC_NAME,
+            # Implicit string concatenation, no summing needed.
+            '/br-instances/binding/bind-instance[name=nosuchinstance]'
+            'binding-table/binding-entry[binding-ipv6info=::123]',
+        ))
+        output = str(self.run_cmd(remove_args, 1), ENC)
+        self.assertRegex(output, 'name does not match',
+            '\n'.join(('OUTPUT', output)))
+        ####
+        set_args = self.get_cmd_args('set')[:-1]
+        set_args[3] = '--schema=ietf-softwire-br'
+        set_args.extend((
+            DAEMON_PROC_NAME,
+            # Implicit string concatenation, no summing needed.
+            '/br-instances/binding/bind-instance[name=nosuchinstance]/'
+            'binding-table/binding-entry',
+            '{ binding-ipv6info ::124; binding-ipv4-addr 8.8.8.8;'
+            'br-ipv6-addr 2001:db8::; port-set { psid 8; psid-len 15; }}',
+        ))
+        output = str(self.run_cmd(set_args, 1), ENC)
+        self.assertRegex(output, 'name does not match',
+            '\n'.join(('OUTPUT', output)))
+        ####
+        set_args = self.get_cmd_args('set')[:-1]
+        set_args[3] = '--schema=ietf-softwire-br'
+        set_args.extend((
+            DAEMON_PROC_NAME,
+            # Implicit string concatenation, no summing needed.
+            '/br-instances/binding/bind-instance[name=nosuchinstance]/'
+            'binding-table/binding-entry[binding-ipv6info=::124]/'
+            'binding-ipv4-addr',
+            '9.9.9.9',
+        ))
+        output = str(self.run_cmd(set_args, 1), ENC)
+        self.assertRegex(output, 'name does not match',
+            '\n'.join(('OUTPUT', output)))
+        ####
+        set_args = self.get_cmd_args('set')[:-1]
+        set_args[3] = '--schema=ietf-softwire-br'
+        set_args.extend((
+            DAEMON_PROC_NAME,
+            # Implicit string concatenation, no summing needed.
+            '/br-instances/binding/bind-instance[name=nosuchinstance]/'
+            'icmp-policy/icmpv4-errors/icmpv4-rate',
+            '1001',
+        ))
+        output = str(self.run_cmd(set_args, 1), ENC)
+        self.assertRegex(output, 'name does not match',
+            '\n'.join(('OUTPUT', output)))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/program/lwaftr/tests/test_env.py
+++ b/src/program/lwaftr/tests/test_env.py
@@ -76,7 +76,7 @@ class BaseTestCase(unittest.TestCase):
             cls.daemon.stderr.close()
             cls.fail(cls, '\n'.join(msg_lines))
 
-    def run_cmd(self, args):
+    def run_cmd(self, args, ret=0):
         proc = Popen(args, stdout=PIPE, stderr=PIPE)
         try:
             output, errput = proc.communicate(timeout=COMMAND_TIMEOUT)
@@ -86,7 +86,7 @@ class BaseTestCase(unittest.TestCase):
             print('\nTimeout running command, trying to kill PID %s' % proc.pid)
             proc.kill()
             raise
-        if proc.returncode != 0:
+        if proc.returncode != ret:
             msg_lines = (
                 'Error running command:', " ".join(args),
                 'Daemon Command:', " ".join(self.daemon_args),


### PR DESCRIPTION
Use new ietf-softwire-br, ietf-softwire-common schemas.

These are from https://tools.ietf.org/html/draft-ietf-softwire-yang-16.

TODO:

- [x] Revert d3a641d and implement YANG 1.1 `if-feature` binary expressions instead