### PR TITLE
Plug various resource leaks in context of (re)configuration

### DIFF
--- a/src/apps/lwaftr/rangemap.lua
+++ b/src/apps/lwaftr/rangemap.lua
@@ -27,6 +27,14 @@ local function make_entry_type(value_type)
       value_type)
 end
 
+local entry_type_cache = {}
+local function get_entry_type(value_type)
+   if not entry_type_cache[value_type] then
+      entry_type_cache[value_type] = make_entry_type(value_type)
+   end
+   return entry_type_cache[value_type]
+end
+
 local function make_entries_type(entry_type)
    return ffi.typeof('$[?]', entry_type)
 end
@@ -63,7 +71,7 @@ end
 function RangeMapBuilder.new(value_type)
    local builder = {}
    builder.value_type = value_type
-   builder.entry_type = make_entry_type(builder.value_type)
+   builder.entry_type = get_entry_type(builder.value_type)
    builder.type = make_entries_type(builder.entry_type)
    builder.equal_fn = make_equal_fn(builder.value_type)
    builder.entries = {}

--- a/src/lib/binary_search.dasl
+++ b/src/lib/binary_search.dasl
@@ -35,6 +35,7 @@ local function assemble (name, prototype, generator)
    return ffi.cast(prototype, mcode)
 end
 
+local gencache = {} -- Cache for generated variants (reuse if possible.)
 function gen(count, entry_type)
    local function gen_binary_search(Dst)
       if count == 1 then
@@ -80,9 +81,19 @@ function gen(count, entry_type)
       | mov rax, rdi
       | ret
    end
-   return assemble("binary_search_"..count,
-                   ffi.typeof("$*(*)($*, uint32_t)", entry_type, entry_type),
-                   gen_binary_search)
+   -- Assemble binary search variant and cache it unless it has not been
+   -- previously generated.
+   if not gencache[entry_type] then
+      gencache[entry_type] = {}
+   end
+   if not gencache[entry_type][count] then
+      gencache[entry_type][count] =
+         assemble("binary_search_"..count,
+                  ffi.typeof("$*(*)($*, uint32_t)", entry_type, entry_type),
+                  gen_binary_search)
+   end
+   -- Return (now) cached routine.
+   return gencache[entry_type][count]
 end
 
 function selftest ()

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -430,11 +430,6 @@ function CTable:remove(key, missing_allowed)
    return true
 end
 
-local function generate_multi_copy(width, size)
-   return multi_copy.gen(width, size)
-end
-generate_multi_copy = memoize(generate_multi_copy)
-
 local function generate_multi_hash(self, width)
    return self.make_multi_hash_fn(width)
 end
@@ -475,7 +470,7 @@ function CTable:make_lookup_streamer(width)
    -- Compile multi-copy and binary-search procedures that are
    -- specialized for this table and this width.
    local entry_size = ffi.sizeof(self.entry_type)
-   res.multi_copy = generate_multi_copy(width, res.entries_per_lookup * entry_size)
+   res.multi_copy = multi_copy.gen(width, res.entries_per_lookup * entry_size)
    res.multi_hash = generate_multi_hash(self, width)
    res.binary_search = generate_binary_search(res.entries_per_lookup, self.entry_type)
 

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -4,13 +4,10 @@ local ffi = require("ffi")
 local C = ffi.C
 local S = require("syscall")
 local lib = require("core.lib")
-local util = require("lib.yang.util")
 local binary_search = require("lib.binary_search")
 local multi_copy = require("lib.multi_copy")
 local siphash = require("lib.hash.siphash")
 
--- TODO: Move to core/lib.lua.
-local memoize = util.memoize
 local min, max, floor, ceil = math.min, math.max, math.floor, math.ceil
 
 CTable = {}
@@ -430,11 +427,6 @@ function CTable:remove(key, missing_allowed)
    return true
 end
 
-local function generate_binary_search(entries_per_lookup, entry_type)
-   return binary_search.gen(entries_per_lookup, entry_type)
-end
-generate_binary_search = memoize(generate_binary_search)
-
 function CTable:make_lookup_streamer(width)
    assert(width > 0 and width <= 262144, "Width value out of range: "..width)
    local res = {
@@ -467,7 +459,7 @@ function CTable:make_lookup_streamer(width)
    local entry_size = ffi.sizeof(self.entry_type)
    res.multi_copy = multi_copy.gen(width, res.entries_per_lookup * entry_size)
    res.multi_hash = self.make_multi_hash_fn(width)
-   res.binary_search = generate_binary_search(res.entries_per_lookup, self.entry_type)
+   res.binary_search = binary_search.gen(res.entries_per_lookup, self.entry_type)
 
    return setmetatable(res, { __index = LookupStreamer })
 end

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -430,11 +430,6 @@ function CTable:remove(key, missing_allowed)
    return true
 end
 
-local function generate_multi_hash(self, width)
-   return self.make_multi_hash_fn(width)
-end
-generate_multi_hash = memoize(generate_multi_hash)
-
 local function generate_binary_search(entries_per_lookup, entry_type)
    return binary_search.gen(entries_per_lookup, entry_type)
 end
@@ -471,7 +466,7 @@ function CTable:make_lookup_streamer(width)
    -- specialized for this table and this width.
    local entry_size = ffi.sizeof(self.entry_type)
    res.multi_copy = multi_copy.gen(width, res.entries_per_lookup * entry_size)
-   res.multi_hash = generate_multi_hash(self, width)
+   res.multi_hash = self.make_multi_hash_fn(width)
    res.binary_search = generate_binary_search(res.entries_per_lookup, self.entry_type)
 
    return setmetatable(res, { __index = LookupStreamer })

--- a/src/lib/hash/siphash.dasl
+++ b/src/lib/hash/siphash.dasl
@@ -427,6 +427,7 @@ local sip_hash_config = {
    size={required=true}, stride={}, key={default=false},
    c={default=2}, d={default=4}, as_specified={default=false}, width={default=1}
 }
+local sip_hash_cache = {} -- Cache for generated variants (reuse if possible.)
 local function make_sip_hash(assembler, opts)
    function siphash(asm)
       -- Arguments:
@@ -513,8 +514,33 @@ local function make_sip_hash(assembler, opts)
 
    opts = lib.parse(opts, sip_hash_config)
    if not opts.stride then opts.stride = opts.size end
+   -- Assemble siphash variant and cache it unless it has not been
+   -- previously generated.
+   sip_hash_cache[assembler] = sip_hash_cache[assembler] or {}
+   for conf, cached in pairs(sip_hash_cache[assembler]) do
+      if lib.equal(conf, opts) then return cached end
+   end
    local asm = assembler(opts.stride)
-   return asm:assemble("siphash_"..opts.c.."_"..opts.d, siphash)
+   local sip_hash = asm:assemble("siphash_"..opts.c.."_"..opts.d, siphash)
+   sip_hash_cache[assembler][opts] = sip_hash
+   return sip_hash
+end
+
+-- Immediate value x86-64 backend for the SipHash implementation.
+local function ImmX86_64()
+   local asm = X86_64()
+   function asm.load_u64_and_advance(dst)
+      asm.copy_argument(dst, 1)
+   end
+   function asm.finish(name, Dst)
+      return finish(name.."_u64",
+                    ffi.typeof("uint32_t (*)(uint64_t)"),
+                    Dst)
+   end
+   asm.load_u32_and_advance = error
+   asm.load_u16_and_advance = error
+   asm.load_u8_and_advance = error
+   return asm
 end
 
 -- A special implementation to hash immediate values; requires our
@@ -523,21 +549,6 @@ function make_u64_hash(opts)
    local opts = lib.deepcopy(opts)
    opts.size = 8
    assert(not opts.as_specified)
-   local function ImmX86_64()
-      local asm = X86_64()
-      function asm.load_u64_and_advance(dst)
-         asm.copy_argument(dst, 1)
-      end
-      function asm.finish(name, Dst)
-         return finish(name.."_u64",
-                       ffi.typeof("uint32_t (*)(uint64_t)"),
-                       Dst)
-      end
-      asm.load_u32_and_advance = error
-      asm.load_u16_and_advance = error
-      asm.load_u8_and_advance = error
-      return asm
-   end
    return make_sip_hash(ImmX86_64, opts)
 end
 

--- a/src/lib/multi_copy.dasl
+++ b/src/lib/multi_copy.dasl
@@ -40,6 +40,7 @@ local function assemble (name, prototype, generator)
    return ffi.cast(prototype, mcode)
 end
 
+local gencache = {} -- Cache for generated variants (reuse if possible.)
 function gen(count, size)
    local function gen_multi_copy(Dst)
       -- dst in rdi
@@ -115,10 +116,13 @@ function gen(count, size)
       | pop r12
       | ret
    end
-
-   return assemble("multi_copy_"..size,
-                   "void(*)(void*, void*)",
-                   gen_multi_copy)
+   local name = "multi_copy_"..size.."_"..count
+   -- Assemble multi copy variant and cache it unless it has not been
+   -- previously generated.
+   if not gencache[name] then
+      gencache[name] = assemble(name, "void(*)(void*, void*)", gen_multi_copy)
+   end
+   return gencache[name]
 end
 
 function selftest ()

--- a/src/lib/ptree/action_codec.lua
+++ b/src/lib/ptree/action_codec.lua
@@ -179,7 +179,10 @@ local function decoder(buf, len)
       return assert(require(require_path)[name])
    end
    function decoder:config()
-      return binary.load_compiled_data_file(self:string()).data
+      local filename = self:string()
+      local data = binary.load_compiled_data_file(filename).data
+      S.unlink(filename)
+      return data
    end
    function decoder:finish(...)
       return { ... }

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -2,6 +2,7 @@
 -- COPYING.
 module(..., package.seeall)
 
+local S = require("syscall")
 local ffi = require("ffi")
 local lib = require("core.lib")
 local shm = require("core.shm")
@@ -474,10 +475,14 @@ end
 function data_copier_from_grammar(production)
    local compile = data_compiler_from_grammar(data_emitter(production), '')
    return function(data)
-      local basename = 'copy-'..lib.random_printable_string(160)
-      local tmp = shm.root..'/'..shm.resolve(basename)
-      compile(data, tmp)
-      return function() return load_compiled_data_file(tmp).data end
+      return function()
+         local basename = 'copy-'..lib.random_printable_string(160)
+         local tmp = shm.root..'/'..shm.resolve(basename)
+         compile(data, tmp)
+         local copy = load_compiled_data_file(tmp).data
+         S.unlink(tmp)
+         return copy
+      end
    end
 end
 


### PR DESCRIPTION
This PR consists of a number of fixes for resource leaks that became apparant after a sufficient number of re-configurations as exercised in #1221. 

There are two classes of bugs here. The first, leaking ctypes (as well as memory used for non-GCed backing code from code-gen) was caused by callers failing to memoize the results of calling our various special purpose code generators. Or more specifically, failing to memoize the results of `ffi.typeof(...)` expressions that allocate new ctype IDs.

This PR fixes these by implementing the memoization at the roots of the problems, as opposed to relying on callers to account for resource management (prone to error).

The second class is lib.yang auxiliary functions creating temporary files in `/var/run` but failing to eventually unlink those. This eventually results in write errors to the typically ramfs backed storage which eventually fills up (“no space left on device”).

Fixes #1221 