### PR TITLE
Disable blacklisting of problematic initial trace instructions

### DIFF
--- a/lib/luajit/src/lj_jit.h
+++ b/lib/luajit/src/lj_jit.h
@@ -76,6 +76,8 @@
   _(\011, sizemcode,	JIT_P_sizemcode_DEFAULT) \
   /* Max. total size of all machine code areas (in KBytes). */ \
   _(\010, maxmcode,	512) \
+  /* Whether to blacklist instructions; zero or nonzero. */ \
+  _(\011, blacklist,	0) \
   /* End of list. */
 
 enum {

--- a/lib/luajit/src/lj_trace.c
+++ b/lib/luajit/src/lj_trace.c
@@ -395,8 +395,11 @@ static int penalty_pc(jit_State *J, GCproto *pt, BCIns *pc, TraceError e)
       val = ((uint32_t)J->penalty[i].val << 1) +
 	    LJ_PRNG_BITS(J, PENALTY_RNDBITS);
       if (val > PENALTY_MAX) {
-	blacklist_pc(pt, pc);  /* Blacklist it, if that didn't help. */
-	return 1;
+        if (J->param[JIT_P_blacklist]) {
+          blacklist_pc(pt, pc);  /* Blacklist it, if that didn't help. */
+          return 1;
+        }
+        val = PENALTY_MAX;
       }
       goto setpenalty;
     }


### PR DESCRIPTION
We have seen some cases where an important trace gets blacklisted just
because it hits an inner loop that hasn't compiled yet.  Now that
RaptorJIT has switched to a more hotcount-per-second model rather than a
cumulative-hotcount model, the eternal aspect of the blacklist no longer
matches the optimization paradigm we are going for.

Therefore add a "blacklist" JIT option off by default.  Instructions
will only ever be blacklisted when "blacklist" is on.