### PR TITLE
Fix snabb top interface view for multiple queues

### DIFF
--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -606,9 +606,24 @@ function compute_display_tree.interface(tree, prev, dt, t)
    --            \-  pci device, macaddr, mtu, speed
    --                  RX:       PPS, bps, %, [drops/s]
    --                  TX:       PPS, bps, %, [drops/s]
+   function queue_local_key(key, counters)
+      local queue_key
+      local stem = ({rxdrop='rxdrops'})[key] or key
+      for i=0,15 do
+         local k = 'q'..i..'_'..stem
+         if counters[k] then
+            if queue_key then
+               return key
+            end
+            queue_key = k
+         end
+      end
+      return queue_key or key
+   end
    local function rate(key, counters, prev)
       if not counters then return 0/0 end
       if not counters[key] then return 0/0 end
+      key = queue_local_key(key, counters)
       local v, rrd = counters[key], nil
       prev = prev and prev[key]
       if is_leaf(v) then


### PR DESCRIPTION
This change makes it so that statistics are correctly core-specific.