### PR TITLE
Revert "lib.ptree: do not aggregate (ignore) counters that are symlinks"

### DIFF
--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -347,11 +347,10 @@ function Manager:monitor_worker_counters(id)
    local events = inotify.recursive_directory_inventory_events(dir, cancel)
    for ev in events.get, events do
       if has_suffix(ev.name, '.counter') then
-         local stat = S.lstat(ev.name)
          local name = strip_prefix(ev.name, dir..'/')
          local qualified_name = '/'..pid..'/'..name
          local counters = self.counters[name]
-         if blacklisted(name) or not stat or stat.islnk then
+         if blacklisted(name) then
             -- Pass.
          elseif ev.kind == 'creat' then
             if not counters then


### PR DESCRIPTION
Reverts Igalia/snabb#1230.  The problem is that if the manager doesn't aggregate counters that are targets of symlinks, it misses NIC counters associated with the `intel_mp` app, because the `intel_mp` app manages stats in a centralized place and has the different processes using the app symlink into the central stats repo.

The problem fixed by #1230 is that the manager ends up creating an erroneous global sum for NIC-wide stats such as `rxdrop`.  However `q1_rxdrop` et al are fine, and the stats are fine in the worker directories.  Therefore I am thinking that we can live with the bug until a more robust fix comes along.