### PR TITLE
timers.ingress_drop_monitor: use app:get_rxstats() (was app:rxdrop())

### DIFF
--- a/src/lib/timers/ingress_drop_monitor.lua
+++ b/src/lib/timers/ingress_drop_monitor.lua
@@ -57,8 +57,8 @@ function IngressDropMonitor:sample ()
    sum[0] = 0
    for i = 1, #app_array do
       local app = app_array[i]
-      if app.rxdrop and not app.dead then
-         sum[0] = sum[0] + app:rxdrop()
+      if app.get_rxstats and not app.dead then
+         sum[0] = sum[0] + app:get_rxstats().dropped
       end
    end
    if self.counter then


### PR DESCRIPTION
For the time being, app:rxdrop() returns total packets dropped, while
app:get_rxstats() returns packets dropped for the app’s dedicated queue in the
context of intel_mp.

This change should improve behavior of ingress_drop_monitor=flush during
multi-queue operation (i.e. when using hardware assisted RSS) as it will only
react to packets lost by its own process.

I suspect this might be the root cause of the lesser performance stability of performance reported with multi-queue operation of the lwaftr.